### PR TITLE
mitosheet: make transpile as function not include params

### DIFF
--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -475,6 +475,26 @@ def test_transpile_as_function_single_param(tmp_path):
         f"txt = function(var_name)"
     ]
 
+def test_transpile_as_function_single_param_no_call(tmp_path):
+    tmp_file = str(tmp_path / 'txt.csv')
+    df1 = pd.DataFrame({'A': [1], 'B': [2]})
+    df1.to_csv(tmp_file, index=False)
+
+    mito = create_mito_wrapper()
+    mito.simple_import([tmp_file])
+    mito.code_options_update_no_check_transpiled({'as_function': True, 'call_function': False, 'function_name': 'function', 'function_params': {'var_name': f"r'{tmp_file}'"}})
+
+    assert mito.transpiled_code == [
+        'from mitosheet.public.v3 import *',
+        "import pandas as pd",
+        "",
+        "def function(var_name):",
+        f"{TAB}txt = pd.read_csv(var_name)",
+        f'{TAB}',
+        f"{TAB}return txt",
+        "",
+    ]
+
 
 def test_transpile_as_function_both_params_and_additional():
     tmp_file = 'txt.csv'

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -253,6 +253,10 @@ def convert_script_to_function(
     final_code.append(f"{TAB}return {return_variables_string}")
     final_code.append("")
 
+    # If we are not calling the function, we just return the code without the call at the end
+    if not call_function:
+        return final_code
+
     # Build the params and variables taking special care to ensure that dataframes and file paths 
     # that are passed as parameters to the function. 
     final_params_to_call_function_with = []
@@ -266,10 +270,6 @@ def convert_script_to_function(
 
     if len(function_params) > 0:
         final_code.append("")
-
-    # If we are not calling the function, we just return the code without the call at the end
-    if not call_function:
-        return final_code
 
     final_params_to_call_function_with_string = ", ".join(final_params_to_call_function_with)
 


### PR DESCRIPTION
# Description

We were including param definitions even if we didn't use them. 

# Testing

See test.

# Documentation

No.