### PR TITLE
Streamlit refactors

### DIFF
--- a/mitosheet/.gitignore
+++ b/mitosheet/.gitignore
@@ -38,6 +38,6 @@ tsconfig.tsbuildinfo
 mitosheet/mito_frontend.js
 mitosheet/mito_frontend.css
 
-mitosheet/streamlit/mitoBuild/*.js
-mitosheet/streamlit/mitoBuild/*.css
-mitosheet/streamlit/messagingBuild/*.js
+mitosheet/streamlit/v1/mitoBuild/*.js
+mitosheet/streamlit/v1/mitoBuild/*.css
+mitosheet/streamlit/v1/messagingBuild/*.js

--- a/mitosheet/mitosheet/api/get_path_contents.py
+++ b/mitosheet/mitosheet/api/get_path_contents.py
@@ -89,10 +89,24 @@ def get_path_contents(params: Dict[str, Any]) -> Dict[str, Any]:
     path parts
     """ 
     path_parts = params['path_parts']
+    import_folder = params.get('import_folder')
 
     # Join the path and normalize it (note this should be OS independent)
     path = os.path.join(*path_parts)
     path = os.path.normpath(path)
+    print("GETTING")
+
+    # First, we make sure that the user has not gone above the import folder, if it exists
+    if import_folder is not None:
+        print("HERE123", import_folder, path)
+        # We get the absolute path of the import folder, and the absolute path of the path
+        # the user is trying to access. Then, we check if the import folder is a prefix of
+        # the path the user is trying to access. If it is not, we return the import folder
+        # contents instead.
+        import_folder = os.path.abspath(import_folder)
+        path = os.path.abspath(path)
+        if not path.startswith(import_folder):
+            return get_path_contents(import_folder)
 
     if path == '\\' and platform.system() == 'Windows':
         # If the path only has one part, it means they are accessing the root folder. If the user is on

--- a/mitosheet/mitosheet/api/get_path_contents.py
+++ b/mitosheet/mitosheet/api/get_path_contents.py
@@ -94,11 +94,9 @@ def get_path_contents(params: Dict[str, Any]) -> Dict[str, Any]:
     # Join the path and normalize it (note this should be OS independent)
     path = os.path.join(*path_parts)
     path = os.path.normpath(path)
-    print("GETTING")
 
     # First, we make sure that the user has not gone above the import folder, if it exists
     if import_folder is not None:
-        print("HERE123", import_folder, path)
         # We get the absolute path of the import folder, and the absolute path of the path
         # the user is trying to access. Then, we check if the import folder is a prefix of
         # the path the user is trying to access. If it is not, we return the import folder

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -52,6 +52,7 @@ class MitoBackend():
             self, 
             *args: Union[pd.DataFrame, str, None], 
             analysis_to_replay: Optional[str]=None, 
+            import_folder: Optional[str]=None,
             user_defined_functions: Optional[List[Callable]]=None,
             user_defined_importers: Optional[List[Callable]]=None,
         ):
@@ -70,6 +71,7 @@ class MitoBackend():
             args, 
             mito_config=self.mito_config, 
             analysis_to_replay=analysis_to_replay, 
+            import_folder=import_folder,
             user_defined_functions=user_defined_functions,
             user_defined_importers=user_defined_importers
         )

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -6,5 +6,8 @@ st.set_page_config(layout="wide")
 
 st.subheader("Dataframe Created from File Upload")
 
-new_dfs, code = spreadsheet()
+new_dfs, code = spreadsheet(r'test_1.csv')
 st.code(code)
+
+_, code1 = spreadsheet(*new_dfs.values(), key="spreadsheet_2")
+st.code(code1)

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -8,3 +8,5 @@ st.subheader("Dataframe Created from File Upload")
 
 new_dfs, code = spreadsheet(import_folder='./datasets')
 st.code(code)
+
+new_dfs, code = spreadsheet(key='test')

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -11,3 +11,5 @@ st.code(code)
 
 _, code1 = spreadsheet(*new_dfs.values(), key="spreadsheet_2")
 st.code(code1)
+
+print("\n\n")

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -6,10 +6,5 @@ st.set_page_config(layout="wide")
 
 st.subheader("Dataframe Created from File Upload")
 
-new_dfs, code = spreadsheet(r'test_1.csv')
+new_dfs, code = spreadsheet(import_folder='./datasets')
 st.code(code)
-
-_, code1 = spreadsheet(*new_dfs.values(), key="spreadsheet_2")
-st.code(code1)
-
-print("\n\n")

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -16,6 +16,10 @@ def _get_dataframe_hash(df: pd.DataFrame) -> bytes:
     2. The values of the dataframe
     3. The index of the dataframe
     4. The order of all of these
+
+    This is necessary due to the issues described here: https://github.com/streamlit/streamlit/issues/7086
+    where streamlit default hashing is not ideal for pandas dataframes, as it misses some column header and
+    reordering changes. 
     """
     try:
         return hashlib.md5(

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -133,9 +133,13 @@ try:
             final dataframes. The second element is a list of lines of code
             that were executed in the Mito spreadsheet.
         """
-        # Get the absolute path to the import_folder, in case it is relative
+        # Get the absolute path to the import_folder, in case it is relative. Also
+        # check that this folder exists, and throw an error if it does not.
         if import_folder is not None:
             import_folder = os.path.abspath(import_folder)
+
+            if not os.path.exists(import_folder):
+                raise ValueError(f"Import folder {import_folder} does not exist. Please change the file path or create the folder.")
 
         mito_backend, responses = _get_mito_backend(
             *args, 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -149,14 +149,20 @@ try:
         user_profile_json = mito_backend.get_user_profile_json()
 
         msg = message_passer_component(key=str(key) + 'message_passer')
-        # Check if the message has already been received. We'll know if the ID of the message
-        # is in the responses list
-        if msg is not None and msg['id'] not in [response['id'] for response in responses]:
-            print("got message", msg['type'], mito_backend.analysis_name)
-            print(msg['id'], [response['id'] for response in responses])
+        if (
+            msg is not None \
+            and msg['id'] not in [response['id'] for response in responses] \
+            and msg['analysis_name'] == mito_backend.analysis_name
+        ):
+            # We receive a message if:
+            # 1. It is not None
+            # 2. We have not already received it on this backend
+            # 3. It is for this analysis. 
+            # Note that the final two conditions are to prevent messages that have been sent
+            # by the message passer component from being received again. This happens because
+            # when a component value is set, it is always returned by the message_passer_component
+            # until a new component value is set            
             mito_backend.receive_message(msg)
-
-        print("mito_backend", type(args[0]), mito_backend.analysis_name, len(mito_backend.steps_manager.steps_including_skipped))
             
         responses_json = json.dumps(responses)
 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -138,8 +138,6 @@ try:
             key=key
         )
 
-        print("mito_backend", args, mito_backend.analysis_name)
-
         # Mito widgets need new ids every time a new one is displayed. As such, if
         # the key is None, we generate a new one. Notably, we do this after getting the
         # mito_backend, so that we can cache the mito_backend on the user provided key.
@@ -151,8 +149,14 @@ try:
         user_profile_json = mito_backend.get_user_profile_json()
 
         msg = message_passer_component(key=str(key) + 'message_passer')
-        if msg is not None:
+        # Check if the message has already been received. We'll know if the ID of the message
+        # is in the responses list
+        if msg is not None and msg['id'] not in [response['id'] for response in responses]:
+            print("got message", msg['type'], mito_backend.analysis_name)
+            print(msg['id'], [response['id'] for response in responses])
             mito_backend.receive_message(msg)
+
+        print("mito_backend", type(args[0]), mito_backend.analysis_name, len(mito_backend.steps_manager.steps_including_skipped))
             
         responses_json = json.dumps(responses)
 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -54,12 +54,14 @@ try:
             *args: Union[pd.DataFrame, str, None], 
             _importers: Optional[List[Callable]]=None, 
             _sheet_functions: Optional[List[Callable]]=None, 
+            _import_folder: Optional[str]=None,
             df_names: Optional[List[str]]=None,
             key: Optional[str]=None # So it caches on key
         ) -> Tuple[MitoBackend, List[Any]]: 
 
         mito_backend = MitoBackend(
             *args, 
+            import_folder=_import_folder,
             user_defined_importers=_importers, user_defined_functions=_sheet_functions
         )
 
@@ -98,6 +100,7 @@ try:
             sheet_functions: Optional[List[Callable]]=None, 
             importers: Optional[List[Callable]]=None, 
             df_names: Optional[List[str]]=None,
+            import_folder: Optional[str]=None,
             key=None
         ) -> Tuple[Dict[str, pd.DataFrame], str]:
         """
@@ -130,10 +133,15 @@ try:
             final dataframes. The second element is a list of lines of code
             that were executed in the Mito spreadsheet.
         """
+        # Get the absolute path to the import_folder, in case it is relative
+        if import_folder is not None:
+            import_folder = os.path.abspath(import_folder)
+
         mito_backend, responses = _get_mito_backend(
             *args, 
             _sheet_functions=sheet_functions,
             _importers=importers, 
+            _import_folder=import_folder,
             df_names=df_names, 
             key=key
         )

--- a/mitosheet/mitosheet/tests/streamlit/test_hash.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_hash.py
@@ -1,0 +1,67 @@
+import time
+import pytest
+import pandas as pd
+from mitosheet.streamlit.v1.spreadsheet import get_dataframe_hash
+
+
+TEST_HASHES = [
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        True
+    ),
+    # Extra column
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4], 'C': [1, 2, 3]}),
+        False
+    ),
+    # Different values
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 5]}),
+        False
+    ),
+    # Different order
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        pd.DataFrame(data={'B': [1, 2, 3], 'A': [2, 3, 4]}),
+        False
+    ),
+    # Different index
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}, index=[1, 2, 3]),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}, index=[1, 2, 4]),
+        False
+    ),
+    # Missing column
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        pd.DataFrame(data={'A': [1, 2, 3]}),
+        False
+    ),
+    # Different sort
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}).sort_values(by=['A']),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}).sort_values(by=['B'], ascending=False),
+        False
+    ),
+    # Different headers
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'C': [2, 3, 4]}),
+        pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]}),
+        False
+    ),
+    # Reordered columns
+    (
+        pd.DataFrame(data={'A': [1, 2, 3], 'C': [2, 3, 4]}),
+        pd.DataFrame(data={'C': [2, 3, 4], 'A': [1, 2, 3]}),
+        False
+    ),
+]
+
+@pytest.mark.parametrize("df1, df2, expected", TEST_HASHES)
+def test_hash_pandas_dataframe(df1, df2, expected):
+    assert len(get_dataframe_hash(df1)) < 100
+    assert (get_dataframe_hash(df1) == get_dataframe_hash(df2)) == expected
+    

--- a/mitosheet/src/jupyter/code.tsx
+++ b/mitosheet/src/jupyter/code.tsx
@@ -1,5 +1,7 @@
 // Utilities for working with the generated code
 
+import { PublicInterfaceVersion } from "../mito";
+
 const IMPORT_STATEMENTS = [
     'from mitosheet.public.v1 import *',
     'from mitosheet.public.v2 import *',
@@ -10,6 +12,7 @@ export function getCodeString(
     analysisName: string,
     code: string[],
     telemetryEnabled: boolean,
+    publicInterfaceVersion: PublicInterfaceVersion
 ): string {
 
     if (code.length == 0) {
@@ -19,18 +22,15 @@ export function getCodeString(
     const finalCode = code.join('\n');
 
     // If telemetry not enabled, we want to be clear about this by
-    // simply not calling a func w/ the analysis name. Notably
-
+    // simply not calling a func w/ the analysis name
     let analysisRegisterCode = '';
-    
-
     if (telemetryEnabled) {
         analysisRegisterCode = `register_analysis("${analysisName}");`
     } else {
         analysisRegisterCode = `# Analysis Name:${analysisName};`
     }
 
-    return finalCode.replace('import *', `import *; ${analysisRegisterCode}`);
+    return finalCode.replace(`mitosheet.public.v${publicInterfaceVersion} import *`, `mitosheet.public.v${publicInterfaceVersion} import *; ${analysisRegisterCode}`);
 }
 
 

--- a/mitosheet/src/jupyter/jupyterUtils.tsx
+++ b/mitosheet/src/jupyter/jupyterUtils.tsx
@@ -61,7 +61,7 @@ export const writeGeneratedCodeToCell = (analysisName: string, code: string[], t
             publicInterfaceVersion: publicInterfaceVersion
         });
     } else if (isInJupyterNotebook()) {
-        notebookWriteGeneratedCodeToCell(analysisName, code, telemetryEnabled);
+        notebookWriteGeneratedCodeToCell(analysisName, code, telemetryEnabled, publicInterfaceVersion);
     } else {
         console.error("Not detected as in Jupyter Notebook or JupyterLab")
     }

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -1,3 +1,4 @@
+import { PublicInterfaceVersion } from "../../mito";
 import { MitoAPI } from "../../mito/api/api";
 import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, containsMitosheetCallWithSpecificAnalysisToReplay, getArgsFromMitosheetCallCode, getCodeString, isMitosheetCallCode, removeWhitespaceInPythonCode } from "../code";
 
@@ -206,8 +207,8 @@ export const notebookOverwriteAnalysisToReplayToMitosheetCall = (oldAnalysisName
     }
 }
 
-export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean): void => {
-    const code = getCodeString(analysisName, codeLines, telemetryEnabled);
+export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion): void => {
+    const code = getCodeString(analysisName, codeLines, telemetryEnabled, publicInterfaceVersion);
         
     // Find the cell that made the mitosheet.sheet call, and if it does not exist, give
     // up immediately

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -139,7 +139,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
 
     // We store the path that the user last uses when they are using the import
     // in Mito so that we can open to the same place next time they use it
-    const [currPathParts, setCurrPathParts] = useState<string[]>(['.']);
+    const [currPathParts, setCurrPathParts] = useState<string[]>(props.analysisData.importFolderData ? props.analysisData.importFolderData.pathParts : ['.']);
 
     // We store all AI Transform params in Mito, so that users can open and close
     // the AI Transform taskpane and still access their old prompts

--- a/mitosheet/src/mito/api/api.tsx
+++ b/mitosheet/src/mito/api/api.tsx
@@ -209,12 +209,13 @@ export class MitoAPI {
     /*
         Gets the path data for given path parts
     */
