### PR TITLE
Fix format code chunk bug for long dataframe names

### DIFF
--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -21,8 +21,7 @@ from mitosheet.utils import (
 def get_format_code(state: State, sheet_indexes: Dict[int, str]) -> list:
     code = []
     formats = state.df_formats
-    for sheet_index in sheet_indexes.keys():
-        sheet_name = state.df_names[sheet_index]
+    for sheet_index, export_location in sheet_indexes.items():
         format = formats[sheet_index]
         # We need to convert the column IDs to column letters
         # for conditional formats to export to excel
@@ -50,7 +49,7 @@ def get_format_code(state: State, sheet_indexes: Dict[int, str]) -> list:
             continue
 
         params_code = param_dict_to_code(param_dict, tab_level=1)
-        code.append(f'{TAB}add_formatting_to_excel_sheet(writer, "{sheet_name}", {state.df_names[sheet_index]}, {params_code})')
+        code.append(f'{TAB}add_formatting_to_excel_sheet(writer, "{export_location}", {state.df_names[sheet_index]}, {params_code})')
     return code
 
 

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -18,10 +18,10 @@ from mitosheet.utils import (
 )
 
 # This is a helper function that generates the code for formatting the excel sheet
-def get_format_code(state: State, sheet_indexes: Dict[int, str]) -> list:
+def get_format_code(state: State, sheet_index_to_export_location: Dict[int, str]) -> list:
     code = []
     formats = state.df_formats
-    for sheet_index, export_location in sheet_indexes.items():
+    for sheet_index, export_location in sheet_index_to_export_location.items():
         format = formats[sheet_index]
         # We need to convert the column IDs to column letters
         # for conditional formats to export to excel

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -316,6 +316,30 @@ df_styler = df.style\\
 """
 
 
+# This tests when the user exports a dataframe with formatting.
+def test_transpiled_with_export_to_xlsx_format_long_df_name():
+    df = pd.DataFrame({'A': [1, 2, 3]})
+    mito = create_mito_wrapper(df, arg_names=['very_very_long_df_name_that_needs_to_be_truncated'])
+    mito.set_dataframe_format(0, DF_FORMAT_HEADER)
+    filename = 'test_format_long_name.xlsx'
+    mito.export_to_file('excel', [0], filename, export_formatting=True)
+    assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
+import pandas as pd
+
+with pd.ExcelWriter(r\'test_format_long_name.xlsx\', engine="openpyxl") as writer:
+    very_very_long_df_name_that_needs_to_be_truncated.to_excel(writer, sheet_name="very_very_long_df_name_that_nee", index=False)
+    add_formatting_to_excel_sheet(writer, "very_very_long_df_name_that_nee", very_very_long_df_name_that_needs_to_be_truncated, 
+        header_background_color='#000000', 
+        header_font_color='#ffffff'
+    )
+
+very_very_long_df_name_that_needs_to_be_truncated_styler = very_very_long_df_name_that_needs_to_be_truncated.style\\
+    .set_table_styles([
+        {'selector': 'thead', 'props': [('color', '#ffffff'), ('background-color', '#000000')]},
+])
+"""
+
+
 # This tests when the user exports a dataframe with row formatting without header formatting.
 def test_transpiled_with_export_to_xlsx_format_rows_no_header():
     df = pd.DataFrame({'A': [1, 2, 3]})


### PR DESCRIPTION
Fixes a bug when dataframe names are long where the generated code for calling `to_excel` uses a different name for the dataframe from the call to `add_formatting_to_excel` and throws an error when run. This switches to using the same value between those two calls