### PR TITLE
Add toggle to export formatting for excel

### DIFF
--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -20,7 +20,8 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
     sheet_indexes = params['sheet_indexes']
 
     # Formatting is a Mito pro feature, but we also allow it for testing
-    allow_formatting = is_pro() or is_running_test()
+    export_formatting = params.get('export_formatting', False)
+    allow_formatting = (is_pro() and export_formatting) or is_running_test()
 
     # We write to a buffer so that we don't have to save the file
     # to the file system for no reason

--- a/mitosheet/mitosheet/api/get_dataframe_as_excel.py
+++ b/mitosheet/mitosheet/api/get_dataframe_as_excel.py
@@ -21,7 +21,7 @@ def get_dataframe_as_excel(params: Dict[str, Any], steps_manager: StepsManagerTy
 
     # Formatting is a Mito pro feature, but we also allow it for testing
     export_formatting = params.get('export_formatting', False)
-    allow_formatting = (is_pro() and export_formatting) or is_running_test()
+    allow_formatting = (is_pro() or is_running_test()) and export_formatting
 
     # We write to a buffer so that we don't have to save the file
     # to the file system for no reason

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -56,11 +56,12 @@ def get_format_code(state: State, sheet_indexes: Dict[int, str]) -> list:
 
 class ExportToFileCodeChunk(CodeChunk):
 
-    def __init__(self, prev_state: State, post_state: State, export_type: str, file_name: str, sheet_index_to_export_location: Dict[int, str]):
+    def __init__(self, prev_state: State, post_state: State, export_type: str, file_name: str, sheet_index_to_export_location: Dict[int, str], export_formatting: bool=False):
         super().__init__(prev_state, post_state)
         self.export_type = export_type
         self.file_name = file_name
         self.sheet_index_to_export_location = sheet_index_to_export_location
+        self.export_formatting = export_formatting
 
     def get_display_name(self) -> str:
         return 'Export To File'
@@ -75,10 +76,11 @@ class ExportToFileCodeChunk(CodeChunk):
                 for sheet_index, export_location in self.sheet_index_to_export_location.items()
             ], []
         elif self.export_type == 'excel':
+            format_code = get_format_code(self.post_state, self.sheet_index_to_export_location) if self.export_formatting else []
             return [f"with pd.ExcelWriter(r{column_header_to_transpiled_code(self.file_name)}, engine=\"openpyxl\") as writer:"] + [
                 f'{TAB}{self.post_state.df_names[sheet_index]}.to_excel(writer, sheet_name="{export_location}", index={False})'
                 for sheet_index, export_location in self.sheet_index_to_export_location.items()
-            ] + get_format_code(self.post_state, self.sheet_index_to_export_location), ['import pandas as pd']
+            ] + format_code, ['import pandas as pd']
         else:
             raise ValueError(f'Not a valid file type: {self.export_type}')
         

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/__init__.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/__init__.py
@@ -40,6 +40,7 @@ a user's saved analysis!
 6.  Write a test for the upgrade function you just wrote. See mitosheet/tests/test_upgrade.py --
     where you can add an entry to the UPGRADE_TESTS. (The "version" field isn't too important, 
     you can use whatever other tests are using)
+7.  Update the version in test_step_format.py in the tests directory to use the new version. 
 
 When adding a test, you can generate a new saved analysis by running the old version of mitosheet,
 and using the old version of the step you are upgrading. Then, open ~/.mito/saved_analyses and find 

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/__init__.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/__init__.py
@@ -38,7 +38,8 @@ a user's saved analysis!
 5.  In the upgrade.py file, edit the STEP_UPGRADES_FUNCTION_MAPPING_NEW_FORMAT dictionary
     to include the new upgrade function you just wrote.
 6.  Write a test for the upgrade function you just wrote. See mitosheet/tests/test_upgrade.py --
-    where you can add an entry to the UPGRADE_TESTS. 
+    where you can add an entry to the UPGRADE_TESTS. (The "version" field isn't too important, 
+    you can use whatever other tests are using)
 
 When adding a test, you can generate a new saved analysis by running the old version of mitosheet,
 and using the old version of the step you are upgrading. Then, open ~/.mito/saved_analyses and find 

