### PR TITLE
Add greater than conditional format to excel export

### DIFF
--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -14,6 +14,8 @@ from mitosheet.types import StepsManagerType
 from mitosheet.user import is_pro
 from mitosheet.user.utils import is_running_test
 
+from mitosheet.utils import get_conditional_formats_objects_to_export_to_excel
+
 
 def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerType) -> str:
     """
@@ -39,6 +41,12 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
 
             # Add formatting to the sheet for pro users
             format = steps_manager.curr_step.df_formats[sheet_index]
+            conditional_formats = get_conditional_formats_objects_to_export_to_excel(
+                format.get('conditional_formats'),
+                df=steps_manager.curr_step.dfs[sheet_index],
+                column_ids=steps_manager.curr_step.column_ids,
+                sheet_index=sheet_index
+            )
             if allow_formatting: 
                 add_formatting_to_excel_sheet(
                     writer,
@@ -49,7 +57,8 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
                     even_background_color=format.get('rows', {}).get('even', {}).get('backgroundColor'),
                     even_font_color=format.get('rows', {}).get('even', {}).get('color'),
                     odd_background_color=format.get('rows', {}).get('odd', {}).get('backgroundColor'),
-                    odd_font_color=format.get('rows', {}).get('odd', {}).get('color')
+                    odd_font_color=format.get('rows', {}).get('odd', {}).get('color'),
+                    conditional_formats=conditional_formats
                 )
     
     # Go back to the start of the buffer

--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -43,6 +43,7 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
                 add_formatting_to_excel_sheet(
                     writer,
                     sheet_name,
+                    df,
                     header_background_color=format.get('headers', {}).get('backgroundColor'),
                     header_font_color=format.get('headers', {}).get('color'),
                     even_background_color=format.get('rows', {}).get('even', {}).get('backgroundColor'),

--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -7,14 +7,11 @@ import base64
 import io
 from typing import Any, Dict
 
-import pandas as pd
-from mitosheet.excel_utils import get_df_name_as_valid_sheet_name
-from mitosheet.public.v3 import add_formatting_to_excel_sheet
 from mitosheet.types import StepsManagerType
 from mitosheet.user import is_pro
 from mitosheet.user.utils import is_running_test
 
-from mitosheet.utils import get_conditional_formats_objects_to_export_to_excel
+from mitosheet.utils import write_to_excel
 
 
 def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerType) -> str:
@@ -29,38 +26,7 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
     # We write to a buffer so that we don't have to save the file
     # to the file system for no reason
     buffer = io.BytesIO()
-    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
-        for sheet_index in sheet_indexes:
-            # Get the dataframe and sheet name
-            df = steps_manager.dfs[sheet_index]
-            df_name = steps_manager.curr_step.df_names[sheet_index]
-            sheet_name = get_df_name_as_valid_sheet_name(df_name)
-
-            # Write the dataframe to the sheet
-            df.to_excel(writer, sheet_name, index=False)
-
-            # Add formatting to the sheet for pro users
-            format = steps_manager.curr_step.df_formats[sheet_index]
-            conditional_formats = get_conditional_formats_objects_to_export_to_excel(
-                format.get('conditional_formats'),
-                df=steps_manager.curr_step.dfs[sheet_index],
-                column_ids=steps_manager.curr_step.column_ids,
-                sheet_index=sheet_index
-            )
-            if allow_formatting: 
-                add_formatting_to_excel_sheet(
-                    writer,
-                    sheet_name,
-                    df,
-                    header_background_color=format.get('headers', {}).get('backgroundColor'),
-                    header_font_color=format.get('headers', {}).get('color'),
-                    even_background_color=format.get('rows', {}).get('even', {}).get('backgroundColor'),
-                    even_font_color=format.get('rows', {}).get('even', {}).get('color'),
-                    odd_background_color=format.get('rows', {}).get('odd', {}).get('backgroundColor'),
-                    odd_font_color=format.get('rows', {}).get('odd', {}).get('color'),
-                    conditional_formats=conditional_formats
-                )
-    
+    write_to_excel(buffer, sheet_indexes, steps_manager.post_state, allow_formatting=allow_formatting)    
     # Go back to the start of the buffer
     buffer.seek(0)
     

--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 from mitosheet.types import StepsManagerType
 from mitosheet.user import is_pro
 from mitosheet.user.utils import is_running_test
-
 from mitosheet.utils import write_to_excel
 
 
@@ -26,7 +25,7 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
     # We write to a buffer so that we don't have to save the file
     # to the file system for no reason
     buffer = io.BytesIO()
-    write_to_excel(buffer, sheet_indexes, steps_manager.post_state, allow_formatting=allow_formatting)    
+    write_to_excel(buffer, sheet_indexes, steps_manager.curr_step.post_state, allow_formatting=allow_formatting)    
     # Go back to the start of the buffer
     buffer.seek(0)
     

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -12,25 +12,21 @@ from mitosheet.transpiler.transpile_utils import TAB, column_header_to_transpile
 
 from mitosheet.transpiler.transpile_utils import param_dict_to_code
 
-from mitosheet.excel_utils import get_column_from_column_index
+from mitosheet.utils import add_columns_to_condition_formats
 
 # This is a helper function that generates the code for formatting the excel sheet
 def get_format_code(state: State) -> list:
     code = []
     formats = state.df_formats
     for sheet_index, (sheet_name, format) in enumerate(zip(state.df_names, formats)):
-        # We need to convert the column IDs to column letters for conditional formats to export to excel
-        conditional_formats = format.get('conditional_formats')
-        column_ids = state.column_ids.get_column_ids(sheet_index=sheet_index)
-        if conditional_formats is not None:
-            for conditional_format in conditional_formats:
-                # Create new object to store the columns in the excel format
-                conditional_format['columns'] = []
-                for column_id in conditional_format.get('columnIDs'):
-                    column = get_column_from_column_index(column_ids.index(column_id))
-                    conditional_format['columns'].append(column)
-
-        # If there is no formatting, we skip trying to access the colors
+        # We need to convert the column IDs to column letters
+        # for conditional formats to export to excel
+        conditional_formats = add_columns_to_condition_formats(
+            format.get('conditional_formats'),
+            df=state.dfs[sheet_index],
+            column_ids=state.column_ids,
+            sheet_index=sheet_index
+        )
         params = {
             'header_background_color': format.get('headers', {}).get('backgroundColor'),
             'header_font_color': format.get('headers', {}).get('color'),

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -23,7 +23,7 @@ def get_format_code(state: State) -> list:
         # for conditional formats to export to excel
         conditional_formats = get_conditional_formats_objects_to_export_to_excel(
             format.get('conditional_formats'),
-            column_ids=state.column_ids,
+            column_id_map=state.column_ids,
             sheet_index=sheet_index
         )
         params = {

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -12,7 +12,7 @@ from mitosheet.transpiler.transpile_utils import TAB, column_header_to_transpile
 
 from mitosheet.transpiler.transpile_utils import param_dict_to_code
 
-from mitosheet.utils import add_columns_to_condition_formats
+from mitosheet.utils import get_conditional_formats_objects_to_export_to_excel
 
 # This is a helper function that generates the code for formatting the excel sheet
 def get_format_code(state: State) -> list:
@@ -21,7 +21,7 @@ def get_format_code(state: State) -> list:
     for sheet_index, (sheet_name, format) in enumerate(zip(state.df_names, formats)):
         # We need to convert the column IDs to column letters
         # for conditional formats to export to excel
-        conditional_formats = add_columns_to_condition_formats(
+        conditional_formats = get_conditional_formats_objects_to_export_to_excel(
             format.get('conditional_formats'),
             df=state.dfs[sheet_index],
             column_ids=state.column_ids,
@@ -44,7 +44,7 @@ def get_format_code(state: State) -> list:
             continue
 
         params_code = param_dict_to_code(param_dict, tab_level=1)
-        code.append(f'{TAB}add_formatting_to_excel_sheet(writer, "{sheet_name}", {params_code})')
+        code.append(f'{TAB}add_formatting_to_excel_sheet(writer, "{sheet_name}", {state.df_names[sheet_index]}, {params_code})')
     return code
 
 

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -23,7 +23,6 @@ def get_format_code(state: State) -> list:
         # for conditional formats to export to excel
         conditional_formats = get_conditional_formats_objects_to_export_to_excel(
             format.get('conditional_formats'),
-            df=state.dfs[sheet_index],
             column_ids=state.column_ids,
             sheet_index=sheet_index
         )

--- a/mitosheet/mitosheet/column_headers.py
+++ b/mitosheet/mitosheet/column_headers.py
@@ -189,6 +189,8 @@ class ColumnIDMap():
         del self.column_id_to_column_header[sheet_index][column_id]
         self.column_header_to_column_id[sheet_index][column_header]
 
+    # Note: The object returned by this function might not reflect the actual order of columns.
+    # To access the list of columns in order, use the dataframe's columns.tolist() method. 
     def get_column_ids(self, sheet_index: int, column_headers: Optional[Collection[ColumnHeader]]=None) -> List[str]:
         if column_headers is None:
             return list(self.column_id_to_column_header[sheet_index].keys())

--- a/mitosheet/mitosheet/public/v3/formatting.py
+++ b/mitosheet/mitosheet/public/v3/formatting.py
@@ -82,8 +82,8 @@ def add_formatting_to_excel_sheet(
                 # Start with the greater than condition
                 if filter['condition'] != 'greater':
                     continue
-                cond_fill = PatternFill(start_color=conditional_format['backgroundColor'][1:], end_color=conditional_format['backgroundColor'][1:], fill_type='solid')
-                cond_font = Font(color=conditional_format['color'][1:])
+                cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['backgroundColor'][1:], fill_type='solid')
+                cond_font = Font(color=conditional_format['font_color'][1:])
                 column_conditional_rule = CellIsRule(operator="greaterThan", font=cond_font, fill=cond_fill, formula=[f'{filter["value"]}'])
                 for column in conditional_format['columns']:
                     sheet.conditional_formatting.add(f'{column}1:{column}{sheet.max_row}', column_conditional_rule)

--- a/mitosheet/mitosheet/public/v3/formatting.py
+++ b/mitosheet/mitosheet/public/v3/formatting.py
@@ -5,6 +5,19 @@ from openpyxl.styles import NamedStyle
 from openpyxl.formatting.rule import CellIsRule
 from pandas import ExcelWriter
 
+def add_conditional_formats(conditional_formats, sheet):
+    for conditional_format in conditional_formats:
+        for filter in conditional_format.get('filters'):
+            # Start with the greater than condition
+            if filter['condition'] != 'greater':
+                continue
+            cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['background_color'][1:], fill_type='solid')
+            cond_font = Font(color=conditional_format['font_color'][1:])
+            column_conditional_rule = CellIsRule(operator="greaterThan", font=cond_font, fill=cond_fill, formula=[f'{filter["value"]}'])
+            for column in conditional_format['columns']:
+                sheet.conditional_formatting.add(f'{column}2:{column}{sheet.max_row}', column_conditional_rule)
+
+
 def add_formatting_to_excel_sheet(
         writer: ExcelWriter,
         sheet_name: str,
@@ -75,15 +88,5 @@ def add_formatting_to_excel_sheet(
                         sheet.cell(row=row, column=col).style = odd_name
 
         # Add conditional formatting
-        if conditional_formats is None:
-            return
-        for conditional_format in conditional_formats:
-            for filter in conditional_format.get('filters'):
-                # Start with the greater than condition
-                if filter['condition'] != 'greater':
-                    continue
-                cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['background_color'][1:], fill_type='solid')
-                cond_font = Font(color=conditional_format['font_color'][1:])
-                column_conditional_rule = CellIsRule(operator="greaterThan", font=cond_font, fill=cond_fill, formula=[f'{filter["value"]}'])
-                for column in conditional_format['columns']:
-                    sheet.conditional_formatting.add(f'{column}2:{column}{sheet.max_row}', column_conditional_rule)
+        if conditional_formats is not None:
+            add_conditional_formats(conditional_formats, sheet)

--- a/mitosheet/mitosheet/public/v3/formatting.py
+++ b/mitosheet/mitosheet/public/v3/formatting.py
@@ -3,9 +3,11 @@ from typing import Optional
 from openpyxl.styles import Font, PatternFill
 from openpyxl.styles import NamedStyle
 from openpyxl.formatting.rule import CellIsRule
-from pandas import ExcelWriter
+from pandas import DataFrame, ExcelWriter
 
-def add_conditional_formats(conditional_formats, sheet):
+from mitosheet.excel_utils import get_column_from_column_index
+
+def add_conditional_formats(conditional_formats, sheet, df):
     for conditional_format in conditional_formats:
         for filter in conditional_format.get('filters'):
             # Start with the greater than condition
@@ -14,13 +16,16 @@ def add_conditional_formats(conditional_formats, sheet):
             cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['background_color'][1:], fill_type='solid')
             cond_font = Font(color=conditional_format['font_color'][1:])
             column_conditional_rule = CellIsRule(operator="greaterThan", font=cond_font, fill=cond_fill, formula=[f'{filter["value"]}'])
-            for column in conditional_format['columns']:
+            for column_header in conditional_format['columns']:
+                column_index = df.columns.tolist().index(column_header)
+                column = get_column_from_column_index(column_index)
                 sheet.conditional_formatting.add(f'{column}2:{column}{sheet.max_row}', column_conditional_rule)
 
 
 def add_formatting_to_excel_sheet(
         writer: ExcelWriter,
         sheet_name: str,
+        df: DataFrame,
         header_background_color: Optional[str]=None,
         header_font_color: Optional[str]=None,
         even_background_color: Optional[str]=None,
@@ -89,4 +94,4 @@ def add_formatting_to_excel_sheet(
 
         # Add conditional formatting
         if conditional_formats is not None:
-            add_conditional_formats(conditional_formats, sheet)
+            add_conditional_formats(conditional_formats, sheet, df)

--- a/mitosheet/mitosheet/public/v3/formatting.py
+++ b/mitosheet/mitosheet/public/v3/formatting.py
@@ -3,11 +3,16 @@ from typing import Optional
 from openpyxl.styles import Font, PatternFill
 from openpyxl.styles import NamedStyle
 from openpyxl.formatting.rule import CellIsRule
+from openpyxl.worksheet.worksheet import Worksheet
 from pandas import DataFrame, ExcelWriter
 
 from mitosheet.excel_utils import get_column_from_column_index
 
-def add_conditional_formats(conditional_formats, sheet, df):
+def add_conditional_formats(
+    conditional_formats: list,
+    sheet: Worksheet,
+    df: DataFrame
+) -> None:
     for conditional_format in conditional_formats:
         for filter in conditional_format.get('filters'):
             # Start with the greater than condition

--- a/mitosheet/mitosheet/public/v3/formatting.py
+++ b/mitosheet/mitosheet/public/v3/formatting.py
@@ -82,8 +82,8 @@ def add_formatting_to_excel_sheet(
                 # Start with the greater than condition
                 if filter['condition'] != 'greater':
                     continue
-                cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['backgroundColor'][1:], fill_type='solid')
+                cond_fill = PatternFill(start_color=conditional_format['background_color'][1:], end_color=conditional_format['background_color'][1:], fill_type='solid')
                 cond_font = Font(color=conditional_format['font_color'][1:])
                 column_conditional_rule = CellIsRule(operator="greaterThan", font=cond_font, fill=cond_fill, formula=[f'{filter["value"]}'])
                 for column in conditional_format['columns']:
-                    sheet.conditional_formatting.add(f'{column}1:{column}{sheet.max_row}', column_conditional_rule)
+                    sheet.conditional_formatting.add(f'{column}2:{column}{sheet.max_row}', column_conditional_rule)

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -86,7 +86,6 @@ class ExportToFileStepPerformer(StepPerformer):
         elif _type == 'excel':
             # Formatting is a Mito pro feature, but we also allow it for testing
             allow_formatting = is_pro() or is_running_test()
-
             sheet_index_to_export_location = get_export_to_excel_sheet_index_to_sheet_name(post_state, file_name, sheet_indexes)
             write_to_excel(file_name, sheet_indexes, post_state, allow_formatting=allow_formatting)
         else:

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -17,6 +17,10 @@ from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.step_performers.utils import get_param
 
+from mitosheet.utils import write_to_excel
+
+from mitosheet.user.utils import is_pro, is_running_test
+
 def get_export_to_csv_sheet_index_to_file_name(file_name: str, sheet_indexes: List[int]) -> Dict[int, str]:
     """
     Note that we add the index to the file name if there are multiple sheets being exported,
