### PR TITLE
streamlit: allow remote file paths

### DIFF
--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -153,8 +153,6 @@ class SimpleImportStepPerformer(StepPerformer):
         return {-1}
 
 
-
-
 def read_csv_get_delimiter_and_encoding(file_name: str) -> Tuple[pd.DataFrame, str, str]:
     """
     Given a file_name, will read in the file as a CSV, and
@@ -162,6 +160,11 @@ def read_csv_get_delimiter_and_encoding(file_name: str) -> Tuple[pd.DataFrame, s
     """
     encoding = DEFAULT_ENCODING
     delimeter = DEFAULT_DELIMETER
+
+    if is_url_to_file(file_name):
+        df = pd.read_csv(file_name)
+        return df, delimeter, encoding
+
     try:
         # First attempt to read csv without specifying an encoding, just with a delimeter
         delimeter = guess_delimeter(file_name)
@@ -201,3 +204,17 @@ def guess_encoding(file_name: str) -> str:
     with open(file_name, 'rb') as f:
         result = chardet.detect(f.readline())
         return result['encoding']
+
+
+def is_url_to_file(file_name: str) -> bool:
+    """
+    Returns true if the file_name is a url to a file -- which we need to know
+    as we can't sniff the delimeter of a url.
+
+    This isn't perfect, and we should improve it, but it's ok for now!
+    """
+    if file_name.startswith('http://') or file_name.startswith('https://'):
+        return True
+    
+    return False
+

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -6,20 +6,6 @@ import streamlit as st
 
 st.set_page_config(layout="wide")
 
-# Delete ./mito/user.json
-button = st.button("Delete user.json")
-if button:
-    import os
-    os.remove('~/.mito/user.json')
-
-st.subheader("Dataframe Created from File Upload")
-
-def importer():
-    import pandas as pd
-    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
-
-
-
 from mitosheet.streamlit.v1 import spreadsheet
-new_dfs, code = spreadsheet(import_folder='~/monorepo/mitosheet/datasets', importers=[importer])
+new_dfs, code = spreadsheet('https://raw.githubusercontent.com/plotly/datasets/master/tesla-stock-price.csv')
 st.code(code)


### PR DESCRIPTION
# Description

This fixes up Mito so it supports remote file paths that are at Urls. Notably, this will now work in a `mitosheet.sheet` call as well -- which is pretty cool!

# Testing

See testing streamlit.py app!

# Documentation

No.