--- a/mitosheet/mitosheet/saved_analyses/upgrade.py
+++ b/mitosheet/mitosheet/saved_analyses/upgrade.py
@@ -56,6 +56,8 @@ from mitosheet.transpiler.transpile_utils import get_default_code_options
 from mitosheet.types import CodeOptions
 from mitosheet.utils import is_prev_version
 
+from mitosheet.step_performers.export_to_file import upgrade_export_to_file_1_to_2
+
 """
 STEP_UPGRADES_FUNCTION_MAPPING mapping contains a mapping of all steps that need to be upgraded. A step
 x at version y needs to be upgraded if STEP_UPGRADES[x][y] is defined, and in fact 
@@ -152,6 +154,9 @@ STEP_UPGRADES_FUNCTION_MAPPING_NEW_FORMAT = {
     'snowflake_import': {
         1: upgrade_snowflake_import_1_to_2,
         2: upgrade_snowflake_import_2_to_3
+    },
+    'export_to_file': {
+        1: upgrade_export_to_file_1_to_2
     }
 }
 

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -71,6 +71,7 @@ class ExportToFileStepPerformer(StepPerformer):
         _type: str = get_param(params, 'type')
         sheet_indexes: List[int] = get_param(params, 'sheet_indexes')
         _file_name: str = get_param(params, 'file_name')
+        _export_formatting: bool = get_param(params, 'export_formatting')
 
         file_name = get_final_file_name(_file_name, _type) # Ensure that the file name has the correct extension
         
@@ -85,7 +86,7 @@ class ExportToFileStepPerformer(StepPerformer):
                 post_state.dfs[sheet_index].to_csv(file_name, index=False)
         elif _type == 'excel':
             # Formatting is a Mito pro feature, but we also allow it for testing
-            allow_formatting = is_pro() or is_running_test()
+            allow_formatting = (is_pro() or is_running_test()) and _export_formatting
             sheet_index_to_export_location = get_export_to_excel_sheet_index_to_sheet_name(post_state, file_name, sheet_indexes)
             write_to_excel(file_name, sheet_indexes, post_state, allow_formatting=allow_formatting)
         else:

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -61,7 +61,7 @@ def upgrade_export_to_file_1_to_2(step: Dict[str, Any], later_steps: List[Dict[s
     params['export_formatting'] = False
     return [{
         "step_version": 2, 
-        "step_type": "change_column_dtype", 
+        "step_type": "export_to_file", 
         "params": params
     }] + later_steps
 

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -53,6 +53,18 @@ def get_final_file_name(file_name: str, _type: str) -> str:
     return file_name
 
 
+def upgrade_export_to_file_1_to_2(step: Dict[str, Any], later_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    '''
+    Adds a new param for exporting the formatting to excel which defaults to false. 
+    '''
+    params = step['params']
+    params['export_formatting'] = False
+    return [{
+        "step_version": 2, 
+        "step_type": "change_column_dtype", 
+        "params": params
+    }] + later_steps
+
 class ExportToFileStepPerformer(StepPerformer):
     """
     Allows you to export to file.
@@ -60,7 +72,7 @@ class ExportToFileStepPerformer(StepPerformer):
 
     @classmethod
     def step_version(cls) -> int:
-        return 1
+        return 2
 
     @classmethod
     def step_type(cls) -> str:

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -114,6 +114,7 @@ class ExportToFileStepPerformer(StepPerformer):
                 get_param(params, 'type'),
                 get_param(execution_data if execution_data is not None else {}, 'file_name'),
                 get_param(execution_data if execution_data is not None else {}, 'sheet_index_to_export_location'),
+                get_param(params, 'export_formatting')
             )
         ]
 

--- a/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
+++ b/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
@@ -567,6 +567,24 @@ UPGRADE_TESTS = [
             }
         }
     ),
