### PR TITLE
Add support for cross-sheet formulas on the frontend

### DIFF
--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -678,7 +678,6 @@ def get_parser_matches(
             }
         
         return None
-    
 
     def get_header_index_header_index_match(formula: str, raw_parser_matches: List[RawParserMatch], match_index: int) -> Optional[ParserMatch]:
 
@@ -756,6 +755,15 @@ def get_parser_matches(
             match_index += 1
             continue
         
+        # If the user is trying to reference a sheet without it being {SHEET}{HEADER}{HEADER},
+        # then we try to point them to using the correct syntax. 
+        if raw_parser_matches[match_index]['type'] == '{SHEET}':
+            raise make_invalid_formula_error(
+                formula,
+                f'Cross-sheet references are only allowed for ranges of columns.',
+                error_modal=False
+            )
+            
         # If you've gotten here, then something has gone wrong
         raise make_invalid_formula_error(
             formula,

--- a/mitosheet/mitosheet/tests/test_parse.py
+++ b/mitosheet/mitosheet/tests/test_parse.py
@@ -1352,6 +1352,7 @@ def test_parse_invalid_cross_sheet_formulas(formula, column_header, formula_labe
     with pytest.raises(MitoError) as e_info:
         parse_formula(formula, column_header, formula_label, {'type': FORMULA_ENTIRE_COLUMN_TYPE}, dfs, df_names, sheet_index) 
     assert e_info.value.type_ == 'invalid_formula_error'
+    assert e_info.value.to_fix == 'Cross-sheet references are only allowed for ranges of columns.'
 
 PARSE_TEST_ERRORS = [
     ('=HLOOKUP(100, A)', 'B', 'invalid_formula_error', 'HLOOKUP'),

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -409,12 +409,6 @@ export const Mito = (props: MitoProps): JSX.Element => {
         if (source !== undefined && source === DFSource.Pivoted && uiState.currOpenTaskpane.type === TaskpaneType.NONE) {
             void openEditedPivot()
         }
-
-        // Close the cell editor if it is open
-        if (editorState !== undefined && !editorState.formula.includes('VLOOKUP')) {
-            setEditorState(undefined)
-        }
-
     }, [uiState.selectedSheetIndex])
 
     // Store the prev open taskpane in a ref, to avoid triggering rerenders

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -411,7 +411,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         }
 
         // Close the cell editor if it is open
-        if (editorState !== undefined) {
+        if (editorState !== undefined && !editorState.formula.includes('VLOOKUP')) {
             setEditorState(undefined)
         }
 

--- a/mitosheet/src/mito/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeader.tsx
@@ -90,7 +90,8 @@ const ColumnHeader = (props: {
             columnIndex: props.columnIndex,
             formula: getDisplayColumnHeader(finalColumnHeader),
             editorLocation: 'cell',
-            editingMode: 'specific_index_labels'
+            editingMode: 'specific_index_labels',
+            sheetIndex: props.gridState.sheetIndex,
         })
     }
 
@@ -136,6 +137,7 @@ const ColumnHeader = (props: {
                         endingRowIndex: -1,
                         startingColumnIndex: props.columnIndex,
                         endingColumnIndex: props.columnIndex,
+                        sheetIndex: props.gridState.sheetIndex,
                     })
                 }
 
@@ -230,7 +232,8 @@ const ColumnHeader = (props: {
                                         columnIndex: props.columnIndex,
                                         formula: getDisplayColumnHeader(lowerLevelColumnHeader),
                                         editorLocation: 'cell',
-                                        editingMode: 'specific_index_labels'
+                                        editingMode: 'specific_index_labels',
+                                        sheetIndex: props.gridState.sheetIndex,
                                     })
                                 }}
                             >
@@ -344,7 +347,8 @@ const ColumnHeader = (props: {
                                     columnIndex: props.columnIndex,
                                     formula: getDisplayColumnHeader(finalColumnHeader),
                                     editorLocation: 'cell',
-                                    editingMode: 'specific_index_labels'
+                                    editingMode: 'specific_index_labels',
+                                    sheetIndex: props.gridState.sheetIndex,
                                 })
                             }}
                             key={props.columnIndex}