-    async getPathContents(pathParts: string[]): Promise<MitoAPIResult<PathContents>> {
+    async getPathContents(pathParts: string[], importFolderPath: string | undefined): Promise<MitoAPIResult<PathContents>> {
         return await this.send<PathContents>({
             'event': 'api_call',
             'type': 'get_path_contents',
             'params': {
-                'path_parts': pathParts
+                'path_parts': pathParts,
+                'import_folder': importFolderPath
             }
         });
     }

--- a/mitosheet/src/mito/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/mito/components/elements/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { Component, ReactNode } from "react";
 import { MitoAPI } from "../../api/api";
 import { DISCORD_INVITE_LINK } from "../../data/documentationLinks";
 import { AnalysisData, SheetData, UserProfile } from "../../types";
+import { isInStreamlit } from "../../utils/location";
 
 interface Props {
     children: ReactNode;
@@ -39,10 +40,16 @@ class ErrorBoundary extends Component<Props, State> {
     }
 
     public render(): ReactNode {
+
+        let fixUpMessage = 'Rerun the Jupyter Cell above';
+        if (isInStreamlit()) {
+            fixUpMessage = 'Refresh the Streamlit app'
+        }
+
         if (this.state.hasError) {
             return (
                 <p className='text-body-1 text-color-red p-10px'>
-                    Looks like Mito had an error! Sorry about that. Rerun the Jupyter Cell above, and join our <a className='text-body-1-link' href={DISCORD_INVITE_LINK} target='_blank' rel="noreferrer">Discord</a> for support if this error occurs again.
+                    Looks like Mito had an error! Sorry about that. {fixUpMessage}, and join our <a className='text-body-1-link' href={DISCORD_INVITE_LINK} target='_blank' rel="noreferrer">Discord</a> for support if this error occurs again.
                 </p>
             )
         }

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowser.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowser.tsx
@@ -109,7 +109,7 @@ function FileBrowser(props: FileBrowserProps): JSX.Element {
                 loadingFolder: true
             }
         })
-        const response = await props.mitoAPI.getPathContents(currPathParts);
+        const response = await props.mitoAPI.getPathContents(currPathParts, props.analysisData.importFolderData?.path);
         const _pathContents = 'error' in response ? undefined : response.result;
         if (_pathContents) {
             setFileBrowserState(prevImportState => {
@@ -148,6 +148,7 @@ function FileBrowser(props: FileBrowserProps): JSX.Element {
                 <FileBrowserBody
                     mitoAPI={props.mitoAPI}
                     userProfile={props.userProfile}
+                    analysisData={props.analysisData}
                     setUIState={props.setUIState}
 
                     currPathParts={props.currPathParts}

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
@@ -86,6 +86,16 @@ function FileBrowserBody(props: FileBrowserProps): JSX.Element {
 
     const displayUpgradeToPro = inRootFolder(props.fileBrowserState.pathContents.path_parts) && !props.userProfile.isPro;
 
+
+    /**
+     * If we are in streamlit and the user hasn't configured the import folder,
+     * we display a message telling them to do so.
+     * 
+     * This is because the security model of streamlit requires us to know the
+     * specific location users can import data from, as we don't just want them
+     * to be able to import from anywhere on the server -- there could be private
+     * data.
+     */
     if (isInStreamlit() && !props.analysisData.importFolderData) {
         return (
             <>

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
@@ -5,18 +5,17 @@ import '../../../../../css/taskpanes/Import/FileBrowser.css';
 import { MitoAPI } from '../../../api/api';
 import { AnalysisData, UIState, UserProfile } from '../../../types';
 import { classNames } from '../../../utils/classNames';
+import { isInStreamlit } from '../../../utils/location';
 import { isExcelImportEnabled } from '../../../utils/packageVersion';
 import SortArrowIcon from '../../icons/SortArrowIcon';
 import Col from '../../layout/Col';
 import Row from '../../layout/Row';
+import Spacer from '../../layout/Spacer';
 import { FileElement, ImportState } from '../../taskpanes/FileImport/FileImportTaskpane';
 import { getElementsToDisplay, getFilePath, inRootFolder, isExcelFile } from '../../taskpanes/FileImport/importUtils';
 import { TaskpaneType } from '../../taskpanes/taskpanes';
 import FileBrowserElement from './FileBrowserElement';
 import FileBrowserPathSelector from './FileBrowserPathSelector';
-import { isInStreamlit } from '../../../utils/location';
-import DefaultEmptyTaskpane from '../../taskpanes/DefaultTaskpane/DefaultEmptyTaskpane';
-import Spacer from '../../layout/Spacer';
 
 
 export interface PathContents {

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import '../../../../../css/elements/Input.css';
 import '../../../../../css/taskpanes/Import/FileBrowser.css';
 import { MitoAPI } from '../../../api/api';
-import { UIState, UserProfile } from '../../../types';
+import { AnalysisData, UIState, UserProfile } from '../../../types';
 import { classNames } from '../../../utils/classNames';
 import { isExcelImportEnabled } from '../../../utils/packageVersion';
 import SortArrowIcon from '../../icons/SortArrowIcon';
@@ -35,6 +35,7 @@ export interface FileBrowserState {
 interface FileBrowserProps {
     mitoAPI: MitoAPI;
     userProfile: UserProfile;
+    analysisData: AnalysisData;
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
 
     currPathParts: string[],
@@ -86,6 +87,7 @@ function FileBrowserBody(props: FileBrowserProps): JSX.Element {
         <div className='file-browser flexbox-column'>
             <div>
                 <FileBrowserPathSelector
+                    importFolderData={props.analysisData.importFolderData}
                     setCurrPathParts={props.setCurrPathParts}
                     pathParts={props.fileBrowserState.pathContents.path_parts}
                 />

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserBody.tsx
@@ -14,6 +14,9 @@ import { getElementsToDisplay, getFilePath, inRootFolder, isExcelFile } from '..
 import { TaskpaneType } from '../../taskpanes/taskpanes';
 import FileBrowserElement from './FileBrowserElement';
 import FileBrowserPathSelector from './FileBrowserPathSelector';
+import { isInStreamlit } from '../../../utils/location';
+import DefaultEmptyTaskpane from '../../taskpanes/DefaultTaskpane/DefaultEmptyTaskpane';
+import Spacer from '../../layout/Spacer';
 
 
 export interface PathContents {
@@ -82,6 +85,29 @@ function FileBrowserBody(props: FileBrowserProps): JSX.Element {
     }, [props.fileBrowserState.selectedElementIndex, props.fileBrowserState.sort])
 
     const displayUpgradeToPro = inRootFolder(props.fileBrowserState.pathContents.path_parts) && !props.userProfile.isPro;
+
+    if (isInStreamlit() && !props.analysisData.importFolderData) {
+        return (
+            <>
+                <p 
+                    className={classNames('text-body-1', 'text-overflow-wrap')}
+                    style={{whiteSpace:'pre-wrap'}} // So we handle new line and tabs correctly
+                >
+                    To use the file browser, you must first configure the folder you want to allow users to 
+                    import from.
+                </p>
+                <Spacer px={10}/>
+                <p 
+                    className={classNames('text-body-1', 'text-overflow-wrap')}
+                    style={{whiteSpace:'pre-wrap'}} // So we handle new line and tabs correctly
+                >
+                    This is configurable with the <code>import_folder</code> parameter in the <code>spreadsheet</code> component 
+                    in your streamlit application.
+                </p>
+            </>
+        )
+
+    }
 
     return (
         <div className='file-browser flexbox-column'>

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserPathSelector.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserPathSelector.tsx
@@ -6,7 +6,7 @@ interface FileBrowserPathSelectorProps {
     importFolderData: {
         path: string,
         pathParts: string[]
-    } | undefined;
+    } | undefined | null;
     pathParts: string[] | undefined;
     setCurrPathParts: (newPathParts: string[]) => void;
 }
@@ -37,8 +37,8 @@ function FileBrowserPathSelector(props: FileBrowserPathSelectorProps): JSX.Eleme
         }
     });
 
-    const pathPartsAndIndexesToDisplay = props.importFolderData !== undefined
-        ? pathPartsAndIndexes?.slice(props.importFolderData.pathParts.length - 1)
+    const pathPartsAndIndexesToDisplay = props.importFolderData
+        ? pathPartsAndIndexes?.slice((props.importFolderData?.pathParts.length ?? 1) - 1)
         : pathPartsAndIndexes;
 
     return (

--- a/mitosheet/src/mito/components/import/FileBrowser/FileBrowserPathSelector.tsx
+++ b/mitosheet/src/mito/components/import/FileBrowser/FileBrowserPathSelector.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import DriveIcon from '../../icons/DriveIcon'
 
 interface FileBrowserPathSelectorProps {
+    importFolderData: {
+        path: string,
+        pathParts: string[]
+    } | undefined;
     pathParts: string[] | undefined;
     setCurrPathParts: (newPathParts: string[]) => void;
 }
@@ -26,9 +30,23 @@ function FileBrowserPathSelector(props: FileBrowserPathSelectorProps): JSX.Eleme
         props.setCurrPathParts(subPathParts);
     }
 
+    const pathPartsAndIndexes = props.pathParts?.map((pathPart, i) => {
+        return {
+            pathPart: pathPart,
+            index: i
+        }
+    });
+
+    const pathPartsAndIndexesToDisplay = props.importFolderData !== undefined
+        ? pathPartsAndIndexes?.slice(props.importFolderData.pathParts.length - 1)
+        : pathPartsAndIndexes;
+
     return (
         <div className='file-browser-path-selector'>
-            {props.pathParts?.map((pathPart, i) => {
+            {pathPartsAndIndexesToDisplay?.map((pathPartAndIndex) => {
+                const pathPart = pathPartAndIndex.pathPart;
+                const i = pathPartAndIndex.index;
+
                 return (
                     <React.Fragment key={i}>
                         <div className='highlight-on-hover file-browser-path-part' key={i} onClick={() => {updateSelectedPath(i)}}>

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -741,6 +741,11 @@ export type UserDefinedImporter = {
  * @param lastResult - This is the result of the last step that was applied. This might be undefined if the 
  *        step does not return a result
  * @param experiment - The experiment that this user is currently running, which may not be defined
+ * @param codeOptions - The options for how to generate code for this analysis
+ * @param userDefinedFunctions - The user defined functions that have been defined in this analysis, usable 
+ *                               in the sheet. 
+ * @param userDefinedImporters - The user defined importers that have been defined in this analysis. USers
+ *        can access these through custom imports
  */
 export interface AnalysisData {
     analysisName: string,
@@ -763,6 +768,11 @@ export interface AnalysisData {
     codeOptions: CodeOptions;
     userDefinedFunctions: string[];
     userDefinedImporters: UserDefinedImporter[];
+
+    importFolderData: {
+        path: string,
+        pathParts: string[],
+    } | undefined
 }
 
 export interface MitoConfig {

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -772,7 +772,7 @@ export interface AnalysisData {
     importFolderData: {
         path: string,
         pathParts: string[],
-    } | undefined
+    } | null
 }
 
 export interface MitoConfig {

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -9,7 +9,7 @@ import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application'
 import { ToolbarButton } from '@jupyterlab/apputils';
 import { INotebookTracker, NotebookActions } from '@jupyterlab/notebook';
 import { mitoJLabIcon } from './jupyter/MitoIcon';
-import { MitoAPI } from './mito';
+import { MitoAPI, PublicInterfaceVersion } from './mito';
 import { LabComm } from './jupyter/comm';
 import {
     getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell
@@ -135,8 +135,9 @@ function activateMitosheetExtension(
             const analysisName = args.analysisName as string;
             const codeLines = args.code as string[];
             const telemetryEnabled = args.telemetryEnabled as boolean;
+            const publicInterfaceVersion = args.publicInterfaceVersion as PublicInterfaceVersion;
 
-            const code = getCodeString(analysisName, codeLines, telemetryEnabled);
+            const code = getCodeString(analysisName, codeLines, telemetryEnabled, publicInterfaceVersion);
             
             // Find the cell that made the mitosheet.sheet call, and if it does not exist, give
             // up immediately

--- a/mitosheet/src/streamlit/MitoStreamlitWrapper.tsx
+++ b/mitosheet/src/streamlit/MitoStreamlitWrapper.tsx
@@ -10,7 +10,8 @@ import { getAnalysisDataFromString, getSheetDataArrayFromString, getUserProfileF
 
 
 interface State {
-    responses: MitoResponse[]
+    responses: MitoResponse[],
+    analysisName: string
 }
 
 // Max delay is the longest we'll wait for the API to return a value
@@ -28,11 +29,7 @@ export const MAX_RETRIES = MAX_DELAY / RETRY_DELAY;
 const getMitoThemeFromStreamlitTheme = (streamlitTheme: Theme | undefined): MitoTheme | undefined => {
     if (streamlitTheme === undefined) {
         return undefined
-    }
-
-    
-
-    
+    }    
 
     if (streamlitTheme.base === 'light') {
         // If it's the default light theme, we simply include the variables that are
@@ -84,7 +81,7 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
 
     constructor(props: any) {
         super(props);
-        this.state = { responses: [] };
+        this.state = { responses: [], analysisName: '' };
     }
 
     public getResponseData<ResultType>(id: string, maxRetries = MAX_RETRIES): Promise<SendFunctionReturnType<ResultType>> {
@@ -139,14 +136,14 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
         })
     }
 
-    public async send(msg: Record<string, unknown>, analysisName: string): Promise<SendFunctionReturnType<any>> {
+    public async send(msg: Record<string, unknown>): Promise<SendFunctionReturnType<any>> {
 
         // We inject the analysisName into the message, so that the backend
         // can make sure it's getting the right message for the right
         // analysis. This is necessary in streamlit as the message passing
         // component "sends" messages even when a new backend is created - and 
         // we don't want to send old messages to the new backend!
-        msg['analysis_name'] = analysisName;
+        msg['analysis_name'] = this.state.analysisName;
 
         // First, get the iframe of the MitoMessagePasser component
         const parentWindow = window.parent;
@@ -178,7 +175,9 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
             const newResponses = responses.slice(this.state.responses.length);
             
             this.setState(prevState => {
-                return {responses: [...prevState.responses, ...newResponses]}
+                return {
+                    responses: [...prevState.responses, ...newResponses],
+                }
             });
         }
         // If we have less responses, this means we have reset the Mito instance,
@@ -187,14 +186,12 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
             this.setState({responses: responses});
         }
 
-        const send = (msg: Record<string, unknown>) => {
-            return this.send(msg, analysisData.analysisName);
-        }
+        this.setState({analysisName: analysisData.analysisName});
 
         return (
             <Mito 
                 key={this.props.args['id'] as string}
-                getSendFunction={async () => send} 
+                getSendFunction={async () => this.send.bind(this)} 
                 sheetDataArray={sheetDataArray} 
                 analysisData={analysisData} 
                 userProfile={userProfile}

--- a/mitosheet/src/streamlit/MitoStreamlitWrapper.tsx
+++ b/mitosheet/src/streamlit/MitoStreamlitWrapper.tsx
@@ -139,7 +139,15 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
         })
     }
 
-    public async send(msg: Record<string, unknown>): Promise<SendFunctionReturnType<any>> {
+    public async send(msg: Record<string, unknown>, analysisName: string): Promise<SendFunctionReturnType<any>> {
+
+        // We inject the analysisName into the message, so that the backend
+        // can make sure it's getting the right message for the right
+        // analysis. This is necessary in streamlit as the message passing
+        // component "sends" messages even when a new backend is created - and 
+        // we don't want to send old messages to the new backend!
+        msg['analysis_name'] = analysisName;
+
         // First, get the iframe of the MitoMessagePasser component
         const parentWindow = window.parent;
         const iframes = parentWindow.frames;
@@ -179,10 +187,14 @@ class MitoStreamlitWrapper extends StreamlitComponentBase<State> {
             this.setState({responses: responses});
         }
 
+        const send = (msg: Record<string, unknown>) => {
+            return this.send(msg, analysisData.analysisName);
+        }
+
         return (
             <Mito 
                 key={this.props.args['id'] as string}
-                getSendFunction={async () => this.send.bind(this)} 
+                getSendFunction={async () => send} 
                 sheetDataArray={sheetDataArray} 
                 analysisData={analysisData} 
                 userProfile={userProfile}


### PR DESCRIPTION
# Description

1. Adds our own hashing function. See issue on streamlit here that this is a workaround for: https://github.com/streamlit/streamlit/issues/7086
2. We were double delivering messages in multiple cases - because setComponentValue persists between runs, even if the backend changes. This fixes that. 

# Testing

1. Renames aren't detected by the caching function in streamlit. We need to write our own caching function.
2. Two mitosheets that feed into eachother. Add column in first, then delete column in second, then add new column in first. The second sheet has code that is out of date with the sheet.
3. 
# Documentation

Note if any new documentation needs to addressed or reviewed.