### PR TITLE
mitosheet: add more code config options that make recon app easier

### DIFF
--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -29,6 +29,7 @@ from mitosheet.saved_analyses import write_analysis
 from mitosheet.steps_manager import StepsManager
 from mitosheet.telemetry.telemetry_utils import (log, log_event_processed,
                                                  telemetry_turned_on)
+from mitosheet.types import CodeOptions
 from mitosheet.updates.replay_analysis import REPLAY_ANALYSIS_UPDATE
 from mitosheet.user import is_local_deployment
 from mitosheet.user.create import try_create_user_json_file
@@ -55,6 +56,7 @@ class MitoBackend():
             import_folder: Optional[str]=None,
             user_defined_functions: Optional[List[Callable]]=None,
             user_defined_importers: Optional[List[Callable]]=None,
+            code_options: Optional[CodeOptions]=None
         ):
         """
         Takes a list of dataframes and strings that are paths to CSV files
@@ -73,7 +75,8 @@ class MitoBackend():
             analysis_to_replay=analysis_to_replay, 
             import_folder=import_folder,
             user_defined_functions=user_defined_functions,
-            user_defined_importers=user_defined_importers
+            user_defined_importers=user_defined_importers,
+            code_options=code_options
         )
 
         # And the api

--- a/mitosheet/mitosheet/saved_analyses/upgrade.py
+++ b/mitosheet/mitosheet/saved_analyses/upgrade.py
@@ -351,6 +351,11 @@ def upgrade_saved_analysis_to_have_code_options(saved_analysis: Optional[Dict[st
 
     if code_options is not None:
         saved_analysis['code_options'] = code_options
+
+        # If the call function is not in the code options, we default it to True. 
+        # this param was added later
+        if 'call_function' not in code_options:
+            saved_analysis['code_options']['call_function'] = True
     else:
         # Otherwise, we have to add it to the analysis as default 1
         saved_analysis['code_options'] = get_default_code_options(analysis_name)

--- a/mitosheet/mitosheet/state.py
+++ b/mitosheet/mitosheet/state.py
@@ -137,13 +137,7 @@ class State:
         # This is helpful for undoing, for example. 
         self.graph_data_dict: OrderedDict[str, Dict[str, Any]] = graph_data_dict if graph_data_dict is not None else OrderedDict()
 
-        # User defined functions. Check them for validity, and wrap them in the correct wrappers
-        check_valid_sheet_functions(user_defined_functions)
-
-        from mitosheet.public.v3.errors import handle_sheet_function_errors
-        user_defined_functions = [handle_sheet_function_errors(user_defined_function) for user_defined_function in (user_defined_functions if user_defined_functions is not None else [])]
         self.user_defined_functions = user_defined_functions if user_defined_functions is not None else []
-
         self.user_defined_importers = user_defined_importers if user_defined_importers is not None else []
 
     def copy(self, deep_sheet_indexes: Optional[List[int]]=None) -> "State":

--- a/mitosheet/mitosheet/steps_manager.py
+++ b/mitosheet/mitosheet/steps_manager.py
@@ -236,7 +236,7 @@ class StepsManager:
         user_defined_functions = [handle_sheet_function_errors(user_defined_function) for user_defined_function in (user_defined_functions if user_defined_functions is not None else [])]
 
         # We also do some checks for the user_defined_importers
-        if not is_enterprise() and user_defined_importers is not None and len(user_defined_importers) > 0:
+        if not is_running_test() and not is_enterprise() and user_defined_importers is not None and len(user_defined_importers) > 0:
             raise ValueError("importers are only supported in the enterprise version of Mito. See Mito plans https://www.trymito.io/plans")
 
         # Then we initialize the analysis with just a simple initialize step
@@ -317,7 +317,7 @@ class StepsManager:
         # The options for the transpiled code. The user can optionally pass these 
         # in, but if they don't, we use the default options
         # We also do some checks for the user_defined_importers
-        if not is_enterprise() and code_options is not None and len(code_options) > 0:
+        if not is_running_test() and not is_enterprise() and code_options is not None and len(code_options) > 0:
             raise ValueError("code_options are only supported in the enterprise version of Mito. See Mito plans https://www.trymito.io/plans")
 
         self.code_options: CodeOptions = get_default_code_options(self.analysis_name) if code_options is None else code_options

--- a/mitosheet/mitosheet/steps_manager.py
+++ b/mitosheet/mitosheet/steps_manager.py
@@ -35,8 +35,8 @@ from mitosheet.transpiler.transpile import transpile
 from mitosheet.transpiler.transpile_utils import get_default_code_options
 from mitosheet.types import CodeOptions
 from mitosheet.updates import UPDATES
-from mitosheet.user.utils import is_pro, is_running_test
-from mitosheet.utils import (NpEncoder, dfs_to_array_for_json, get_new_id,
+from mitosheet.user.utils import is_enterprise, is_pro, is_running_test
+from mitosheet.utils import (NpEncoder, check_valid_sheet_functions, dfs_to_array_for_json, get_new_id,
                              is_default_df_names)
 
 def get_step_indexes_to_skip(step_list: List[Step]) -> Set[int]:
@@ -179,6 +179,7 @@ class StepsManager:
             import_folder: Optional[str]=None,
             user_defined_functions: Optional[List[Callable]]=None,
             user_defined_importers: Optional[List[Callable]]=None,
+            code_options: Optional[CodeOptions]=None
         ):
         """
         When initalizing the StepsManager, we also do preprocessing