--- a/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
@@ -159,7 +159,8 @@ export default function ColumnHeaderDropdown(props: {
                         formula: startingColumnFormula,
                         arrowKeysScrollInFormula: arrowKeysScrollInFormula,
                         editorLocation: 'cell',
-                        editingMode: editingMode
+                        editingMode: editingMode,
+                        sheetIndex: props.sheetIndex,
                     })
                 }}
                 supressFocusSettingOnClose

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -238,11 +238,17 @@ function EndoGrid(props: {
                     editorState.pendingSelections?.inputSelectionEnd,
                     selectionEnd
                 )
+
+                // If the user is holding down the shift key, we want to extend the selection
+                // rather than starting from scratch with a new selection
                 let startingColumnIndex = props.editorState?.pendingSelections?.selections[0].startingColumnIndex ?? columnIndex;
                 let endingColumnIndex = props.editorState?.pendingSelections?.selections[0].endingColumnIndex ?? columnIndex;
-                if (startingColumnIndex > columnIndex) {
+                if (e.shiftKey && startingColumnIndex > columnIndex) {
                     startingColumnIndex = columnIndex;
-                } else if (endingColumnIndex < columnIndex) {
+                } else if (e.shiftKey && endingColumnIndex < columnIndex) {
+                    endingColumnIndex = columnIndex;
+                } else if (!e.shiftKey) {
+                    startingColumnIndex = columnIndex;
                     endingColumnIndex = columnIndex;
                 }
                 const newSelection: MitoSelection[] = [{

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -244,6 +244,7 @@ function EndoGrid(props: {
                     endingRowIndex: rowIndex !== undefined ? rowIndex : -1,
                     startingColumnIndex: columnIndex,
                     endingColumnIndex: columnIndex,
+                    sheetIndex: sheetIndex,
                 }]
 
                 // Select the column that was clicked on, as they do in Excel
@@ -306,6 +307,7 @@ function EndoGrid(props: {
                             endingRowIndex: rowIndex,
                             startingColumnIndex: columnIndex,
                             endingColumnIndex: columnIndex,
+                            sheetIndex: sheetIndex,
                         })
                         return {
                             ...gridState,
@@ -333,6 +335,7 @@ function EndoGrid(props: {
                                     endingRowIndex: rowIndex,
                                     startingColumnIndex: columnIndex,
                                     endingColumnIndex: columnIndex,
+                                    sheetIndex: sheetIndex,
                                 })
                                 return {
                                     ...gridState,
@@ -349,6 +352,7 @@ function EndoGrid(props: {
                                 endingRowIndex: rowIndex,
                                 startingColumnIndex: columnIndex,
                                 endingColumnIndex: columnIndex,
+                                sheetIndex: sheetIndex,
                             })
                             setGridState((gridState) => {
                                 return {
@@ -367,6 +371,7 @@ function EndoGrid(props: {
                                         endingRowIndex: rowIndex,
                                         startingColumnIndex: columnIndex,
                                         endingColumnIndex: columnIndex,
+                                        sheetIndex: sheetIndex,
                                     }]
                                 }
                             })
@@ -395,6 +400,7 @@ function EndoGrid(props: {
                                 endingRowIndex: rowIndex,
                                 startingColumnIndex: columnIndex,
                                 endingColumnIndex: columnIndex,
+                                sheetIndex: sheetIndex,
                             }]
                         }
                     })
@@ -511,7 +517,8 @@ function EndoGrid(props: {
             formula: startingColumnFormula,
             arrowKeysScrollInFormula: arrowKeysScrollInFormula,
             editorLocation: 'cell',
-            editingMode: editingMode
+            editingMode: editingMode,
+            sheetIndex: sheetIndex,
         })
     }
     
@@ -578,7 +585,8 @@ function EndoGrid(props: {
                         formula: startingColumnFormula,
                         arrowKeysScrollInFormula: arrowKeysScrollInFormula,
                         editorLocation: 'cell',
-                        editingMode: editingMode
+                        editingMode: editingMode,
+                        sheetIndex: sheetIndex,
                     });
 
                     e.preventDefault();
@@ -589,7 +597,8 @@ function EndoGrid(props: {
                             startingRowIndex: lastSelection.startingRowIndex,
                             endingRowIndex: lastSelection.startingRowIndex,
                             startingColumnIndex: lastSelection.startingColumnIndex,
-                            endingColumnIndex: lastSelection.startingColumnIndex
+                            endingColumnIndex: lastSelection.startingColumnIndex,
+                            sheetIndex: sheetIndex,
                         }]
                     }
                 })

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -637,7 +637,7 @@ function EndoGrid(props: {
     return (
         <>
             <FormulaBar
-                sheetData={sheetData}
+                sheetDataArray={sheetDataArray}
                 selection={gridState.selections[gridState.selections.length - 1]}
                 sheetIndex={props.sheetIndex}
                 editorState={editorState}
@@ -737,7 +737,7 @@ function EndoGrid(props: {
                 </div>
                 {sheetData !== undefined && editorState !== undefined && editorState.editorLocation === 'cell' && editorState.rowIndex > -1 &&
                     <FloatingCellEditor
-                        sheetData={sheetData}
+                        sheetDataArray={sheetDataArray}
                         sheetIndex={sheetIndex}
                         gridState={gridState}
                         editorState={editorState}

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -238,12 +238,18 @@ function EndoGrid(props: {
                     editorState.pendingSelections?.inputSelectionEnd,
                     selectionEnd
                 )
-
+                let startingColumnIndex = props.editorState?.pendingSelections?.selections[0].startingColumnIndex ?? columnIndex;
+                let endingColumnIndex = props.editorState?.pendingSelections?.selections[0].endingColumnIndex ?? columnIndex;
+                if (startingColumnIndex > columnIndex) {
+                    startingColumnIndex = columnIndex;
+                } else if (endingColumnIndex < columnIndex) {
+                    endingColumnIndex = columnIndex;
+                }
                 const newSelection: MitoSelection[] = [{
                     startingRowIndex: rowIndex !== undefined ? rowIndex : -1,
                     endingRowIndex: rowIndex !== undefined ? rowIndex : -1,
-                    startingColumnIndex: columnIndex,
-                    endingColumnIndex: columnIndex,
+                    startingColumnIndex: startingColumnIndex,
+                    endingColumnIndex: endingColumnIndex,
                     sheetIndex: sheetIndex,
                 }]
 

--- a/mitosheet/src/mito/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/mito/components/endo/FormulaBar.tsx
@@ -35,7 +35,7 @@ const FormulaBar = (props: {
 
     const rowIndex = props.selection.startingRowIndex
     const colIndex = props.selection.startingColumnIndex
-    const sheetData = props.sheetDataArray[props.sheetIndex];
+    const sheetData = props.sheetDataArray[props.editorState?.sheetIndex ?? props.sheetIndex];
     const {columnHeader, columnFormula, cellValue, columnFormulaLocation} = getCellDataFromCellIndexes(sheetData, rowIndex, colIndex);
     const originalFormulaBarValue = '' + (columnFormula !== undefined && columnFormula !== '' ? columnFormula : (cellValue !== undefined ? cellValue : ''));
     const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(sheetData, props.editorState.rowIndex, props.editorState.columnIndex);

--- a/mitosheet/src/mito/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/mito/components/endo/FormulaBar.tsx
@@ -17,7 +17,7 @@ import { calculateCurrentSheetView } from './sheetViewUtils';
 import { getCellDataFromCellIndexes } from './utils';
 
 const FormulaBar = (props: {
-    sheetData: SheetData,
+    sheetDataArray: SheetData[],
     sheetIndex: number,
     gridState: GridState,
     editorState: EditorState | undefined,
@@ -35,10 +35,10 @@ const FormulaBar = (props: {
 
     const rowIndex = props.selection.startingRowIndex
     const colIndex = props.selection.startingColumnIndex
-
-    const {columnHeader, columnFormula, cellValue, columnFormulaLocation} = getCellDataFromCellIndexes(props.sheetData, rowIndex, colIndex);
+    const sheetData = props.sheetDataArray[props.sheetIndex];
+    const {columnHeader, columnFormula, cellValue, columnFormulaLocation} = getCellDataFromCellIndexes(sheetData, rowIndex, colIndex);
     const originalFormulaBarValue = '' + (columnFormula !== undefined && columnFormula !== '' ? columnFormula : (cellValue !== undefined ? cellValue : ''));
-    const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
+    const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
 
     let formulaBarValue = ''
@@ -51,7 +51,7 @@ const FormulaBar = (props: {
         }
     } else {
         // If we're editing, display the formula
-        formulaBarValue = getFullFormula(props.editorState, props.sheetData);
+        formulaBarValue = getFullFormula(props.editorState, sheetData);
     }
 
     const currentSheetView = calculateCurrentSheetView(props.gridState);
@@ -73,7 +73,7 @@ const FormulaBar = (props: {
             <Col flex='1'>
                 {props.editorState?.editorLocation === 'formula bar' &&
                     <CellEditor
-                        sheetData={props.sheetData}
+                        sheetDataArray={props.sheetDataArray}
                         sheetIndex={props.sheetIndex}
                         gridState={props.gridState}
                         editorState={props.editorState}

--- a/mitosheet/src/mito/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/mito/components/endo/FormulaBar.tsx
@@ -51,7 +51,7 @@ const FormulaBar = (props: {
         }
     } else {
         // If we're editing, display the formula
-        formulaBarValue = getFullFormula(props.editorState.formula, props.editorState.pendingSelections, props.sheetData);
+        formulaBarValue = getFullFormula(props.editorState, props.sheetData);
     }
 
     const currentSheetView = calculateCurrentSheetView(props.gridState);
@@ -99,7 +99,8 @@ const FormulaBar = (props: {
                                 formula: formulaBarValue,
                                 arrowKeysScrollInFormula: true,
                                 editorLocation: 'formula bar',
-                                editingMode: columnFormulaLocation || 'entire_column'
+                                editingMode: columnFormulaLocation || 'entire_column',
+                                sheetIndex: props.editorState?.sheetIndex ?? props.sheetIndex,
                             })
                         }}
                     >

--- a/mitosheet/src/mito/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/mito/components/endo/FormulaBar.tsx
@@ -51,7 +51,7 @@ const FormulaBar = (props: {
         }
     } else {
         // If we're editing, display the formula
-        formulaBarValue = getFullFormula(props.editorState, sheetData);
+        formulaBarValue = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex);
     }
 
     const currentSheetView = calculateCurrentSheetView(props.gridState);

--- a/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
@@ -105,7 +105,6 @@ const CellEditor = (props: {
             // If there is a pendingSelections, then we set the selection to be 
             // at the _end_ of them!
             if (props.editorState.pendingSelections !== undefined) {
-                // TODO: use the correct funciton, rather than JSON.stringify
                 const index = props.editorState.pendingSelections.inputSelectionStart + getSelectionFormulaString(props.editorState.pendingSelections.selections, sheetData, props.editorState.sheetIndex).length;
                 cellEditorInputRef.current?.setSelectionRange(
                     index, index
@@ -477,6 +476,8 @@ const CellEditor = (props: {
         // Don't refresh the page
         e.preventDefault();
 
+        // If the user is currently editing a cell but is looking at a different sheet (for cross-sheet formulas),
+        // then we want to switch to the sheet they are editing in when they're done editing the cell. 
         if (props.sheetIndex !== props.editorState.sheetIndex) {
             props.setUIState((prevUIState: UIState) => {
                 return {

--- a/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
@@ -56,8 +56,8 @@ const CellEditor = (props: {
     mitoContainerRef: React.RefObject<HTMLDivElement>,
 }): JSX.Element => {
 
-    const sheetData = props.sheetDataArray[props.sheetIndex];
-    const fullFormula = getFullFormula(props.editorState, sheetData);
+    const fullFormula = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex);
+    const sheetData = props.sheetDataArray[props.editorState.sheetIndex];
 
     const cellEditorInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
@@ -149,7 +149,8 @@ const CellEditor = (props: {
     }
 
     const displayedDropdownType = getDisplayedDropdownType(
-        sheetData,
+        props.sheetDataArray,
+        props.editorState.sheetIndex,
         props.editorState,
         cellEditorInputRef.current?.selectionStart,
         cellEditorError,
@@ -392,9 +393,7 @@ const CellEditor = (props: {
             );
 
             // Take the pendingSelections, and clear them
-            const fullFormula = getFullFormula(
-                props.editorState, sheetData
-            );
+            const fullFormula = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex);
 
             props.setEditorState({
                 ...props.editorState,
@@ -498,7 +497,7 @@ const CellEditor = (props: {
         const editorSheetData = props.sheetDataArray[props.editorState.sheetIndex];
         const columnID = editorSheetData.data[props.editorState.columnIndex].columnID;
         const columnHeader = editorSheetData.data[props.editorState.columnIndex].columnHeader;
-        const formula = getFullFormula(props.editorState, sheetData)
+        const formula = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex);
         const formulaLabel = editorSheetData.index[props.editorState.rowIndex];
 
         // Mark this as loading
@@ -617,7 +616,7 @@ const CellEditor = (props: {
                 }
             </form>
             <CellEditorDropdown
-                sheetData={sheetData}
+                sheetDataArray={props.sheetDataArray}
                 sheetIndex={props.sheetIndex}
                 editorState={props.editorState}
                 setEditorState={props.setEditorState}

--- a/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
@@ -56,7 +56,7 @@ const CellEditor = (props: {
     mitoContainerRef: React.RefObject<HTMLDivElement>,
 }): JSX.Element => {
 
-    const fullFormula = getFullFormula(props.editorState.formula, props.editorState.pendingSelections, props.sheetData);
+    const fullFormula = getFullFormula(props.editorState, props.sheetData);
 
     const cellEditorInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
@@ -105,7 +105,7 @@ const CellEditor = (props: {
             // at the _end_ of them!
             if (props.editorState.pendingSelections !== undefined) {
                 // TODO: use the correct funciton, rather than JSON.stringify
-                const index = props.editorState.pendingSelections.inputSelectionStart + getSelectionFormulaString(props.editorState.pendingSelections.selections, props.sheetData).length;
+                const index = props.editorState.pendingSelections.inputSelectionStart + getSelectionFormulaString(props.editorState.pendingSelections.selections, props.sheetData, props.editorState.sheetIndex).length;
                 cellEditorInputRef.current?.setSelectionRange(
                     index, index
                 )
@@ -154,7 +154,7 @@ const CellEditor = (props: {
         cellEditorInputRef.current?.selectionStart,
         cellEditorError,
         loading,
-        props.analysisData
+        props.analysisData,
     )
 
     // A helper function to close the cell editor, selecting the cell that was
@@ -380,6 +380,7 @@ const CellEditor = (props: {
                         endingRowIndex: props.editorState.rowIndex,
                         startingColumnIndex: props.editorState.columnIndex,
                         endingColumnIndex: props.editorState.columnIndex,
+                        sheetIndex: props.sheetIndex,
                     }]
                 }
             });
@@ -392,9 +393,7 @@ const CellEditor = (props: {
 
             // Take the pendingSelections, and clear them
             const fullFormula = getFullFormula(
-                props.editorState.formula, 
-                props.editorState.pendingSelections,
-                props.sheetData,
+                props.editorState, props.sheetData
             );
 
             props.setEditorState({
@@ -487,7 +486,7 @@ const CellEditor = (props: {
 
         const columnID = props.sheetData.data[props.editorState.columnIndex].columnID;
         const columnHeader = props.sheetData.data[props.editorState.columnIndex].columnHeader;
-        const formula = getFullFormula(props.editorState.formula, props.editorState.pendingSelections, props.sheetData)
+        const formula = getFullFormula(props.editorState, props.sheetData)
         const formulaLabel = props.sheetData.index[props.editorState.rowIndex];
 
         // Mark this as loading

--- a/mitosheet/src/mito/components/endo/celleditor/CellEditorDropdown.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditorDropdown.tsx
@@ -41,7 +41,7 @@ export const getDisplayedDropdownType = (
     analysisData: AnalysisData,
 ): DisplayedDropdownType | undefined => {
 
-    const fullFormula = getFullFormula(editorState.formula, editorState.pendingSelections, sheetData);
+    const fullFormula = getFullFormula(editorState, sheetData);
     const endsInReference = getFormulaEndsInReference(fullFormula, sheetData);
 
 
@@ -99,7 +99,7 @@ const CellEditorDropdown = (props: {
 
     const displayedDropdownType = props.displayedDropdownType;
 
-    const formula = getFullFormula(props.editorState.formula, props.editorState.pendingSelections, props.sheetData)
+    const formula = getFullFormula(props.editorState, props.sheetData)
     const cellEditorWidth = getCellEditorWidth(formula, props.editorState.editorLocation);
 
     return (

--- a/mitosheet/src/mito/components/endo/celleditor/CellEditorDropdown.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditorDropdown.tsx
@@ -33,7 +33,8 @@ type DisplayedDropdownType = {
 
 
 export const getDisplayedDropdownType = (
-    sheetData: SheetData,
+    sheetDataArray: SheetData[],
+    sheetIndex: number,
     editorState: EditorState,
     selectionStart: number | null | undefined,
     cellEditorError: string | undefined,
@@ -41,7 +42,8 @@ export const getDisplayedDropdownType = (
     analysisData: AnalysisData,
 ): DisplayedDropdownType | undefined => {
 
-    const fullFormula = getFullFormula(editorState, sheetData);
+    const fullFormula = getFullFormula(editorState, sheetDataArray, sheetIndex);
+    const sheetData = sheetDataArray[editorState.sheetIndex];
     const endsInReference = getFormulaEndsInReference(fullFormula, sheetData);
 
 
@@ -80,7 +82,7 @@ export const getDisplayedDropdownType = (
 }
 
 const CellEditorDropdown = (props: {
-    sheetData: SheetData,
+    sheetDataArray: SheetData[],
     sheetIndex: number,
     editorState: EditorState,
     setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>,
@@ -90,8 +92,8 @@ const CellEditorDropdown = (props: {
     displayedDropdownType: DisplayedDropdownType | undefined,
     takeSuggestion: (idx: number) => void,
 }): JSX.Element => {
-
-    const {columnID, columnHeader, indexLabel} = getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
+    const sheetData = props.sheetDataArray[props.sheetIndex];
+    const {columnID, columnHeader, indexLabel} = getCellDataFromCellIndexes(sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
 
     if (columnID === undefined || columnHeader === undefined || indexLabel === undefined) {
         return <></>;
@@ -99,7 +101,7 @@ const CellEditorDropdown = (props: {
 
     const displayedDropdownType = props.displayedDropdownType;
 
-    const formula = getFullFormula(props.editorState, props.sheetData)
+    const formula = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex)
     const cellEditorWidth = getCellEditorWidth(formula, props.editorState.editorLocation);
 
     return (

--- a/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
@@ -45,7 +45,7 @@ const FloatingCellEditor = (props: {
     const currentSheetView = calculateCurrentSheetView(props.gridState);
     const {columnID, columnHeader} = getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
 
-    const fullFormula = getFullFormula(props.editorState.formula, props.editorState.pendingSelections, props.sheetData);
+    const fullFormula = getFullFormula(props.editorState, props.sheetData);
     const cellEditorWidth = getCellEditorWidth(fullFormula, props.editorState.editorLocation)
 
     // Ensures that the cell editor is in the right location, when initially placed.

--- a/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
@@ -41,11 +41,11 @@ const FloatingCellEditor = (props: {
         left: 0,
         display: 'none'
     })
-    const sheetData = props.sheetDataArray[props.sheetIndex];
+    const sheetData = props.sheetDataArray[props.editorState.sheetIndex];
     const currentSheetView = calculateCurrentSheetView(props.gridState);
     const {columnID, columnHeader} = getCellDataFromCellIndexes(sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
 
-    const fullFormula = getFullFormula(props.editorState, sheetData);
+    const fullFormula = getFullFormula(props.editorState, props.sheetDataArray, props.sheetIndex);
     const cellEditorWidth = getCellEditorWidth(fullFormula, props.editorState.editorLocation)
 
     // Ensures that the cell editor is in the right location, when initially placed.

--- a/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/FloatingCellEditor.tsx
@@ -21,7 +21,7 @@ interface EditorStyle {top?: number, left?: number, bottom?: number, right?: num
     it is visible in the right location. 
 */
 const FloatingCellEditor = (props: {
-    sheetData: SheetData,
+    sheetDataArray: SheetData[],
     sheetIndex: number,
     gridState: GridState,
     editorState: EditorState,
@@ -41,11 +41,11 @@ const FloatingCellEditor = (props: {
         left: 0,
         display: 'none'
     })
-
+    const sheetData = props.sheetDataArray[props.sheetIndex];
     const currentSheetView = calculateCurrentSheetView(props.gridState);
-    const {columnID, columnHeader} = getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
+    const {columnID, columnHeader} = getCellDataFromCellIndexes(sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
 
-    const fullFormula = getFullFormula(props.editorState, props.sheetData);
+    const fullFormula = getFullFormula(props.editorState, sheetData);
     const cellEditorWidth = getCellEditorWidth(fullFormula, props.editorState.editorLocation)
 
     // Ensures that the cell editor is in the right location, when initially placed.
@@ -144,7 +144,7 @@ const FloatingCellEditor = (props: {
             }}
         >
             <CellEditor 
-                sheetData={props.sheetData}
+                sheetDataArray={props.sheetDataArray}
                 sheetIndex={props.sheetIndex}
                 gridState={props.gridState}
                 editorState={props.editorState}

--- a/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
@@ -14,9 +14,9 @@ export const getSelectionFormulaString = (selections: MitoSelection[], sheetData
     const selectionStrings: string[] = []
 
     selections.forEach(selection => {
-        let sheetIndexStr = '';
+        let dfName = '';
         if (sheetIndex !== selection.sheetIndex) {
-            sheetIndexStr = `${sheetData.dfName}!`;
+            dfName = `${sheetData.dfName}!`;
         }
         const [[upperLeftColumnHeader, upperLeftIndexLabel], [bottomRightColumnHeader, bottomRightIndexLabel]] = getUpperLeftAndBottomRight(selection, sheetData);
 
@@ -25,13 +25,13 @@ export const getSelectionFormulaString = (selections: MitoSelection[], sheetData
             return;
         } else if (upperLeftIndexLabel === undefined && bottomRightIndexLabel === undefined && (upperLeftColumnHeader !== undefined && bottomRightColumnHeader !== undefined)) {
             // Handle selections that are just column headers
-            selectionStrings.push(sheetIndexStr + getDisplayColumnHeader(upperLeftColumnHeader) + ":" + getDisplayColumnHeader(bottomRightColumnHeader));
+            selectionStrings.push(dfName + getDisplayColumnHeader(upperLeftColumnHeader) + ":" + getDisplayColumnHeader(bottomRightColumnHeader));
         } else if (upperLeftColumnHeader == bottomRightColumnHeader && upperLeftIndexLabel == bottomRightIndexLabel && (upperLeftColumnHeader !== undefined && upperLeftIndexLabel !== undefined)) {
             // Then, we handle the case where there is just a single cell selected
-            selectionStrings.push(sheetIndexStr + getDisplayColumnHeader(upperLeftColumnHeader) + getDisplayColumnHeader(upperLeftIndexLabel));
+            selectionStrings.push(dfName + getDisplayColumnHeader(upperLeftColumnHeader) + getDisplayColumnHeader(upperLeftIndexLabel));
         } else if (upperLeftColumnHeader !== undefined && upperLeftIndexLabel !== undefined && bottomRightColumnHeader !== undefined && bottomRightIndexLabel !== undefined) {
             // Then, handle the case where they are all defined
-            selectionStrings.push(sheetIndexStr + getDisplayColumnHeader(upperLeftColumnHeader) + getDisplayColumnHeader(upperLeftIndexLabel) + ":" + getDisplayColumnHeader(bottomRightColumnHeader) + getDisplayColumnHeader(bottomRightIndexLabel));
+            selectionStrings.push(dfName + getDisplayColumnHeader(upperLeftColumnHeader) + getDisplayColumnHeader(upperLeftIndexLabel) + ":" + getDisplayColumnHeader(bottomRightColumnHeader) + getDisplayColumnHeader(bottomRightIndexLabel));
         }
     })
 

--- a/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
@@ -22,7 +22,7 @@ export const getSelectionFormulaString = (selections: MitoSelection[], selectedS
         if (editorSheetIndex !== selection.sheetIndex) {
             dfName = `${selectedSheetData.dfName}!`;
         }
-        const [[upperLeftColumnHeader, upperLeftIndexLabel], [bottomRightColumnHeader, bottomRightIndexLabel]] = getUpperLeftAndBottomRight(selection, sheetData);
+        const [[upperLeftColumnHeader, upperLeftIndexLabel], [bottomRightColumnHeader, bottomRightIndexLabel]] = getUpperLeftAndBottomRight(selection, selectedSheetData);
 
         if (upperLeftColumnHeader === undefined && upperLeftIndexLabel === undefined && bottomRightColumnHeader === undefined && bottomRightIndexLabel === undefined) {
             // If none are defined, skip this selection

--- a/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
@@ -14,6 +14,10 @@ export const getSelectionFormulaString = (selections: MitoSelection[], sheetData
     const selectionStrings: string[] = []
 
     selections.forEach(selection => {
+        // For cross-sheet formulas, the sheetData represents the sheet that is currently open,
+        // while the editorState.sheetIndex represents the sheet that the formula is being written in.
+        // If you're writing to a different sheet from the sheet that is currently open,
+        // we need to add the sheet name to the formula
         let dfName = '';
         if (sheetIndex !== selection.sheetIndex) {
             dfName = `${sheetData.dfName}!`;

--- a/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
@@ -9,7 +9,7 @@ import { getCellDataFromCellIndexes } from "../utils";
 import { CELL_EDITOR_DEFAULT_WIDTH, CELL_EDITOR_MAX_WIDTH } from "./CellEditor";
 
 
-export const getSelectionFormulaString = (selections: MitoSelection[], sheetData: SheetData, sheetIndex: number): string => {
+export const getSelectionFormulaString = (selections: MitoSelection[], selectedSheetData: SheetData, editorSheetIndex: number): string => {
     // For each of the selections, we turn them into a string that goes into the formula
     const selectionStrings: string[] = []
 
@@ -19,8 +19,8 @@ export const getSelectionFormulaString = (selections: MitoSelection[], sheetData
         // If you're writing to a different sheet from the sheet that is currently open,
         // we need to add the sheet name to the formula
         let dfName = '';
-        if (sheetIndex !== selection.sheetIndex) {
-            dfName = `${sheetData.dfName}!`;
+        if (editorSheetIndex !== selection.sheetIndex) {
+            dfName = `${selectedSheetData.dfName}!`;
         }
         const [[upperLeftColumnHeader, upperLeftIndexLabel], [bottomRightColumnHeader, bottomRightIndexLabel]] = getUpperLeftAndBottomRight(selection, sheetData);
 

--- a/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/cellEditorUtils.tsx
@@ -49,14 +49,15 @@ export const getSelectionFormulaString = (selections: MitoSelection[], sheetData
 */
 export const getFullFormula = (
     editorState: EditorState,
-    sheetData: SheetData,
+    sheetDataArray: SheetData[],
+    selectedSheetIndex: number
 ): string => {
     const { formula, pendingSelections, sheetIndex } = editorState; 
     if (pendingSelections === undefined || pendingSelections.selections.length === 0) {
         return formula;
     }
 
-    const selectionFormulaString = getSelectionFormulaString(pendingSelections.selections, sheetData, sheetIndex);
+    const selectionFormulaString = getSelectionFormulaString(pendingSelections.selections, sheetDataArray[selectedSheetIndex], sheetIndex);
 
     const beforeSelection = formula.substring(0, pendingSelections.inputSelectionStart);
     const afterSelection = formula.substring(pendingSelections.inputSelectionEnd);

--- a/mitosheet/src/mito/components/endo/selectionUtils.tsx
+++ b/mitosheet/src/mito/components/endo/selectionUtils.tsx
@@ -114,7 +114,8 @@ export const getNewSelectionAfterMouseUp = (selection: MitoSelection, rowIndex: 
         startingRowIndex: selection.startingRowIndex,
         endingRowIndex: rowIndex,
         startingColumnIndex: selection.startingColumnIndex,
-        endingColumnIndex: columnIndex
+        endingColumnIndex: columnIndex,
+        sheetIndex: selection.sheetIndex
     }
 }
 
@@ -295,7 +296,8 @@ export const getNewSelectionAfterKeyPress = (selection: MitoSelection, e: Keyboa
         startingRowIndex: startingRowIndex,
         endingRowIndex: endingRowIndex,
         startingColumnIndex: startingColumnIndex,
-        endingColumnIndex: endingColumnIndex
+        endingColumnIndex: endingColumnIndex,
+        sheetIndex: selection.sheetIndex,
     }
 }
 
@@ -608,7 +610,8 @@ export const reconciliateSingleSelection = (oldSheetIndex: number, newSheetIndex
             startingRowIndex: -1,
             endingRowIndex: -1,
             startingColumnIndex: 0,
-            endingColumnIndex: 0
+            endingColumnIndex: 0,
+            sheetIndex: newSheetIndex
         }
     }
 
@@ -660,7 +663,8 @@ export const reconciliateSingleSelection = (oldSheetIndex: number, newSheetIndex
             startingRowIndex: selection.startingRowIndex,
             endingRowIndex: selection.endingRowIndex,
             startingColumnIndex: newStartingColumnIndex,
-            endingColumnIndex: newEndingColumnIndex
+            endingColumnIndex: newEndingColumnIndex,
+            sheetIndex: newSheetIndex
         }
     } else if (oldColumnIDsArray.length < newColumnsIDsArray.length) {
         // Columns have been added
@@ -696,7 +700,8 @@ export const reconciliateSingleSelection = (oldSheetIndex: number, newSheetIndex
             startingRowIndex: selection.startingRowIndex,
             endingRowIndex: selection.endingRowIndex,
             startingColumnIndex: newStartingColumnIndex,
-            endingColumnIndex: newEndingColumnIndex
+            endingColumnIndex: newEndingColumnIndex,
+            sheetIndex: newSheetIndex
         }
 
     } 
@@ -728,7 +733,8 @@ export const removeColumnFromSelections = (selections: MitoSelection[], columnIn
                     startingRowIndex: -1,
                     endingRowIndex: -1,
                     startingColumnIndex: smallerColumnIndex,
-                    endingColumnIndex: columnIndex - 1
+                    endingColumnIndex: columnIndex - 1,
+                    sheetIndex: selection.sheetIndex
                 })
             } 
 
@@ -737,7 +743,8 @@ export const removeColumnFromSelections = (selections: MitoSelection[], columnIn
                     startingRowIndex: -1,
                     endingRowIndex: -1,
                     startingColumnIndex: columnIndex + 1,
-                    endingColumnIndex: largerColumnIndex
+                    endingColumnIndex: largerColumnIndex,
+                    sheetIndex: selection.sheetIndex
                 })
             }
         } 
@@ -750,7 +757,8 @@ export const removeColumnFromSelections = (selections: MitoSelection[], columnIn
             startingColumnIndex: 0,
             endingColumnIndex: 0,
             startingRowIndex: 0,
-            endingRowIndex: 0
+            endingRowIndex: 0,
+            sheetIndex: 0
         })
     }
 

--- a/mitosheet/src/mito/components/endo/utils.tsx
+++ b/mitosheet/src/mito/components/endo/utils.tsx
@@ -46,7 +46,8 @@ export const getDefaultGridState = (sheetDataArray: SheetData[], selectedSheetIn
             startingColumnIndex: 0,
             endingColumnIndex: 0,
             startingRowIndex: -1,
-            endingRowIndex: -1
+            endingRowIndex: -1,
+            sheetIndex: selectedSheetIndex,
         }],
         copiedSelections: [],
         // When sheetDataArray is empty, we create a default widthDataArray so that we avoid 

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -538,12 +538,14 @@ export interface SheetView {
  * @param endingRowIndex - The index of the final row the user is selecting. Might be less than startingRowIndex.
  * @param startingColumnIndex - The index of the column that the user first selected.
  * @param endingColumnIndex - The index of the final column the user is selecting. Might be less than startingColumnIndex.
+ * @param sheetIndex - the index of the sheet that the user is selecting
  */
 export interface MitoSelection {
     startingRowIndex: number;
     endingRowIndex: number;
     startingColumnIndex: number;
     endingColumnIndex: number;
+    sheetIndex: number;
 }
 
 /**
@@ -614,6 +616,7 @@ export interface ScrollPosition {
 export type EditorState = {
     rowIndex: number;
     columnIndex: number;
+    sheetIndex: number;
     formula: string;
     editingMode: 'entire_column' | 'specific_index_labels';
 

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -892,7 +892,8 @@ export const createActions = (
                     columnIndex: startingColumnIndex,
                     formula: getDisplayColumnHeader(finalColumnHeader),
                     editorLocation: 'cell',
-                    editingMode: 'specific_index_labels'
+                    editingMode: 'specific_index_labels',
+                    sheetIndex: sheetIndex
                 })
 
             },
@@ -985,7 +986,8 @@ export const createActions = (
                     // Since you can't reference other cells while setting the value of a single cell, we default to scrolling in the formula
                     arrowKeysScrollInFormula: true,
                     editorLocation: 'cell',
-                    editingMode: 'specific_index_labels'
+                    editingMode: 'specific_index_labels',
+                    sheetIndex: sheetIndex
                 })
             },
             isDisabled: () => {
@@ -1016,7 +1018,8 @@ export const createActions = (
                     formula: startingColumnFormula,
                     arrowKeysScrollInFormula: arrowKeysScrollInFormula,
                     editorLocation: 'cell',
-                    editingMode: 'entire_column'
+                    editingMode: 'entire_column',
+                    sheetIndex: sheetIndex
                 })
             },
             isDisabled: () => {


### PR DESCRIPTION
Adds the ability to select columns in different sheets **when the user is editing a VLOOKUP formula**. 

This changes the `editorState` to include `sheetIndex`.

Also updates the behavior of selecting a range of columns to allow for the user to shift and click another header to select the range. 

Todo:
- [x] When the user presses "enter" in the cell editor, it should refer to the `editorConfig.sheetIndex`. Right now it assumes you're adding this to the sheet you currently have open