### PR TITLE
mitosheet: fix bug in unique in left/right calcs due to index issues

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
@@ -86,25 +86,15 @@ class MergeCodeChunk(CodeChunk):
 
         # Finially append the merge
         if self.how == UNIQUE_IN_LEFT:
-            merge_code.append(
-                f'{df_two_to_merge}_tmp = {df_two_to_merge}.drop_duplicates(subset={column_header_list_to_transpiled_code(merge_keys_two)})'
-            )
-            merge_code.append(
-                f'bool_index_array = {df_one_to_merge}.merge({df_two_to_merge}_tmp, left_on={column_header_list_to_transpiled_code(merge_keys_one)}, right_on={column_header_list_to_transpiled_code(merge_keys_two)}, how=\'left\', indicator=True)[\'_merge\'] == \'left_only\''
-            )
-            merge_code.append(
-                f'{self.df_new_name} = {df_one_to_merge}.copy(deep=True)[bool_index_array][{column_header_list_to_transpiled_code(selected_column_headers_one)}].reset_index(drop=True)'
-            )
+            merge_code.extend([
+                f'{self.df_new_name} = {df_one_to_merge}.merge({df_two_to_merge}[{column_header_list_to_transpiled_code(merge_keys_two)}], left_on={column_header_list_to_transpiled_code(merge_keys_one)}, right_on={column_header_list_to_transpiled_code(merge_keys_two)}, how="left", indicator=True)',
+                f'{self.df_new_name} = {self.df_new_name}[{self.df_new_name}["_merge"] == "left_only"].drop(columns="_merge")[{df_one_to_merge}.columns].reset_index(drop=True)',
+            ])
         elif self.how == UNIQUE_IN_RIGHT:
