### PR TITLE
streamlit: make sure we cache on the right variables

### DIFF
--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -56,17 +56,17 @@ try:
     @st.cache_resource(hash_funcs={pd.DataFrame: get_dataframe_hash})
     def _get_mito_backend(
             *args: Union[pd.DataFrame, str, None], 
-            _importers: Optional[List[Callable]]=None, 
-            _sheet_functions: Optional[List[Callable]]=None, 
-            _import_folder: Optional[str]=None,
+            importers: Optional[List[Callable]]=None, 
+            sheet_functions: Optional[List[Callable]]=None, 
+            import_folder: Optional[str]=None,
             df_names: Optional[List[str]]=None,
             key: Optional[str]=None # So it caches on key
         ) -> Tuple[MitoBackend, List[Any]]: 
 
         mito_backend = MitoBackend(
             *args, 
-            import_folder=_import_folder,
-            user_defined_importers=_importers, user_defined_functions=_sheet_functions
+            import_folder=import_folder,
+            user_defined_importers=importers, user_defined_functions=sheet_functions
         )
 
         # Make a send function that stores the responses in a list
@@ -148,9 +148,9 @@ try:
 
         mito_backend, responses = _get_mito_backend(
             *args, 
-            _sheet_functions=sheet_functions,
-            _importers=importers, 
-            _import_folder=import_folder,
+            sheet_functions=sheet_functions,
+            importers=importers, 
+            import_folder=import_folder,
             df_names=df_names, 
             key=key
         )

--- a/mitosheet/src/mito/utils/location.tsx
+++ b/mitosheet/src/mito/utils/location.tsx
@@ -20,13 +20,15 @@ export const isInJupyterNotebook = (): boolean => {
 }
 
 export const isInStreamlit = (): boolean => {
-    // Check if we are in an iframe, and if we are, look for an stApp that we are a part of
-    let currentWindow: Window | null = window;
-    if (currentWindow !== window.top) {        
-        if (currentWindow.document?.getElementsByClassName('stApp').length > 0) {
-            return true;
+    
+    // We are in streamlit if we are in an iframe that has a parent with
+    // a class of "stApp"
+
+    if (window.parent) {
+        const parent = window.parent.document.querySelector('.stApp')
+        if (parent) {
+            return true
         }
-        currentWindow = window.parent;
     }
-    return false;
+    return false
 }

--- a/mitosheet/src/mito/utils/location.tsx
+++ b/mitosheet/src/mito/utils/location.tsx
@@ -20,12 +20,13 @@ export const isInJupyterNotebook = (): boolean => {
 }
 
 export const isInStreamlit = (): boolean => {
-    // Check if we are in an iframe
-    if (window.self !== window.top) {
-        const topDocument = window.top?.document;
-        return (topDocument && topDocument.getElementsByClassName('stApp').length > 0) ||
-            (window.top !== null && (window.top as any).streamlitDebug !== undefined)
+    // Check if we are in an iframe, and if we are, look for an stApp that we are a part of
+    let currentWindow: Window | null = window;
+    if (currentWindow !== window.top) {        
+        if (currentWindow.document?.getElementsByClassName('stApp').length > 0) {
+            return true;
+        }
+        currentWindow = window.parent;
     }
     return false;
-    // TODO: What else can we check?
 }


### PR DESCRIPTION
# Description

We used to make it so if you change the import path, or any of the sheet functions, you had to restart the app to get the new stuff. This is obviously not correct, and this fixes that. 

# Testing

N/A.

# Documentation

No.