### PR TITLE
mitosheet: make code options public for streamlit

### DIFF
--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -135,6 +135,7 @@ try:
             importers: Optional[List[Callable]]=None, 
             df_names: Optional[List[str]]=None,
             import_folder: Optional[str]=None,
+            code_options: Optional[CodeOptions]=None,
             key=None
         ) -> Tuple[OrderedDict[str, pd.DataFrame], str]:
         """
@@ -182,6 +183,7 @@ try:
             *args, 
             _sheet_functions=sheet_functions,
             _importers=importers, 
+            _code_options=code_options,
             import_folder=import_folder,
             session_id=session_id,
             df_names=df_names, 


### PR DESCRIPTION
# Description

Exposes code options for streamlit. After having to write a bunch of code to simulate our function generation in Streamlit dashboards a few times -- I want to just use what we already have written!

# Testing

Use it!

# Documentation

No.