-            merge_code.append(
-                f'{df_one_to_merge}_tmp = {df_one_to_merge}.drop_duplicates(subset={column_header_list_to_transpiled_code(merge_keys_one)})'
-            )
-            merge_code.append(
-                f'bool_index_array = {df_one_to_merge}_tmp.merge({df_two_to_merge}, left_on={column_header_list_to_transpiled_code(merge_keys_one)}, right_on={column_header_list_to_transpiled_code(merge_keys_two)}, how=\'right\', indicator=True)[\'_merge\'] == \'right_only\''
-            )
-            merge_code.append(
-                f'{self.df_new_name} = {df_two_to_merge}.copy(deep=True)[bool_index_array][{column_header_list_to_transpiled_code(selected_column_headers_two)}].reset_index(drop=True)'
-            )
+            merge_code.extend([
+                f'{self.df_new_name} = {df_two_to_merge}.merge({df_one_to_merge}[{column_header_list_to_transpiled_code(merge_keys_one)}], left_on={column_header_list_to_transpiled_code(merge_keys_two)}, right_on={column_header_list_to_transpiled_code(merge_keys_one)}, how="left", indicator=True)',
+                f'{self.df_new_name} = {self.df_new_name}[{self.df_new_name}["_merge"] == "left_only"].drop(columns="_merge")[{df_two_to_merge}.columns].reset_index(drop=True)',
+            ])
         else:      
             merge_code.append(
                 f'{self.df_new_name} = {df_one_to_merge}.merge({df_two_to_merge}, left_on={column_header_list_to_transpiled_code(merge_keys_one)}, right_on={column_header_list_to_transpiled_code(merge_keys_two)}, how=\'{how_to_use}\', suffixes=[\'_{suffix_one}\', \'_{suffix_two}\'])'

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -200,55 +200,79 @@ MERGE_UNIQUE_TESTS = [
     ),
     (
         [
-            pd.DataFrame({'A': [1], 'B': [None]}),
+            pd.DataFrame({'A': [1], 'B': [np.nan]}),
             pd.DataFrame({'A': [1], 'C': [3]})
         ],
         'unique in left', 0, 1, [['A', 'A'], ['B', 'C']], ['A', 'B'], ['A', 'C'],
         [
-            pd.DataFrame({'A': [1], 'B': [None]}),
+            pd.DataFrame({'A': [1], 'B': [np.nan]}),
             pd.DataFrame({'A': [1], 'C': [3]}),
-            pd.DataFrame({'A': [1], 'B': [None]})
+            pd.DataFrame({'A': [1], 'B': [np.nan]})
         ],
     ),
     (
         [
             pd.DataFrame({'A': [1], 'B': [2]}),
-            pd.DataFrame({'A': [1], 'C': [None]})
+            pd.DataFrame({'A': [1], 'C': [np.nan]})
         ],
         'unique in right', 0, 1, [['A', 'A'], ['B', 'C']], ['A', 'B'], ['A', 'C'],
         [
             pd.DataFrame({'A': [1], 'B': [2]}),
-            pd.DataFrame({'A': [1], 'C': [None]}),
-            pd.DataFrame({'A': [1], 'C': [None]})
+            pd.DataFrame({'A': [1], 'C': [np.nan]}),
+            pd.DataFrame({'A': [1], 'C': [np.nan]})
         ],
     ),
     (
         [
-            pd.DataFrame({'A': [None,2,3], 'B': [4,5,6]}),
+            pd.DataFrame({'A': [np.nan,2,3], 'B': [4,5,6]}),
             pd.DataFrame({'C': [1,1,2], 'D': [5,4,3]})
         ],
         'unique in left', 0, 1, [['A', 'C'], ['B', 'D']], ['A', 'B'], ['C', 'D'],
         [
-            pd.DataFrame({'A': [None,2,3], 'B': [4,5,6]}),
+            pd.DataFrame({'A': [np.nan,2,3], 'B': [4,5,6]}),
             pd.DataFrame({'C': [1,1,2], 'D': [5,4,3]}),
-            pd.DataFrame({'A': [2,3], 'B': [5,6]}),
+            pd.DataFrame({'A': [np.nan, 2,3], 'B': [4,5,6]}),
         ],
     ),
     (
         [
             pd.DataFrame({'A': [1,2,3], 'B': [4,5,6]}),
-            pd.DataFrame({'C': [1,None,2], 'D': [5,4,3]})
+            pd.DataFrame({'C': [1,np.nan,2], 'D': [5,4,3]})
         ],
         'unique in right', 0, 1, [['A', 'C'], ['B', 'D']], ['A', 'B'], ['C', 'D'],
         [
             pd.DataFrame({'A': [1,2,3], 'B': [4,5,6]}),
-            pd.DataFrame({'C': [1,None,2], 'D': [5,4,3]}),
-            pd.DataFrame({'C': [None,2], 'D': [5,3]}),
+            pd.DataFrame({'C': [1,np.nan,2], 'D': [5,4,3]}),
+            pd.DataFrame({'C': [1,np.nan,2], 'D': [5,4,3]}),
+        ],
+    ),
+    (
+        [
+            pd.DataFrame({'A': [4]}, index=[2]),
+            pd.DataFrame({'A': [1, 2, 3]}),
+        ],
+        'unique in left', 0, 1, [['A', 'A']], ['A'], ['A'],
+        [
+            pd.DataFrame({'A': [4]}, index=[2]),
+            pd.DataFrame({'A': [1, 2, 3]}),
+            pd.DataFrame({'A': [4]}),
+        ],
+    ),
+    (
+        [
+            pd.DataFrame({'A': [1, 2, 3]}),
+            pd.DataFrame({'A': [4]}, index=[2]),
+        ],
+        'unique in right', 0, 1, [['A', 'A']], ['A'], ['A'],
+        [
+            pd.DataFrame({'A': [1, 2, 3]}),
+            pd.DataFrame({'A': [4]}, index=[2]),
+            pd.DataFrame({'A': [4]}),
         ],
     ),
 ]
 @pandas_post_1_only
-@pytest.mark.parametrize("input_dfs, how, sheet_index_one, sheet_index_two, merge_key_columns, selected_columns_one, selected_columns_two, output_dfs", MERGE_TESTS)
+@pytest.mark.parametrize("input_dfs, how, sheet_index_one, sheet_index_two, merge_key_columns, selected_columns_one, selected_columns_two, output_dfs", MERGE_UNIQUE_TESTS)
 def test_merge_unique(input_dfs, how, sheet_index_one, sheet_index_two, merge_key_columns, selected_columns_one, selected_columns_two, output_dfs):
     mito = create_mito_wrapper(*input_dfs)
 
@@ -258,6 +282,8 @@ def test_merge_unique(input_dfs, how, sheet_index_one, sheet_index_two, merge_ke
 
     assert len(mito.dfs) == len(output_dfs)
     for actual, expected in zip(mito.dfs, output_dfs):
+        print(actual)
+        print(expected)
         assert actual.equals(expected)
 
 

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -282,8 +282,6 @@ def test_merge_unique(input_dfs, how, sheet_index_one, sheet_index_two, merge_ke
 
     assert len(mito.dfs) == len(output_dfs)
     for actual, expected in zip(mito.dfs, output_dfs):
-        print(actual)
-        print(expected)
         assert actual.equals(expected)
 
 


### PR DESCRIPTION
# Description

This fixes a long-standing bug where dataframes would fail to merge. I finally replicated it -- it's when the new dataframe doesn't have the same index as the old dataframe.

We calculate these differently now -- but it works good!


# Testing

See new tests. **Also, this makes the unique in left and unique in right tests work properly -- they were never running before. Doh!.**

# Documentation

No.