### PR TITLE
Prevent export when 'export as code' is selected

### DIFF
--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -97,10 +97,7 @@ class ExportToFileStepPerformer(StepPerformer):
             for sheet_index, file_name in sheet_index_to_export_location.items():
                 post_state.dfs[sheet_index].to_csv(file_name, index=False)
         elif _type == 'excel':
-            # Formatting is a Mito pro feature, but we also allow it for testing
-            allow_formatting = (is_pro() or is_running_test()) and _export_formatting
             sheet_index_to_export_location = get_export_to_excel_sheet_index_to_sheet_name(post_state, file_name, sheet_indexes)
-            write_to_excel(file_name, sheet_indexes, post_state, allow_formatting=allow_formatting)
         else:
             raise ValueError(f"Invalid file type: {_type}")
 

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -93,8 +93,6 @@ class ExportToFileStepPerformer(StepPerformer):
 
         if _type == 'csv':
             sheet_index_to_export_location = get_export_to_csv_sheet_index_to_file_name(file_name, sheet_indexes)
-            for sheet_index, file_name in sheet_index_to_export_location.items():
-                post_state.dfs[sheet_index].to_csv(file_name, index=False)
         elif _type == 'excel':
             sheet_index_to_export_location = get_export_to_excel_sheet_index_to_sheet_name(post_state, file_name, sheet_indexes)
         else:

--- a/mitosheet/mitosheet/step_performers/export_to_file.py
+++ b/mitosheet/mitosheet/step_performers/export_to_file.py
@@ -83,7 +83,6 @@ class ExportToFileStepPerformer(StepPerformer):
         _type: str = get_param(params, 'type')
         sheet_indexes: List[int] = get_param(params, 'sheet_indexes')
         _file_name: str = get_param(params, 'file_name')
-        _export_formatting: bool = get_param(params, 'export_formatting')
 
         file_name = get_final_file_name(_file_name, _type) # Ensure that the file name has the correct extension
         

--- a/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_export_to_file.py
@@ -189,10 +189,13 @@ def test_export_to_file_csv(tmp_path, input_dfs, type, sheet_indexes, file_name,
     mito = create_mito_wrapper(*input_dfs)
 
     mito.export_to_file(type, sheet_indexes, file_name)
+    assert not os.path.exists(file_name)
 
-    for sheet_index, final_file_name_part in zip(sheet_indexes, final_file_names):
-        final_file_name = str(tmp_path / final_file_name_part)
-        assert pd.read_csv(final_file_name).equals(input_dfs[sheet_index])
+    df_definitions = ''
+    for sheet_index in sheet_indexes:
+        df_definitions += f"df{sheet_index+1} = {get_dataframe_generation_code(mito.dfs[sheet_index])}\n"
+
+    exec(df_definitions + "\n".join(mito.transpiled_code))
 
     # Remove the files, run generated code, and check that things are still equal
     files = glob.glob(str(tmp_path / '*'))
@@ -263,6 +266,7 @@ def test_export_to_file_excel(tmp_path, input_dfs, type, sheet_indexes, file_nam
         df_definitions += f"df{sheet_index+1} = {get_dataframe_generation_code(mito.dfs[sheet_index])}\n"
 
     mito.export_to_file(type, sheet_indexes, file_name)
+    assert not os.path.exists(file_name)
     exec(df_definitions + "\n".join(mito.transpiled_code))
 
     final_file_name = str(tmp_path / final_file_name)


### PR DESCRIPTION
Currently when the user selects "Download File when Executing Code", the code downloads when the user generates the code. This is not the expected behavior for the user, so I just removed it. 