### PR TITLE
Fix escape from cell editor bug

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1001,6 +1001,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
             ref={mitoContainerRef} 
             tabIndex={0}
             onKeyDown={(e) => {
+                // If the user presses escape anywhere in the mitosheet, we close the editor
                 if (e.key === 'Escape') {
                     setEditorState(undefined)
                 }

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1000,6 +1000,11 @@ export const Mito = (props: MitoProps): JSX.Element => {
             data-jp-suppress-context-menu 
             ref={mitoContainerRef} 
             tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                    setEditorState(undefined)
+                }
+            }}
         >
             <ErrorBoundary mitoAPI={mitoAPI} analyisData={analysisData} userProfile={userProfile} sheetDataArray={sheetDataArray}>
                 <Toolbar 


### PR DESCRIPTION
# Description
This fixes a small bug where when the focus moves out of the cell editor, using "escape" to close the cell editor stops working. 

# Testing
1. Open the cell editor
2. Click anywhere outside of the editor
3. Press "escape" 
4. The cell editor should close
