### PR TITLE
Add a 'Conditional Formats' option to the column dropdowns

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -736,6 +736,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     setUIState={setUIState}
                     mitoAPI={mitoAPI}
                     selectedSheetIndex={uiState.selectedSheetIndex}
+                    startingColumnIDs={uiState.currOpenTaskpane.startingColumnIDs}
                 />
             )
             case TaskpaneType.DATAFRAMEIMPORT: return (

--- a/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
@@ -133,6 +133,20 @@ export default function ColumnHeaderDropdown(props: {
                 disabled={!isNumberDtype(props.columnDtype)}
                 tooltip={!isNumberDtype(props.columnDtype) ? "Only number columns can be formatted currently" : undefined}
             />
+            <DropdownItem 
+                title='Conditional Format'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        const columnIndexesSelected = getColumnIndexesInSelections(props.gridState.selections);
+                        const columnIDsToFormat = columnIndexesSelected.map(colIdx => props.sheetData?.data[colIdx]?.columnID || '').filter(columnID => columnID !== '')
+
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {type: TaskpaneType.CONDITIONALFORMATTING, startingColumnIDs: columnIDsToFormat},
+                        }
+                    })
+                }}
+            />
             <DropdownSectionSeperator isDropdownSectionSeperator/>
             <DropdownItem 
                 title='Set Column Formula'

--- a/mitosheet/src/mito/components/taskpanes/taskpanes.tsx
+++ b/mitosheet/src/mito/components/taskpanes/taskpanes.tsx
@@ -93,7 +93,10 @@ export type TaskpaneInfo =
     | {type: TaskpaneType.SPLIT_TEXT_TO_COLUMNS, startingColumnID: ColumnID | undefined}
     | {type: TaskpaneType.MELT}
     | {type: TaskpaneType.SET_DATAFRAME_FORMAT}