@@ -80,10 +84,11 @@ class ExportToFileStepPerformer(StepPerformer):
             for sheet_index, file_name in sheet_index_to_export_location.items():
                 post_state.dfs[sheet_index].to_csv(file_name, index=False)
         elif _type == 'excel':
+            # Formatting is a Mito pro feature, but we also allow it for testing
+            allow_formatting = is_pro() or is_running_test()
+
             sheet_index_to_export_location = get_export_to_excel_sheet_index_to_sheet_name(post_state, file_name, sheet_indexes)
-            with pd.ExcelWriter(file_name) as writer:
-                for sheet_index, sheet_name in sheet_index_to_export_location.items():
-                    post_state.dfs[sheet_index].to_excel(writer, sheet_name=sheet_name, index=False)
+            write_to_excel(file_name, sheet_indexes, post_state, allow_formatting=allow_formatting)
         else:
             raise ValueError(f"Invalid file type: {_type}")
 

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -29,7 +29,6 @@ def get_cell_formatting(
     sheet = wb[sheet_name]
     formats = []
     for conditional in sheet.conditional_formatting._cf_rules.items():
-        pdb.set_trace()
         if conditional[0].__contains__(cell_address):
             formats.append((conditional[1][0].dxf.fill.start_color.rgb, conditional[1][0].dxf.font.color.rgb))
     return formats
@@ -354,7 +353,6 @@ df_styler = df.style\\
     .apply(lambda series: np.where(series > 5, 'color: #e72323; background-color: #ffffff', None), subset=['A'])
 """
 
-    exec("\n".join(mito.transpiled_code))
     assert get_cell_formatting('A4', filename, 'df') == [('00ffffff', '00e72323')]
 
 

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 from mitosheet.tests.test_utils import check_dataframes_equal, create_mito_wrapper
 from mitosheet.tests.decorators import pandas_post_1_2_only, python_post_3_6_only
+from typing import Any
 
 import pandas as pd
 from openpyxl import load_workbook
@@ -21,7 +22,7 @@ def get_cell_formatting(
     cell_address: str,
     file_path: str,
     sheet_name: str,
-) -> any:
+) -> Any:
     # Load the workbook using openpyxl
     wb = load_workbook(file_path)
 

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -9,10 +9,30 @@ Contains tests for Export To File
 
 import glob
 import os
+import pdb
 import pandas as pd
 import pytest
 from mitosheet.tests.test_utils import check_dataframes_equal, create_mito_wrapper
 from mitosheet.tests.decorators import pandas_post_1_2_only, python_post_3_6_only
+
+import pandas as pd
+from openpyxl import load_workbook
+
+def get_cell_formatting(
+    cell_address: str,
+    file_path: str,
+    sheet_name: str,
+):
+    # Load the workbook using openpyxl
+    wb = load_workbook(file_path)
+
+    sheet = wb[sheet_name]
+    formats = []
+    for conditional in sheet.conditional_formatting._cf_rules.items():
+        pdb.set_trace()
+        if conditional[0].__contains__(cell_address):
+            formats.append((conditional[1][0].dxf.fill.start_color.rgb, conditional[1][0].dxf.font.color.rgb))
+    return formats
 
 DF_FORMAT_HEADER = {
     'headers': {
@@ -312,7 +332,7 @@ df_styler = df.style\\
 
 # This tests when the user exports a dataframe with row formatting without header formatting.
 def test_transpiled_with_export_to_xlsx_conditional_format():
-    df = pd.DataFrame({'A': [1, 2, 3]})
+    df = pd.DataFrame({'A': [4, 5, 6]})
     mito = create_mito_wrapper(df, arg_names=['df'])
     mito.set_dataframe_format(0, DF_FORMAT_CONDITIONAL)
     filename = 'test_format_conditional.xlsx'
@@ -333,6 +353,9 @@ with pd.ExcelWriter(r\'test_format_conditional.xlsx\', engine="openpyxl") as wri
 df_styler = df.style\\
     .apply(lambda series: np.where(series > 5, 'color: #e72323; background-color: #ffffff', None), subset=['A'])
 """
+
+    exec("\n".join(mito.transpiled_code))
+    assert get_cell_formatting('A4', filename, 'df') == [('00ffffff', '00e72323')]
 
 
 # This tests when the user exports a dataframe with row formatting without header formatting.

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -21,7 +21,7 @@ def get_cell_formatting(
     cell_address: str,
     file_path: str,
     sheet_name: str,
-):
+) -> any:
     # Load the workbook using openpyxl
     wb = load_workbook(file_path)
 

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -553,7 +553,9 @@ def test_transpile_parameterize_excel_imports(tmp_path):
         "import pandas as pd",
         "",
         "def function(var_name):",