+    # Upgrades the export to file step performer
+    (
+        {
+            "version": "0.2.4", 
+            "steps_data": [{"step_version": 1, "step_type": "export_to_file", "params": {"type": "excel", "file_name": "Sample.xlsx", "sheet_indexes": [0]}}]
+        },
+        {
+            "version": __version__, 
+            "steps_data": [{"step_version": 2, "step_type": "export_to_file", "params": {"type": "excel", "file_name": "Sample.xlsx", "sheet_indexes": [0], "export_formatting": False}}],
+            "args": [],
+            "public_interface_version": 1,
+            "code_options": {
+                'as_function': False,
+                'function_name': 'function_ysis',
+                'function_params': {}
+            }
+        }
+    ),
     # Upgrades the Excel range import
     (
         {

--- a/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
+++ b/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
@@ -601,6 +601,7 @@ UPGRADE_TESTS = [
             "public_interface_version": 1,
             "code_options": {
                 'as_function': False,
+                'call_function': True,
                 'function_name': 'function_ysis',
                 'function_params': {}
             }

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -298,7 +298,7 @@ def test_transpiled_with_export_to_xlsx_format():
     mito = create_mito_wrapper(df, arg_names=['df'])
     mito.set_dataframe_format(0, DF_FORMAT_HEADER)
     filename = 'test_format.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -322,7 +322,7 @@ def test_transpiled_with_export_to_xlsx_format_rows_no_header():
     mito = create_mito_wrapper(df, arg_names=['df'])
     mito.set_dataframe_format(0, DF_FORMAT_ROWS)
     filename = 'test_format_rows_no_header.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -578,7 +578,7 @@ def test_transpiled_with_export_to_xlsx_conditional_format(column_ids, filters, 
     })
     filename = 'test_format_conditional.xlsx'
     numpy_import = f"\nimport numpy as np" if number_formatting else ''
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code[:-2] if number_formatting else mito.transpiled_code) == f"""from mitosheet.public.v3 import *
 import pandas as pd{numpy_import}
 
@@ -624,7 +624,7 @@ def test_transpiled_with_export_to_xlsx_conditional_and_rows(column_ids, filters
         ]
     })
     filename = 'test_format_conditional_and_rows.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     numpy_import = f"\nimport numpy as np" if number_formatting else ''
     assert "\n".join(mito.transpiled_code[:-2]) == f"""from mitosheet.public.v3 import *
 import pandas as pd{numpy_import}
@@ -653,7 +653,7 @@ def test_transpiled_with_export_to_xlsx_format_two_sheets():
     mito.set_dataframe_format(0, DF_FORMAT_HEADER)
     mito.set_dataframe_format(1, DF_FORMAT_HEADER_AND_ROWS)
     filename = 'test_format_two.xlsx'
-    mito.export_to_file('excel', [1], filename)
+    mito.export_to_file('excel', [1], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -687,7 +687,7 @@ def test_transpiled_with_export_two_sheets_to_xlsx_format_one():
     mito = create_mito_wrapper(df_1, df_2, arg_names=['df_1', 'df_2'])
     mito.set_dataframe_format(0, DF_FORMAT_HEADER_AND_ROWS)
     filename = 'test_two_format_one.xlsx'
-    mito.export_to_file('excel', [0, 1], filename)
+    mito.export_to_file('excel', [0, 1], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -724,7 +724,7 @@ def test_transpiled_number_formatting(number_format, expected_column, expected_s
         "conditional_formats": []
     })
     filename = 'test_number_formatting.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code[:-2]) == f"""from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -752,7 +752,7 @@ def test_transpiled_number_formatting_multiple_columns():
         "conditional_formats": []
     })
     filename = 'test_number_formatting_columns.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code[:-2]) == f"""from mitosheet.public.v3 import *
 import pandas as pd
 
@@ -787,7 +787,7 @@ def test_transpiled_number_formatting_and_conditional_formatting(number_format, 
         ]
     })
     filename = 'test_number_formatting_conditional.xlsx'