@@ -187,9 +188,9 @@ class StepsManager:
         All preprocessing can be found in mitosheet/preprocessing, and each of
         the transformations are applied before the data is considered imported.
         """
+
         # We just randomly generate analysis names as a string of 10 letters
         self.analysis_name = 'id-' + ''.join(random.choice(string.ascii_lowercase) for _ in range(10))
-
 
         # We also save some data about the analysis the user wants to replay, if there
         # is such an analysis
@@ -225,7 +226,18 @@ class StepsManager:
             args, df_names, execution_data = preprocess_step_performers.execute(args)
             self.preprocess_execution_data[
                 preprocess_step_performers.preprocess_step_type()
-            ] = execution_data            
+            ] = execution_data       
+
+
+        # Then, we check user defined functions. Check them for validity, and wrap them in the correct wrappers,
+        # before passing them to the step to be used
+        check_valid_sheet_functions(user_defined_functions)
+        from mitosheet.public.v3.errors import handle_sheet_function_errors
+        user_defined_functions = [handle_sheet_function_errors(user_defined_function) for user_defined_function in (user_defined_functions if user_defined_functions is not None else [])]
+
+        # We also do some checks for the user_defined_importers
+        if not is_enterprise() and user_defined_importers is not None and len(user_defined_importers) > 0:
+            raise ValueError("importers are only supported in the enterprise version of Mito. See Mito plans https://www.trymito.io/plans")
 
         # Then we initialize the analysis with just a simple initialize step
         self.steps_including_skipped: List[Step] = [
@@ -302,9 +314,13 @@ class StepsManager:
         # The version of the public interface used by this analysis
         self.public_interface_version = 3
 
-        # The options for the transpiled code. For now, we just store if it should
-        # be a function, which we default to False
-        self.code_options: CodeOptions = get_default_code_options(self.analysis_name)
+        # The options for the transpiled code. The user can optionally pass these 
+        # in, but if they don't, we use the default options
+        # We also do some checks for the user_defined_importers
+        if not is_enterprise() and code_options is not None and len(code_options) > 0:
+            raise ValueError("code_options are only supported in the enterprise version of Mito. See Mito plans https://www.trymito.io/plans")
+
+        self.code_options: CodeOptions = get_default_code_options(self.analysis_name) if code_options is None else code_options
 
     @property
     def curr_step(self) -> Step:

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Callable, Optional, Tuple, Union
 import pandas as pd
 
 from mitosheet.mito_backend import MitoBackend
+from mitosheet.types import CodeOptions
 from mitosheet.utils import get_new_id
 
 def _get_dataframe_hash(df: pd.DataFrame) -> bytes:
@@ -83,6 +84,7 @@ try:
             *args: Union[pd.DataFrame, str, None], 
             _importers: Optional[List[Callable]]=None, 
             _sheet_functions: Optional[List[Callable]]=None, 
+            _code_options: Optional[CodeOptions]=None,
             import_folder: Optional[str]=None,
             df_names: Optional[List[str]]=None,
             session_id: Optional[str]=None,
@@ -92,7 +94,8 @@ try:
         mito_backend = MitoBackend(
             *args, 
             import_folder=import_folder,
-            user_defined_importers=_importers, user_defined_functions=_sheet_functions
+            user_defined_importers=_importers, user_defined_functions=_sheet_functions,
+            code_options=_code_options,
         )
 
         # Make a send function that stores the responses in a list

--- a/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
+++ b/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
@@ -55,6 +55,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -76,6 +77,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -98,6 +100,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -119,6 +122,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -148,6 +152,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -170,6 +175,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -193,6 +199,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -218,6 +225,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -247,6 +255,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -273,6 +282,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -299,6 +309,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -327,6 +338,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -350,6 +362,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -373,6 +386,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -396,6 +410,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -432,6 +447,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -461,6 +477,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -497,6 +514,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -526,6 +544,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -544,6 +563,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -562,6 +582,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -579,6 +600,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -596,6 +618,7 @@ UPGRADE_TESTS = [
             "args": [],
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }
@@ -605,11 +628,11 @@ UPGRADE_TESTS = [
     (
         {
             "version": "0.3.131", 
-            "steps_data": [{"step_version": 2, "step_type": "snowflake_import", "params": {"table_loc_and_warehouse": {"warehouse": "COMPUTE_WH", "database": "PYTESTDATABASE", "schema": "INFORMATION_SCHEMA", "table_or_view": "APPLICABLE_ROLES"}, "query_params": {"columns": ["GRANTEE", "ROLE_NAME", "ROLE_OWNER", "IS_GRANTABLE"]}}}], "public_interface_version": 3, "args": [], "code_options": {"as_function": False, "function_name": "function_rgge", "function_params": {}}
+            "steps_data": [{"step_version": 2, "step_type": "snowflake_import", "params": {"table_loc_and_warehouse": {"warehouse": "COMPUTE_WH", "database": "PYTESTDATABASE", "schema": "INFORMATION_SCHEMA", "table_or_view": "APPLICABLE_ROLES"}, "query_params": {"columns": ["GRANTEE", "ROLE_NAME", "ROLE_OWNER", "IS_GRANTABLE"]}}}], "public_interface_version": 3, "args": [], "code_options": {"as_function": False, "call_function": True, "function_name": "function_rgge", "function_params": {}}
         },
         {
             "version": __version__, 
-            "steps_data": [{"step_version": 3, "step_type": "snowflake_import", "params": {"table_loc_and_warehouse": {"warehouse": "COMPUTE_WH", "database": "PYTESTDATABASE", "schema": "INFORMATION_SCHEMA", "table_or_view": "APPLICABLE_ROLES", "role": None}, "query_params": {"columns": ["GRANTEE", "ROLE_NAME", "ROLE_OWNER", "IS_GRANTABLE"]}}}], "public_interface_version": 3, "args": [], "code_options": {"as_function": False, "function_name": "function_rgge", "function_params": {}}
+            "steps_data": [{"step_version": 3, "step_type": "snowflake_import", "params": {"table_loc_and_warehouse": {"warehouse": "COMPUTE_WH", "database": "PYTESTDATABASE", "schema": "INFORMATION_SCHEMA", "table_or_view": "APPLICABLE_ROLES", "role": None}, "query_params": {"columns": ["GRANTEE", "ROLE_NAME", "ROLE_OWNER", "IS_GRANTABLE"]}}}], "public_interface_version": 3, "args": [], "code_options": {"as_function": False, "call_function": True, "function_name": "function_rgge", "function_params": {}}
         }
     )
 ]
@@ -644,6 +667,7 @@ def test_doesnt_upgrade_updated_format():
         "args": [],
         "code_options": {
             'as_function': False,
+            "call_function": True,
             'function_name': 'function_ysis',
             'function_params': {}
         }

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -525,6 +525,7 @@ def test_transpiled_with_export_to_xlsx_conditional_format(column_ids, filters, 
     filename = 'test_format_conditional.xlsx'
     numpy_import = f"\nimport numpy as np" if number_formatting else ''
     mito.export_to_file('excel', [0], filename)
+    print("\n".join(mito.transpiled_code[:-2]))
     assert "\n".join(mito.transpiled_code[:-2] if number_formatting else mito.transpiled_code) == f"""from mitosheet.public.v3 import *
 import pandas as pd{numpy_import}
 