-        f"{TAB}sheet_df_dictonary = pd.read_excel(var_name, engine='openpyxl', sheet_name=['Sheet1'], skiprows=0)",
+        f"{TAB}sheet_df_dictonary = pd.read_excel(var_name, engine='openpyxl', sheet_name=[\n"
+        f"{TAB*2}'Sheet1'\n"
+        f"{TAB}], skiprows=0)",
         f"{TAB}Sheet1 = sheet_df_dictonary['Sheet1']",
         f'{TAB}',
         f"{TAB}dataframe_1 = pd.read_excel(var_name, sheet_name='Sheet1', skiprows=0, nrows=1, usecols='A:B')",

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -35,7 +35,7 @@ def column_header_list_to_transpiled_code(column_headers: Union[List[ColumnHeade
     return f'[{joined_transpiled_column_headers}]'
 
 
-def column_header_to_transpiled_code(column_header: ColumnHeader, tab_level: Optional[int]=0) -> str:
+def column_header_to_transpiled_code(column_header: ColumnHeader, tab_level: int=0) -> str:
     """
     Makes sure the column header is correctly transpiled to 
     code in a way that makes sure it's referenced properly.

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -6,6 +6,7 @@
 """
 Contains helpful utility functions
 """
+from io import BytesIO
 import json
 from random import randint
 import re
@@ -173,7 +174,12 @@ def get_conditional_formats_objects_to_export_to_excel(
 # Writes dataframes to an excel file or a buffer with formatting
 # Path argument is either the path to the file or a BytesIO object,
 #    because the file can be sent to the front-end through a buffer
-def write_to_excel(path, sheet_indexes, state, allow_formatting=True):
+def write_to_excel(
+    path: BytesIO | str,
+    sheet_indexes: list[int],
+    state: any,
+    allow_formatting:bool=True
+):
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
         for sheet_index in sheet_indexes:
             # Get the dataframe and sheet name

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -147,7 +147,6 @@ def dfs_to_array_for_json(
 
 def get_conditional_formats_objects_to_export_to_excel(
     conditional_formats: Optional[List[Dict[str, Any]]],
-    df: any,
     column_ids: ColumnIDMap,
     sheet_index: int
 ) -> Any:
@@ -174,9 +173,9 @@ def get_conditional_formats_objects_to_export_to_excel(
 # Path argument is either the path to the file or a BytesIO object,
 #    because the file can be sent to the front-end through a buffer
 def write_to_excel(
-    path: any,
+    path: Any,
     sheet_indexes: list,
-    state: any,
+    state: Any,
     allow_formatting:bool=True
 ):
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
@@ -193,7 +192,6 @@ def write_to_excel(
             format = state.df_formats[sheet_index]
             conditional_formats = get_conditional_formats_objects_to_export_to_excel(
                 format.get('conditional_formats'),
-                df=state.dfs[sheet_index],
                 column_ids=state.column_ids,
                 sheet_index=sheet_index
             )

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -20,7 +20,6 @@ from mitosheet.column_headers import ColumnIDMap, get_column_header_display
 from mitosheet.is_type_utils import get_float_dt_td_columns
 from mitosheet.types import (ColumnHeader, ColumnID, DataframeFormat, FrontendFormulaAndLocation, StateType, FrontendFormula)
 
-from mitosheet.excel_utils import get_column_from_column_index
 
 # We only send the first 1500 rows of a dataframe; note that this
 # must match this variable defined on the front-end
@@ -143,7 +142,7 @@ def dfs_to_array_for_json(
     return new_array
 
 
-def add_columns_to_condition_formats(
+def get_conditional_formats_objects_to_export_to_excel(
     conditional_formats: Optional[List[Dict[str, Any]]],
     df: any,
     column_ids: ColumnIDMap,
@@ -164,9 +163,7 @@ def add_columns_to_condition_formats(
         export_cond_formats.append(new_format)
         for column_id in conditional_format.get('columnIDs'):
             column_header = column_ids.get_column_header_by_id(sheet_index, column_id)
-            column_index = df.columns.tolist().index(column_header)
-            column = get_column_from_column_index(column_index)
-            new_format['columns'].append(column)
+            new_format['columns'].append(column_header)
     return export_cond_formats
 
 def _get_column_id_from_header_safe(

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -152,15 +152,22 @@ def add_columns_to_condition_formats(
     if conditional_formats is None:
         return None
 
+    export_cond_formats = []
     for conditional_format in conditional_formats:
         # Create new object to store the columns in the excel format
-        conditional_format['columns'] = []
+        new_format = {
+            'columns': [],
+            'filters': conditional_format.get('filters'),
+            'font_color': conditional_format.get('color'),
+            'background_color': conditional_format.get('backgroundColor')
+        }
+        export_cond_formats.append(new_format)
         for column_id in conditional_format.get('columnIDs'):
             column_header = column_ids.get_column_header_by_id(sheet_index, column_id)
             column_index = df.columns.tolist().index(column_header)
             column = get_column_from_column_index(column_index)
-            conditional_format['columns'].append(column)
-    return conditional_formats
+            new_format['columns'].append(column)
+    return export_cond_formats
 
 def _get_column_id_from_header_safe(
     column_header: ColumnHeader,

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -148,7 +148,7 @@ def get_conditional_formats_objects_to_export_to_excel(
     column_ids: ColumnIDMap,
     sheet_index: int
 ) -> Any:
-    if conditional_formats is None:
+    if conditional_formats is None or conditional_formats == []:
         return None
 
     export_cond_formats = []

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -147,7 +147,7 @@ def dfs_to_array_for_json(
 
 def get_conditional_formats_objects_to_export_to_excel(
     conditional_formats: Optional[List[Dict[str, Any]]],
-    column_ids: ColumnIDMap,
+    column_id_map: ColumnIDMap,
     sheet_index: int
 ) -> Any:
     if conditional_formats is None or conditional_formats == []:
@@ -156,15 +156,18 @@ def get_conditional_formats_objects_to_export_to_excel(
     export_cond_formats = []
     for conditional_format in conditional_formats:
         # Create new object to store the columns in the excel format
-        new_format = {
+        new_format: Any = {
             'columns': [],
             'filters': conditional_format.get('filters'),
             'font_color': conditional_format.get('color'),
             'background_color': conditional_format.get('backgroundColor')
         }
         export_cond_formats.append(new_format)
-        for column_id in conditional_format.get('columnIDs'):
-            column_header = column_ids.get_column_header_by_id(sheet_index, column_id)
+        column_ids = conditional_format.get('columnIDs')
+        if column_ids is None:
+            continue
+        for column_id in column_ids:
+            column_header = column_id_map.get_column_header_by_id(sheet_index, column_id)
             new_format['columns'].append(column_header)
     return export_cond_formats
 
@@ -177,7 +180,7 @@ def write_to_excel(
     sheet_indexes: list,
     state: Any,
     allow_formatting:bool=True
-):
+) -> None:
     with pd.ExcelWriter(path, engine="openpyxl") as writer:
         for sheet_index in sheet_indexes:
             # Get the dataframe and sheet name
@@ -192,7 +195,7 @@ def write_to_excel(
             format = state.df_formats[sheet_index]
             conditional_formats = get_conditional_formats_objects_to_export_to_excel(
                 format.get('conditional_formats'),
-                column_ids=state.column_ids,
+                column_id_map=state.column_ids,
                 sheet_index=sheet_index
             )
             if allow_formatting: 

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -175,7 +175,7 @@ def get_conditional_formats_objects_to_export_to_excel(
 #    because the file can be sent to the front-end through a buffer
 def write_to_excel(
     path: any,
-    sheet_indexes: list[int],
+    sheet_indexes: list,
     state: any,
     allow_formatting:bool=True
 ):

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -11,7 +11,6 @@ from random import randint
 import re
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-from pandas._typing import WriteExcelBuffer, FilePath
 import os
 
 import numpy as np
@@ -175,7 +174,7 @@ def get_conditional_formats_objects_to_export_to_excel(
 # Path argument is either the path to the file or a BytesIO object,
 #    because the file can be sent to the front-end through a buffer
 def write_to_excel(
-    path: FilePath | WriteExcelBuffer,
+    path: any,
     sheet_indexes: list[int],
     state: any,
     allow_formatting:bool=True

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -20,6 +20,8 @@ from mitosheet.column_headers import ColumnIDMap, get_column_header_display
 from mitosheet.is_type_utils import get_float_dt_td_columns
 from mitosheet.types import (ColumnHeader, ColumnID, DataframeFormat, FrontendFormulaAndLocation, StateType, FrontendFormula)
 
+from mitosheet.excel_utils import get_column_from_column_index
+
 # We only send the first 1500 rows of a dataframe; note that this
 # must match this variable defined on the front-end
 MAX_ROWS = 1_500
@@ -140,6 +142,25 @@ def dfs_to_array_for_json(
 
     return new_array
 
+
+def add_columns_to_condition_formats(
+    conditional_formats: Optional[List[Dict[str, Any]]],
+    df: any,
+    column_ids: ColumnIDMap,
+    sheet_index: int
+) -> Any:
+    if conditional_formats is None:
+        return None
+
+    for conditional_format in conditional_formats:
+        # Create new object to store the columns in the excel format
+        conditional_format['columns'] = []
+        for column_id in conditional_format.get('columnIDs'):
+            column_header = column_ids.get_column_header_by_id(sheet_index, column_id)
+            column_index = df.columns.tolist().index(column_header)
+            column = get_column_from_column_index(column_index)
+            conditional_format['columns'].append(column)
+    return conditional_formats
 
 def _get_column_id_from_header_safe(
     column_header: ColumnHeader,

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -6,12 +6,12 @@
 """
 Contains helpful utility functions
 """
-from io import BytesIO
 import json
 from random import randint
 import re
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from pandas._typing import WriteExcelBuffer, FilePath
 import os
 
 import numpy as np
@@ -175,7 +175,7 @@ def get_conditional_formats_objects_to_export_to_excel(
 # Path argument is either the path to the file or a BytesIO object,
 #    because the file can be sent to the front-end through a buffer
 def write_to_excel(
-    path: BytesIO | str,
+    path: FilePath | WriteExcelBuffer,
     sheet_indexes: list[int],
     state: any,
     allow_formatting:bool=True

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -19,6 +19,9 @@ import pandas as pd
 from mitosheet.column_headers import ColumnIDMap, get_column_header_display
 from mitosheet.is_type_utils import get_float_dt_td_columns
 from mitosheet.types import (ColumnHeader, ColumnID, DataframeFormat, FrontendFormulaAndLocation, StateType, FrontendFormula)
+from mitosheet.excel_utils import get_df_name_as_valid_sheet_name
+
+from mitosheet.public.v3.formatting import add_formatting_to_excel_sheet
 
 
 # We only send the first 1500 rows of a dataframe; note that this
@@ -165,6 +168,45 @@ def get_conditional_formats_objects_to_export_to_excel(
             column_header = column_ids.get_column_header_by_id(sheet_index, column_id)
             new_format['columns'].append(column_header)
     return export_cond_formats
+
+
+# Writes dataframes to an excel file or a buffer with formatting
+# Path argument is either the path to the file or a BytesIO object,
+#    because the file can be sent to the front-end through a buffer
+def write_to_excel(path, sheet_indexes, state, allow_formatting=True):
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        for sheet_index in sheet_indexes:
+            # Get the dataframe and sheet name
+            df = state.dfs[sheet_index]
+            df_name = state.df_names[sheet_index]
+            sheet_name = get_df_name_as_valid_sheet_name(df_name)
+
+            # Write the dataframe to the sheet
+            df.to_excel(writer, sheet_name, index=False)
+
+            # Add formatting to the sheet for pro users
+            format = state.df_formats[sheet_index]
+            conditional_formats = get_conditional_formats_objects_to_export_to_excel(
+                format.get('conditional_formats'),
+                df=state.dfs[sheet_index],
+                column_ids=state.column_ids,
+                sheet_index=sheet_index
+            )
+            if allow_formatting: 
+                add_formatting_to_excel_sheet(
+                    writer,
+                    sheet_name,
+                    df,
+                    header_background_color=format.get('headers', {}).get('backgroundColor'),
+                    header_font_color=format.get('headers', {}).get('color'),
+                    even_background_color=format.get('rows', {}).get('even', {}).get('backgroundColor'),
+                    even_font_color=format.get('rows', {}).get('even', {}).get('color'),
+                    odd_background_color=format.get('rows', {}).get('odd', {}).get('backgroundColor'),
+                    odd_font_color=format.get('rows', {}).get('odd', {}).get('color'),
+                    conditional_formats=conditional_formats
+                )
+    
+
 
 def _get_column_id_from_header_safe(
     column_header: ColumnHeader,


### PR DESCRIPTION
This adds the ability to export (through code chunks) conditional formats for the "greater than" condition. The generated code looks like this:
```
    add_formatting_to_excel_sheet(writer, "df", df, 
        conditional_formats=[
            {'columns': ['A'], 'filters': [{'condition': 'greater', 'value': 5}], 'font_color': '#e72323', 'background_color': '#ffffff'},
            {'columns': [], 'filters': [{'condition': 'not_empty', 'value': ''}], 'font_color': None, 'background_color': None}
        ]
    )
```