-    mito.export_to_file('excel', [0], filename)
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
     assert "\n".join(mito.transpiled_code[:-2]) == f"""from mitosheet.public.v3 import *
 import pandas as pd
 import numpy as np
@@ -802,4 +802,37 @@ with pd.ExcelWriter(r\'test_number_formatting_conditional.xlsx\', engine="openpy
             "{expected_column}": '{expected_string}'
         }}
     )
+"""
+
+def test_formatting_off():
+    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4.12, 5.123, 6.1234]})
+    mito = create_mito_wrapper(df, arg_names=['df'])
+    mito.set_dataframe_format(0, {
+        'headers': {},
+        "columns": {
+            "A": {
+                "type": CURRENCY,
+                "precision": 3
+            }
+        },
+        "rows": {},
+        "border": {},
+        "conditional_formats": [
+            {
+                'format_uuid': '_hkyc4pcux',
+                'columnIDs': ['B'],
+                'filters': [{'condition': 'greater', 'value': 5}],
+                'color': '#e72323',
+                'backgroundColor': '#0c5200'
+            }
+        ]
+    })
+    filename = 'test_formatting_off.xlsx'
+    mito.export_to_file('excel', [0], filename, export_formatting=False)
+    assert "\n".join(mito.transpiled_code[:-2]) == f"""from mitosheet.public.v3 import *
+import pandas as pd
+import numpy as np
+
+with pd.ExcelWriter(r\'test_formatting_off.xlsx\', engine="openpyxl") as writer:
+    df.to_excel(writer, sheet_name="df", index=False)
 """

--- a/mitosheet/mitosheet/tests/test_step_format.py
+++ b/mitosheet/mitosheet/tests/test_step_format.py
@@ -293,7 +293,7 @@ def test_params_static():
 
     check_step(
         ExportToFileStepPerformer,
-        1,
+        2,
         'export_to_file'
     )
 

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -595,7 +595,8 @@ class MitoWidgetTestWrapper:
                 'params': {
                     'type': type,
                     'sheet_indexes': sheet_indexes,
-                    'file_name': file_name
+                    'file_name': file_name,
+                    'export_formatting': True
                 }
             }
         )

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -584,6 +584,7 @@ class MitoWidgetTestWrapper:
             type: str,
             sheet_indexes: List[int],
             file_name: str,
+            export_formatting: bool=False
         ) -> bool:
 
         return self.mito_backend.receive_message(
@@ -596,7 +597,7 @@ class MitoWidgetTestWrapper:
                     'type': type,
                     'sheet_indexes': sheet_indexes,
                     'file_name': file_name,
-                    'export_formatting': True
+                    'export_formatting': export_formatting
                 }
             }
         )