--- a/mitosheet/mitosheet/tests/test_mito_backend.py
+++ b/mitosheet/mitosheet/tests/test_mito_backend.py
@@ -6,6 +6,7 @@
 import json
 import os
 import pandas as pd
+from mitosheet.transpiler.transpile_utils import get_default_code_options
 import pytest
 import numpy as np
 
@@ -167,3 +168,9 @@ def test_create_mito_backend_with_string_names_set_df_names():
     mito = create_mito_wrapper('test_file.csv')
     assert mito.mito_backend.steps_manager.curr_step.final_defined_state.df_names == ['test_file']
     os.remove('test_file.csv')
+
+def test_create_backend_with_code_options_works():
+    code_options = get_default_code_options('tmp')
+    code_options['call_function'] = False
+    mito_backend = MitoBackend(code_options=code_options)
+    assert mito_backend.steps_manager.code_options == code_options

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -311,7 +311,7 @@ def test_transpile_as_function_no_params(tmp_path):
 
     mito = create_mito_wrapper()
     mito.simple_import([tmp_file])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     print(mito.transpiled_code)
 
@@ -327,10 +327,31 @@ def test_transpile_as_function_no_params(tmp_path):
         "txt = function()"
     ]
 
+def test_transpile_as_function_no_call(tmp_path):
+    tmp_file = str(tmp_path / 'txt.csv')
+    df1 = pd.DataFrame({'A': [1], 'B': [2]})
+    df1.to_csv(tmp_file, index=False)
+
+    mito = create_mito_wrapper()
+    mito.simple_import([tmp_file])
+    mito.code_options_update_no_check_transpiled({'as_function': True, 'call_function': False, 'function_name': 'function', 'function_params': {}})
+
+
+    assert mito.transpiled_code == [
+        'from mitosheet.public.v3 import *',
+        "import pandas as pd",
+        "",
+        "def function():",
+        f"{TAB}txt = pd.read_csv(r'{tmp_file}')",
+        f'{TAB}',
+        f"{TAB}return txt",
+        ""
+    ]
+
 def test_transpile_as_function_df_params():
     mito = create_mito_wrapper(pd.DataFrame({'A': [1]}), arg_names=['df1'])
     mito.add_column(0, 'B')
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     print(mito.transpiled_code)
     assert mito.transpiled_code == [
@@ -350,7 +371,7 @@ def test_transpile_as_function_string_params():
     df1.to_csv(tmp_file, index=False)
 
     mito = create_mito_wrapper(str(tmp_file), arg_names=[f"'{tmp_file}'"])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -373,7 +394,7 @@ def test_transpile_as_function_string_params_no_args_update():
     df1.to_csv(tmp_file, index=False)
 
     mito = create_mito_wrapper(str(tmp_file))
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -396,7 +417,7 @@ def test_transpile_as_function_both_params():
     df1.to_csv(tmp_file, index=False)
 
     mito = create_mito_wrapper(df1, str(tmp_file), arg_names=['df1', f"'{tmp_file}'"])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -418,7 +439,7 @@ def test_transpile_pivot_table_indents():
     df1 = pd.DataFrame(data={'Name': ['Nate', 'Nate'], 'Height': [4, 5]})
     mito = create_mito_wrapper(df1, arg_names=['df1'])
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     mito.pivot_sheet(
         0, 
@@ -438,7 +459,7 @@ def test_transpile_as_function_single_param(tmp_path):
 
     mito = create_mito_wrapper()
     mito.simple_import([tmp_file])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -462,7 +483,7 @@ def test_transpile_as_function_both_params_and_additional():
 
     mito = create_mito_wrapper(df1, str(tmp_file), arg_names=['df1', f"'{tmp_file}'"])
     mito.simple_import([tmp_file])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -491,7 +512,7 @@ def test_transpile_as_function_single_param_multiple_times(tmp_path):
     mito = create_mito_wrapper()
     mito.simple_import([tmp_file])
     mito.simple_import([tmp_file])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -518,7 +539,7 @@ def test_transpile_as_function_multiple_params(tmp_path):
     mito = create_mito_wrapper()
     mito.simple_import([tmp_file1])
     mito.simple_import([tmp_file2])
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'var_name1': f"r'{tmp_file1}'", 'var_name2': f"r'{tmp_file2}'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'var_name1': f"r'{tmp_file1}'", 'var_name2': f"r'{tmp_file2}'"}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -546,7 +567,7 @@ def test_transpile_parameterize_excel_imports(tmp_path):
     mito = create_mito_wrapper()
     mito.excel_import(tmp_file, sheet_names=['Sheet1'], has_headers=True, skiprows=0)
     mito.excel_range_import(tmp_file, {'type': 'sheet name', 'value': 'Sheet1'}, [{'type': 'range', 'df_name': 'dataframe_1', 'value': 'A1:B2'}], convert_csv_to_xlsx=False)
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
 
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -574,7 +595,7 @@ def test_transpile_with_function_params_over_mitosheet():
     mito.add_column(0, 'C')
     mito.add_column(1, 'C')
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'param': "df"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'param': "df"}})
 
     
     assert mito.transpiled_code == [
@@ -606,7 +627,7 @@ line in it", '\t', '     ']})
         """
     )
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
@@ -636,7 +657,7 @@ print(df)
         """
     )
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 
@@ -659,7 +680,7 @@ def test_transpiled_with_export_to_csv_singular():
 
     assert [('df', 'df_name', 'Dataframe'), ("r'te" + '"' + "st.csv'", 'file_name', 'CSV export file path')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'path': "r'te" + '"' + "st.csv'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'path': "r'te" + '"' + "st.csv'"}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 
@@ -679,7 +700,7 @@ def test_transpiled_with_export_to_csv_multiple():
 
     assert [('df1', 'df_name', 'Dataframe'), ('df2', 'df_name', 'Dataframe'), ("r'test_0.csv'", 'file_name', 'CSV export file path'), ("r'test_1.csv'", 'file_name', 'CSV export file path')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test_0.csv'", 'path_1': "r'test_1.csv'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test_0.csv'", 'path_1': "r'test_1.csv'"}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 
@@ -701,7 +722,7 @@ def test_transpiled_with_export_to_xlsx_single():
 
     assert [('df', 'df_name', 'Dataframe'), ('r"te' + "'" + 'st.xlsx"', 'file_name', 'Excel export file path')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'path': 'r"te' + "'" + 'st.xlsx"'}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'path': 'r"te' + "'" + 'st.xlsx"'}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
@@ -723,7 +744,7 @@ def test_transpiled_with_export_to_xlsx_multiple():
 
     assert [('df1', 'df_name', 'Dataframe'), ('df2', 'df_name', 'Dataframe'), ("r'test.xlsx'", 'file_name', 'Excel export file path')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
-    mito.code_options_update({'as_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test.xlsx'"}})
+    mito.code_options_update({'as_function': True, 'call_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test.xlsx'"}})
 
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -1216,6 +1216,20 @@ class MitoWidgetTestWrapper:
                 },
             }
         )
+    
+    # Some code options allow you to turn off the actually calling of a function, and
+    # in this case, we don't want to check the transpiled code, as it will always fail
+    def code_options_update_no_check_transpiled(self, code_options: CodeOptions) -> bool:
+        return self.mito_backend.receive_message(
+            {
+                'event': 'update_event',
+                'id': get_new_id(),
+                'type': 'code_options_update',
+                'params': {
+                    'code_options': code_options
+                },
+            }
+        )
 
     @check_transpiled_code_after_call
     def checkout_step_by_idx(self, index: int) -> bool:

--- a/mitosheet/mitosheet/transpiler/transpile.py
+++ b/mitosheet/mitosheet/transpiler/transpile.py
@@ -98,7 +98,8 @@ def transpile(
             final_imports_code,
             code,
             steps_manager.code_options['function_name'],
-            steps_manager.code_options['function_params']
+            steps_manager.code_options['function_params'],
+            steps_manager.code_options['call_function']
         )
         return final_code
 

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -212,7 +212,14 @@ def replace_newlines_with_newline_and_tab(text: str) -> str:
     result = re.sub(pattern, replacement, text)
     return result
 
-def convert_script_to_function(steps_manager: StepsManagerType, imports: List[str], code: List[str], function_name: str, function_params: Dict[ParamName, ParamValue]) -> List[str]:
+def convert_script_to_function(
+        steps_manager: StepsManagerType, 
+        imports: List[str], 
+        code: List[str], 
+        function_name: str, 
+        function_params: Dict[ParamName, ParamValue],
+        call_function: bool
+    ) -> List[str]:
     """
     Given a list of code lines, puts it inside of a function.
     """
@@ -264,6 +271,10 @@ def convert_script_to_function(steps_manager: StepsManagerType, imports: List[st
     if len(function_params) > 0:
         final_code.append("")
 
+    # If we are not calling the function, we just return the code without the call at the end
+    if not call_function:
+        return final_code
+
     final_params_to_call_function_with_string = ", ".join(final_params_to_call_function_with)
 
     if len(return_variables_string) > 0:
@@ -278,6 +289,7 @@ def convert_script_to_function(steps_manager: StepsManagerType, imports: List[st
 def get_default_code_options(analysis_name: str) -> CodeOptions:
     return {
         'as_function': False,
+        'call_function': True,
         'function_name': 'function_' + analysis_name[-4:], # Give it a random name, just so we don't overwrite them
         'function_params': dict()
     }

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -328,6 +328,7 @@ if sys.version_info[:3] > (3, 8, 0):
 
     class CodeOptions(TypedDict):
         as_function: bool
+        call_function: bool
         function_name: str
         function_params: Dict[ParamName, ParamValue]
 

--- a/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsTaskpane.tsx
@@ -83,6 +83,23 @@ const CodeOptionsTaskpane = (props: CodeOptionsTaskpaneProps): JSX.Element => {
                         ></Input>
                     </Col>
                 </Row>
+                <Row justify='space-between' align='center'>
+                    <Col>
+                        <LabelAndTooltip tooltip="You can optionally configure the code to not call your generated function. Toggling this to false in a Jupyter notebook may break later cells.">
+                            Call Function
+                        </LabelAndTooltip>
+                    </Col>
+                    <Col>
+                        <Toggle 
+                            value={props.analysisData.codeOptions.call_function} 
+                            onChange={function (): void {
+                                const newCodeOptions = {...codeOptions};
+                                newCodeOptions.call_function = !newCodeOptions.call_function;
+                                setCodeOptions(newCodeOptions);
+                            }}
+                        />
+                    </Col>
+                </Row>
                 <CodeOptionsParameters
                     mitoAPI={props.mitoAPI}
                     codeOptions={codeOptions}

--- a/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsTaskpane.tsx
@@ -92,6 +92,7 @@ const CodeOptionsTaskpane = (props: CodeOptionsTaskpaneProps): JSX.Element => {
                     <Col>
                         <Toggle 
                             value={props.analysisData.codeOptions.call_function} 
+                            disabled={!codeOptions.as_function}
                             onChange={function (): void {
                                 const newCodeOptions = {...codeOptions};
                                 newCodeOptions.call_function = !newCodeOptions.call_function;

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -80,6 +80,7 @@ export type ParameterizableParams = [ParamValue, ParamType, ParamDescription][];
 
 export type CodeOptions = {
     as_function: boolean,
+    call_function: boolean,
     function_name: string
     function_params: Record<ParamName, ParamValue>
 }


### PR DESCRIPTION
# Description

Ian into this when creating the recon app. If you are Mito Enterprise, and you want the function to transpile as code - you can configure through the Code > Code Options taskpane. 

However, in Streamlit, you often want this script to _not_ call the code it generates. This is pretty reasonable, I think -- so I added a configuration option for it. 

In the future, we should make the code options configurable through the `spreadsheet` interface - you should be able to by default turn on the function generation.

# Testing

Use this feature, make sure it's not calling the function it generates.

# Documentation

We should add to docs