### PR TITLE
streamlit: fix caching issues

### DIFF
--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -14,6 +14,12 @@ if button:
 
 st.subheader("Dataframe Created from File Upload")
 
+def importer():
+    import pandas as pd
+    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+
+
+
 from mitosheet.streamlit.v1 import spreadsheet
-new_dfs, code = spreadsheet(import_folder='~/monorepo/mitosheet/datasets')
+new_dfs, code = spreadsheet(import_folder='~/monorepo/mitosheet/datasets', importers=[importer])
 st.code(code)


### PR DESCRIPTION
# Description

Makes it so different users don't share the same Mitosheet. Notably:
1. The clear on page refresh is exactly how other streamlit components work (e.g. buttons work like this!) -- so it's actually more legit than what we were doing before!
2. We can't use cache_data because the Mito backend is a) not serializable, and b) massive. It's literally every step, so it would be so slow for large datasets to serialize it. 
3. The only thing it would make sense to serialize with st.cache_data is the messages sent from the backend, but this requires then reprocessing _from the start_ for every edit, which is also very slow. 

All in all, this solution is pretty sweet and smooth and I am very happy with it!

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.