### PR TITLE
mitosheet: fix tests for python 3.11

### DIFF
--- a/mitosheet/mitosheet/tests/step_performers/test_sort_step.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_sort_step.py
@@ -106,9 +106,9 @@ SORT_TWICE_TESTS = [
         pd.DataFrame(data={'A': [6, 5, 4, 3, 2, 1]}, index=[5, 4, 3, 2, 1, 0]),
     ),
     (
-        pd.DataFrame(data={'A': [6, 5, 3, 4, 5, 10]}),
-        pd.DataFrame(data={'A': [3, 4, 5, 5, 6, 10]}, index=[2, 3, 1, 4, 0, 5]),
-        pd.DataFrame(data={'A': [10, 6, 5, 5, 4, 3]}, index=[5, 0, 1, 4, 3, 2]),
+        pd.DataFrame(data={'A': [6, 5, 3, 4, 5.5, 10]}),
+        pd.DataFrame(data={'A': [3, 4, 5, 5.5, 6, 10]}, index=[2, 3, 1, 4, 0, 5]),
+        pd.DataFrame(data={'A': [10, 6, 5.5, 5, 4, 3]}, index=[5, 0, 4, 1, 3, 2]),
     ),
     (
         pd.DataFrame(data={'A': [6, -5, 3, -4, 5, 10]}),


### PR DESCRIPTION
# Description

Fix tests for python 3.11

In the release of Python 3.11, sorting perf improvements caused tuple ordering to be ill-defined. In Python 3.11 the two 5's in these dataframes were sorted in different orders than in Python 3.8. 

<img width="800" alt="Screenshot 2023-08-22 at 1 26 49 PM" src="https://github.com/mito-ds/mito/assets/18709905/8cb53cb2-dda1-4d72-8ba5-76da0da176f0">

# Testing

See tests

# Documentation

No. 