-    | {type: TaskpaneType.CONDITIONALFORMATTING}
+    | {
+        type: TaskpaneType.CONDITIONALFORMATTING,
+        startingColumnIDs?: string[]
+      }
     | {type: TaskpaneType.DATAFRAMEIMPORT}
     | {
         type: TaskpaneType.UPDATEIMPORTS,

--- a/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
+++ b/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
@@ -29,7 +29,7 @@ import { useEffectOnUpdateEvent } from "./useEffectOnUpdateEvent";
     backend is different than what is useful on the frontend.
 */
 function useLiveUpdatingParams<FrontendParamType, BackendParamType>(
-    // Params to represent what should be shown when we open the taskpane
+    // Params to represent what should be shown when we open the taskpane and are by default send to the backend
     defaultParams: FrontendParamType | undefined | (() => FrontendParamType | undefined),
     stepType: string,
     mitoAPI: MitoAPI,

--- a/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
+++ b/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
@@ -35,6 +35,7 @@ function useLiveUpdatingParams<FrontendParamType, BackendParamType>(
     mitoAPI: MitoAPI,
     analysisData: AnalysisData,
     debounceDelay: number,
+    // Functions to update params when passed between frontend and backend. 
     frontendToBackendConverters?: {
         getBackendFromFrontend: (params: FrontendParamType, sheetDataArray?: SheetData[]) => BackendParamType,
         getFrontendFromBackend: (params: BackendParamType, sheetDataArray?: SheetData[]) => FrontendParamType,

--- a/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
+++ b/mitosheet/src/mito/hooks/useLiveUpdatingParams.tsx
@@ -18,7 +18,7 @@ import { useEffectOnUpdateEvent } from "./useEffectOnUpdateEvent";
     4. Return errors if errors are returned that are not meant to be displayed
        in the error modal are returned.
 
-    See ConcatTaskpane for how this is used. In generally, it allows us to
+    See ConcatTaskpane for how this is used. In general, it allows us to
     take the custom UI code we have to write down to _just_ the code to display
     the parameters to the user and allow them to edit them. This is really
     sweet, and we'll continue to migrate to this hook over time. Woo!
@@ -29,6 +29,7 @@ import { useEffectOnUpdateEvent } from "./useEffectOnUpdateEvent";
     backend is different than what is useful on the frontend.
 */
 function useLiveUpdatingParams<FrontendParamType, BackendParamType>(
+    // Params to represent what should be shown when we open the taskpane
     defaultParams: FrontendParamType | undefined | (() => FrontendParamType | undefined),
     stepType: string,
     mitoAPI: MitoAPI,

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingCard.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingCard.tsx
@@ -145,7 +145,11 @@ const ConditionalFormattingCard = (props: ConditionalFormattingProps): JSX.Eleme
             {invalidColumnIDMessage}
             <Filter
                 filter={props.conditionalFormat.filters[0]}
-                columnDtype={undefined}
+                columnDtype={
+                    props.conditionalFormat.columnIDs.length > 0
+                    ? props.sheetData.columnDtypeMap[props.conditionalFormat.columnIDs[0]]
+                    : undefined
+                }
                 operator={"And"}
                 displayOperator={false}
                 setFilter={(newFilter) => {

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingCard.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingCard.tsx
@@ -145,11 +145,7 @@ const ConditionalFormattingCard = (props: ConditionalFormattingProps): JSX.Eleme
             {invalidColumnIDMessage}
             <Filter
                 filter={props.conditionalFormat.filters[0]}
-                columnDtype={
-                    props.conditionalFormat.columnIDs.length > 0
-                    ? props.sheetData.columnDtypeMap[props.conditionalFormat.columnIDs[0]]
-                    : undefined
-                }
+                columnDtype={undefined}
                 operator={"And"}
                 displayOperator={false}
                 setFilter={(newFilter) => {

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
@@ -93,12 +93,21 @@ const ConditionalFormattingTaskpane = (props: ConditionalFormattingTaskpaneProps
                         newFilter.value = newValue;
                         return newFilter;
                     });
+                    
                     return {
                         ...newConditionalFormat,
                         filters: newFilters
                     };
                 })
-
+                if (props.startingColumnIDs !== undefined) {
+                    conditionalFormats.push({
+                        format_uuid: getRandomId(),
+                        columnIDs: props.startingColumnIDs,
+                        filters: [{condition: 'not_empty', value: ''}], // Always default to one filter for now
+                        color: undefined,
+                        backgroundColor: undefined
+                    });
+                }
                 return {
                     ...params,
                     df_format: {
@@ -123,20 +132,6 @@ const ConditionalFormattingTaskpane = (props: ConditionalFormattingTaskpaneProps
     const [openFormattingCardIndex, setOpenFormattingCardIndex] = useState(
         props.startingColumnIDs ? conditionalFormats.length - 1 : conditionalFormats.length > 0 ? 0 : -1
     )
-
-    useEffect(() => {
-        if (props.startingColumnIDs !== undefined) {
-            const newConditionalFormats = [...params.df_format.conditional_formats];
-            newConditionalFormats.push({
-                format_uuid: getRandomId(),
-                columnIDs: props.startingColumnIDs,
-                filters: [{condition: 'not_empty', value: ''}], // Always default to one filter for now
-                color: undefined,
-                backgroundColor: undefined
-            });
-        }
-    }, [props.startingColumnIDs])
-
 
     const updateDataframeFormatParams = (newParams: RecursivePartial<DataframeFormat>): void => {
         setParams(prevParams => {

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
@@ -99,15 +99,6 @@ const ConditionalFormattingTaskpane = (props: ConditionalFormattingTaskpaneProps
                         filters: newFilters
                     };
                 })
-                if (props.startingColumnIDs !== undefined) {
-                    conditionalFormats.push({
-                        format_uuid: getRandomId(),
-                        columnIDs: props.startingColumnIDs,
-                        filters: [{condition: 'not_empty', value: ''}], // Always default to one filter for now
-                        color: undefined,
-                        backgroundColor: undefined
-                    });
-                }
                 return {
                     ...params,
                     df_format: {

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
@@ -51,14 +51,14 @@ const getDefaultParams = (
         return undefined;
     }
 
-    const new_format = sheetDataArray[sheetIndex].dfFormat || getDefaultDataframeFormat();
+    const newFormat = sheetDataArray[sheetIndex].dfFormat || getDefaultDataframeFormat();
     if (startingColumnIDs !== undefined) {
-        new_format.conditional_formats.push(getDefaultEmptyConditionalFormat(startingColumnIDs));
+        newFormat.conditional_formats.push(getDefaultEmptyConditionalFormat(startingColumnIDs));
     }
 
     return {
         sheet_index: sheetIndex,
-        df_format: new_format,
+        df_format: newFormat,
     }
 }
 

--- a/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
+++ b/mitosheet/src/mito/pro/taskpanes/ConditionalFormatting/ConditionalFormattingTaskpane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import useLiveUpdatingParams from '../../../hooks/useLiveUpdatingParams';
 import { MitoAPI,  getRandomId } from "../../../api/api";
 import { AnalysisData, ConditionalFormat, DataframeFormat, RecursivePartial, SheetData, StepType, UIState, UserProfile } from "../../../types";


### PR DESCRIPTION
Adds an option to the context menu for adding a conditional format to the selected columns: 
<img width="375" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/6354c934-7028-4981-a594-8cb1bf83c8fe">

And when the user clicks on that option, it opens the conditional formats panel with a new conditional format that has the selected column(s) pre-selected:
<img width="512" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/e4f1af64-e242-478f-a6d8-ecf9bffd4fda">

**Note**: Also changes the behavior of the conditional formats panel to by default open the first conditional format when the conditional format taskpane is opened, unless you're opening the taskpane from the context menu. 