--- a/mitosheet/src/mito/api/api.tsx
+++ b/mitosheet/src/mito/api/api.tsx
@@ -258,12 +258,13 @@ export class MitoAPI {
         must be decoded from base64, and then turned into bytes
         before it can be downloaded
     */
-    async getDataframesAsExcel(sheetIndexes: number[]): Promise<MitoAPIResult<string>> {
+    async getDataframesAsExcel(sheetIndexes: number[], exportFormatting?: boolean): Promise<MitoAPIResult<string>> {
         return await this.send<string>({
             'event': 'api_call',
             'type': 'get_dataframe_as_excel',
             'params': {
-                'sheet_indexes': sheetIndexes
+                'sheet_indexes': sheetIndexes,
+                'export_formatting': exportFormatting
             },
         });
     }

--- a/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
@@ -208,7 +208,7 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
                             <Row justify='space-between' align='center'>
                                 <Col style={{ display: 'flex' }}>
                                     <p className="text-header-3">Export with formatting</p>&nbsp;
-                                    <ProIcon/>
+                                    {!props.userProfile.isPro && <ProIcon/>}
                                 </Col>
                                 <Col>
                                     <Toggle

--- a/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
@@ -23,6 +23,7 @@ import DefaultTaskpaneFooter from '../DefaultTaskpane/DefaultTaskpaneFooter';
 import { getInvalidFileNameError } from '../../../utils/filename';
 import Col from '../../layout/Col';
 import Toggle from '../../elements/Toggle';
+import ProIcon from '../../icons/ProIcon';
 
 interface DownloadTaskpaneProps {
     uiState: UIState
@@ -64,7 +65,7 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
     // The string that stores the file that actually should be downloaded
     const [exportHRef, setExportHref] = useState<string>('');
     
-    const [exportFormatting, setExportFormatting] = useState<boolean>(true);
+    const [exportFormatting, setExportFormatting] = useState<boolean>(props.userProfile.isPro);
     
     const emptySheet = props.sheetDataArray.length === 0;
     const numRows = props.sheetDataArray[props.selectedSheetIndex]?.numRows;
@@ -205,16 +206,19 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
                     { props.uiState.exportConfiguration.exportType === 'excel' && 
                         <div>
                             <Row justify='space-between' align='center'>
-                                <Col>
-                                    <p className="text-header-3">Export with formatting</p>
+                                <Col style={{ display: 'flex' }}>
+                                    <p className="text-header-3">Export with formatting</p>&nbsp;
+                                    {!props.userProfile.isPro && <ProIcon/>}
                                 </Col>
                                 <Col>
+                                    {props.userProfile.isPro ? 
                                     <Toggle
                                         value={exportFormatting}
                                         onChange={() => {
                                             setExportFormatting(!exportFormatting)
                                         }}
-                                    />
+                                    /> :
+                                    <p>Upgrade to Pro</p>}
                                 </Col>
                             </Row>
                             <ExcelDownloadConfigSection 

--- a/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
@@ -208,17 +208,16 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
                             <Row justify='space-between' align='center'>
                                 <Col style={{ display: 'flex' }}>
                                     <p className="text-header-3">Export with formatting</p>&nbsp;
-                                    {!props.userProfile.isPro && <ProIcon/>}
+                                    <ProIcon/>
                                 </Col>
                                 <Col>
-                                    {props.userProfile.isPro ? 
                                     <Toggle
                                         value={exportFormatting}
+                                        disabled={!props.userProfile.isPro}
                                         onChange={() => {
                                             setExportFormatting(!exportFormatting)
                                         }}
-                                    /> :
-                                    <p>Upgrade to Pro</p>}
+                                    />
                                 </Col>
                             </Row>
                             <ExcelDownloadConfigSection 

--- a/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Download/DownloadTaskpane.tsx
@@ -21,6 +21,8 @@ import DefaultTaskpaneBody from '../DefaultTaskpane/DefaultTaskpaneBody';
 import DefaultEmptyTaskpane from '../DefaultTaskpane/DefaultEmptyTaskpane';
 import DefaultTaskpaneFooter from '../DefaultTaskpane/DefaultTaskpaneFooter';
 import { getInvalidFileNameError } from '../../../utils/filename';
+import Col from '../../layout/Col';
+import Toggle from '../../elements/Toggle';
 
 interface DownloadTaskpaneProps {
     uiState: UIState
@@ -62,6 +64,8 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
     // The string that stores the file that actually should be downloaded
     const [exportHRef, setExportHref] = useState<string>('');
     
+    const [exportFormatting, setExportFormatting] = useState<boolean>(true);
+    
     const emptySheet = props.sheetDataArray.length === 0;
     const numRows = props.sheetDataArray[props.selectedSheetIndex]?.numRows;
     
@@ -79,7 +83,7 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
                 { type: 'text/csv' }
             )));
         } else if (props.uiState.exportConfiguration.exportType === 'excel') {
-            const response = await props.mitoAPI.getDataframesAsExcel((props.uiState.exportConfiguration as ExcelExportState).sheetIndexes);
+            const response = await props.mitoAPI.getDataframesAsExcel((props.uiState.exportConfiguration as ExcelExportState).sheetIndexes, exportFormatting);
             const excelString = 'error' in response ? '' : response.result;
             setExportHref(URL.createObjectURL(new Blob(
                 /* 
@@ -96,7 +100,7 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
     useDebouncedEffect(() => {
         setExportHref('');
         void loadExport();
-    }, [props.uiState.exportConfiguration, props.selectedSheetIndex, props.sheetDataArray], 500)
+    }, [props.uiState.exportConfiguration, props.selectedSheetIndex, props.sheetDataArray, exportFormatting], 500)
 
     const onDownload = () => {
         if (invalidFileNameWarning) {
@@ -199,16 +203,31 @@ const DownloadTaskpane = (props: DownloadTaskpaneProps): JSX.Element => {
                         </Select>
                     </Row>
                     { props.uiState.exportConfiguration.exportType === 'excel' && 
-                        <ExcelDownloadConfigSection 
-                            dfNames={props.dfNames}
-                            mitoAPI={props.mitoAPI}
-                            userProfile={props.userProfile}
-                            sheetDataArray={props.sheetDataArray}
-                            exportState={props.uiState.exportConfiguration as ExcelExportState}
-                            setUIState={props.setUIState}
-                            newlyFormattedColumns={newlyFormattedColumns}
-                            setNewlyFormattedColumns={setNewlyFormattedColumns}
-                        />  
+                        <div>
+                            <Row justify='space-between' align='center'>
+                                <Col>
+                                    <p className="text-header-3">Export with formatting</p>
+                                </Col>
+                                <Col>
+                                    <Toggle
+                                        value={exportFormatting}
+                                        onChange={() => {
+                                            setExportFormatting(!exportFormatting)
+                                        }}
+                                    />
+                                </Col>
+                            </Row>
+                            <ExcelDownloadConfigSection 
+                                dfNames={props.dfNames}
+                                mitoAPI={props.mitoAPI}
+                                userProfile={props.userProfile}
+                                sheetDataArray={props.sheetDataArray}
+                                exportState={props.uiState.exportConfiguration as ExcelExportState}
+                                setUIState={props.setUIState}
+                                newlyFormattedColumns={newlyFormattedColumns}
+                                setNewlyFormattedColumns={setNewlyFormattedColumns}
+                            /> 
+                        </div> 
                     }
                     {props.uiState.exportConfiguration.exportType === 'csv' && 
                         <CSVDownloadConfigSection 

--- a/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
@@ -142,7 +142,7 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                 <Row justify='space-between' align='center'>
                     <Col style={{ display: 'flex' }}>
                         <p className="text-header-3">Export with formatting</p>&nbsp;
-                        <ProIcon/>
+                        {!props.userProfile.isPro && <ProIcon/>}
                     </Col>
                     <Col>
                         <Toggle

--- a/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
@@ -142,12 +142,12 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                 <Row justify='space-between' align='center'>
                     <Col style={{ display: 'flex' }}>
                         <p className="text-header-3">Export with formatting</p>&nbsp;
-                        {!props.userProfile.isPro && <ProIcon/>}
+                        <ProIcon/>
                     </Col>
-                    {props.userProfile.isPro ? 
                     <Col>
                         <Toggle
                             value={params.export_formatting ?? true}
+                            disabled={!props.userProfile.isPro}
                             onChange={() => {
                                 setParams(prevParams => {
                                     return {
@@ -157,11 +157,7 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                                 })
                             }}
                         />
-                    </Col> :
-                    <Col>
-                        <p> Upgrade to Pro </p>
                     </Col>
-                    }
                 </Row>}
                 <Row>
                     <Col>

--- a/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
@@ -17,6 +17,7 @@ import TextButton from "../../elements/TextButton";
 import DefaultTaskpaneFooter from "../DefaultTaskpane/DefaultTaskpaneFooter";
 import { getInvalidFileNameError } from "../../../utils/filename";
 import Toggle from "../../elements/Toggle";
+import ProIcon from "../../icons/ProIcon";
 
 
 interface ExportToFileTaskpaneProps {
@@ -37,6 +38,7 @@ interface ExportToFileParams {
 const getDefaultParams = (
     sheetDataArray: SheetData[], 
     sheetIndex: number,
+    isPro?: boolean,
 ): ExportToFileParams | undefined => {
 
     if (sheetDataArray.length === 0 || sheetDataArray[sheetIndex] === undefined) {
@@ -49,7 +51,7 @@ const getDefaultParams = (
         type: "csv",
         sheet_indexes: [sheetIndex],
         file_name: `${sheetName}_export`,
-        export_formatting: true,
+        export_formatting: isPro ?? false,
     }
 }
 
@@ -59,7 +61,7 @@ const getDefaultParams = (
 const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => {
 
     const {params, setParams, edit, editApplied, loading} = useSendEditOnClick<ExportToFileParams, undefined>(
-        () => getDefaultParams(props.sheetDataArray, props.selectedSheetIndex),
+        () => getDefaultParams(props.sheetDataArray, props.selectedSheetIndex, props.userProfile.isPro),
         StepType.ExportToFile, 
         props.mitoAPI,
         props.analysisData,
@@ -138,9 +140,11 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                 </Row>
                 {params.type === 'excel' &&
                 <Row justify='space-between' align='center'>
-                    <Col>
-                        <p className="text-header-3">Export with formatting</p>
+                    <Col style={{ display: 'flex' }}>
+                        <p className="text-header-3">Export with formatting</p>&nbsp;
+                        {!props.userProfile.isPro && <ProIcon/>}
                     </Col>
+                    {props.userProfile.isPro ? 
                     <Col>
                         <Toggle
                             value={params.export_formatting ?? true}
@@ -153,7 +157,11 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                                 })
                             }}
                         />
+                    </Col> :
+                    <Col>
+                        <p> Upgrade to Pro </p>
                     </Col>
+                    }
                 </Row>}
                 <Row>
                     <Col>

--- a/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/ExportToFile/ExportToFileTaskpane.tsx
@@ -16,6 +16,7 @@ import DefaultTaskpaneHeader from "../DefaultTaskpane/DefaultTaskpaneHeader";
 import TextButton from "../../elements/TextButton";
 import DefaultTaskpaneFooter from "../DefaultTaskpane/DefaultTaskpaneFooter";
 import { getInvalidFileNameError } from "../../../utils/filename";
+import Toggle from "../../elements/Toggle";
 
 
 interface ExportToFileTaskpaneProps {
@@ -31,6 +32,7 @@ interface ExportToFileParams {
     type: 'csv' | 'excel',
     sheet_indexes: number[],
     file_name: string,
+    export_formatting: boolean,
 }
 const getDefaultParams = (
     sheetDataArray: SheetData[], 
@@ -46,7 +48,8 @@ const getDefaultParams = (
     return {
         type: "csv",
         sheet_indexes: [sheetIndex],
-        file_name: `${sheetName}_export`
+        file_name: `${sheetName}_export`,
+        export_formatting: true,
     }
 }
 
@@ -133,6 +136,25 @@ const ExportToFileTaskpane = (props: ExportToFileTaskpaneProps): JSX.Element => 
                         </Select>
                     </Col>
                 </Row>
+                {params.type === 'excel' &&
+                <Row justify='space-between' align='center'>
+                    <Col>
+                        <p className="text-header-3">Export with formatting</p>
+                    </Col>
+                    <Col>
+                        <Toggle
+                            value={params.export_formatting ?? true}
+                            onChange={() => {
+                                setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        export_formatting: !prevParams.export_formatting
+                                    }
+                                })
+                            }}
+                        />
+                    </Col>
+                </Row>}
                 <Row>
                     <Col>
                         <p className="text-header-3">Dataframes to Export</p>


### PR DESCRIPTION
Adds a toggle to the download taskpane when the file type is excel:
![image](https://github.com/mito-ds/mito/assets/6673460/0657c26e-4bc0-483e-8477-222b84549ffa)
![image](https://github.com/mito-ds/mito/assets/6673460/b2bac401-6c40-49e5-9845-273b4353155b)

(Maybe should be changed) CTA for non-pro users:
![image](https://github.com/mito-ds/mito/assets/6673460/266faad1-faa0-4771-8934-f9e8c6086fe8)


Todo:
- [x] Add toggle to export as code taskpane
- [x] Add CTA for non-pro users
- [ ] Add tooltip to explain that performance is slower when formatting is on
  - I tried adding a tooltip but the component we have is a little question mark icon and it looked a little weird next to the pro icon so I left it out. I can add that in if you think it's a good idea though!

Questions:
- How do we handle when CSV is the file type? (Right now it just only appears as a field to the user when excel is the file type)
  - Keep as is
- What should the CTA be for non-pro users? Right now I have a really plain text that says "Upgrade to Pro" - not saying that should be the design but I'm not sure what should be 
  - Solution: disabling the toggle