### PR TITLE
Add api for total number of matches

### DIFF
--- a/mitosheet/css/elements/SearchBar.css
+++ b/mitosheet/css/elements/SearchBar.css
@@ -6,6 +6,11 @@
     box-shadow: 0px 3px 11px -4px;
     padding: 5px;
     display: flex;
+    align-items: center;
+}
+
+.mito-search-bar span {
+    margin-left: 5px;
 }
 
 .mito-close-search-button {

--- a/mitosheet/css/elements/SearchBar.css
+++ b/mitosheet/css/elements/SearchBar.css
@@ -11,6 +11,9 @@
 
 .mito-search-bar span {
     margin-left: 5px;
+    min-width: 9ch;
+    justify-content: flex-end;
+    display: flex;
 }
 
 .mito-close-search-button {

--- a/mitosheet/mitosheet/api/api.py
+++ b/mitosheet/mitosheet/api/api.py
@@ -18,6 +18,7 @@ from mitosheet.api.get_csv_files_metadata import get_csv_files_metadata
 from mitosheet.api.get_dataframe_as_csv import get_dataframe_as_csv
 from mitosheet.api.get_dataframe_as_excel import get_dataframe_as_excel
 from mitosheet.api.get_defined_df_names import get_defined_df_names
+from mitosheet.api.get_total_number_matches import get_total_number_matches
 from mitosheet.api.get_excel_file_metadata import get_excel_file_metadata
 from mitosheet.api.get_imported_files_and_dataframes_from_analysis_name import \
     get_imported_files_and_dataframes_from_analysis_name
@@ -178,6 +179,8 @@ def handle_api_event(
             result = get_dataframe_as_excel(params, steps_manager)
         elif event["type"] == "get_defined_df_names":
             result = get_defined_df_names(params, steps_manager)
+        elif event["type"] == "get_total_number_matches":
+            result = get_total_number_matches(params, steps_manager)
         elif event["type"] == 'get_imported_files_and_dataframes_from_current_steps':
             result = get_imported_files_and_dataframes_from_current_steps(params, steps_manager)
         elif event["type"] == 'get_imported_files_and_dataframes_from_analysis_name':

--- a/mitosheet/mitosheet/api/get_total_number_matches.py
+++ b/mitosheet/mitosheet/api/get_total_number_matches.py
@@ -16,7 +16,7 @@ def get_total_number_matches(params: Dict[str, Any], steps_manager: StepsManager
     search_value = params['search_value']
     df = steps_manager.dfs[sheet_index]
 
-    # First, count the matches in the dataframe:
+    # First, generate a count for each value in the dataframe:
     unique_value_counts = df.value_counts()
 
     # Then, filter for the search value:

--- a/mitosheet/mitosheet/api/get_total_number_matches.py
+++ b/mitosheet/mitosheet/api/get_total_number_matches.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+from typing import Any, Dict
+from mitosheet.types import StepsManagerType
+
+
+def get_total_number_matches(params: Dict[str, Any], steps_manager: StepsManagerType) -> str:
+    """
+    Finds the number of matches to a given search value in the dataframe.
+    """
+    sheet_index = params['sheet_index']
+    search_value = params['search_value']
+    df = steps_manager.dfs[sheet_index]
+
+    # First, count the matches in the dataframe:
+    unique_value_counts = df.value_counts()
+
+    # Then, filter for the search value:
+    matches = unique_value_counts.filter(like=search_value, axis=0)
+
+    # Then, sum the matches:
+    total_number_matches = matches.sum()
+
+    return total_number_matches

--- a/mitosheet/mitosheet/api/get_total_number_matches.py
+++ b/mitosheet/mitosheet/api/get_total_number_matches.py
@@ -3,6 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
+import re
 from typing import Any, Dict
 from mitosheet.types import StepsManagerType
 
@@ -19,7 +20,7 @@ def get_total_number_matches(params: Dict[str, Any], steps_manager: StepsManager
     unique_value_counts = df.value_counts()
 
     # Then, filter for the search value:
-    matches = unique_value_counts.filter(like=search_value, axis=0)
+    matches = unique_value_counts.filter(regex=re.compile(search_value, re.IGNORECASE), axis=0)
 
     # Then, sum the matches:
     total_number_matches = matches.sum()

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -10,7 +10,7 @@ Contains tests for the add_formatting_to_excel_sheet function.
 import pandas as pd
 import pytest
 
-from mitosheet.tests.test_utils import create_mito_wrapper_with_data
+from mitosheet.tests.test_utils import create_mito_wrapper, create_mito_wrapper_with_data
 from mitosheet.api.get_total_number_matches import get_total_number_matches
 from mitosheet.tests.decorators import pandas_post_1_only
 
@@ -128,8 +128,46 @@ def test_get_number_matches(data, sheet_index, search_value, expected):
     # Create a mito wrapper with data
     test_wrapper = create_mito_wrapper_with_data(data)
 
-    # Get the excel string
     total_matches = get_total_number_matches({'sheet_index': sheet_index, 'search_value': search_value }, test_wrapper.mito_backend.steps_manager)
     
     # Check that the excel string is not empty
+    assert total_matches == expected
+
+
+NUMBER_MATCHES_TESTS_MULTIPLE_DF = [
+    (
+        [
+            pd.DataFrame({'A': [1, 2, 3]}),
+        ],
+        0,
+        '1',
+        1
+    ),
+    (
+        [
+            pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c'], 'C': [True, False, True], 'D': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03')]}),
+            pd.DataFrame({'E': [3, 3, 3], 'F': ['c', 'c', 'd'], 'G': [True, False, False], 'H': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03')]})
+        ],
+        1,
+        'c',
+        2
+    ),
+    (
+        [
+            pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c'], 'C': [True, False, True], 'D': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03')]}),
+            pd.DataFrame({'E': [3, 3, 3], 'F': ['c', 'c', 'd'], 'G': [True, False, False], 'H': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03')]})
+        ],
+        0,
+        'c',
+        1
+    )
+]
+
+@pandas_post_1_only
+@pytest.mark.parametrize("dfs,sheet_index,search_value,expected", NUMBER_MATCHES_TESTS_MULTIPLE_DF)
+def test_get_number_matches_multiple_dataframes(dfs,sheet_index,search_value,expected):
+    test_wrapper = create_mito_wrapper(*dfs)
+
+    total_matches = get_total_number_matches({'sheet_index': sheet_index, 'search_value': search_value }, test_wrapper.mito_backend.steps_manager)
+
     assert total_matches == expected

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+"""
+Contains tests for the add_formatting_to_excel_sheet function.
+"""
+
+import pytest
+
+from mitosheet.tests.test_utils import create_mito_wrapper_with_data
+from mitosheet.api.get_total_number_matches import get_total_number_matches
+
+NUMBER_MATCHES_TESTS = [
+    (
+        0, 
+        'abc',
+        2
+    ),
+    (
+        0, 
+        'def',
+        1
+    ),
+    (
+        0, 
+        'f',
+        2
+    ),
+    (
+        0, 
+        'ef',
+        1
+    ),
+]
+
+@pytest.mark.parametrize("sheet_index,search_value,expected", NUMBER_MATCHES_TESTS)
+# This tests exporting as excel without formatting
+def test_get_number_matches(sheet_index, search_value, expected):
+    # Create a mito wrapper with data
+    test_wrapper = create_mito_wrapper_with_data(['abc', 'def', 'fgh', 'abc'])
+
+    # Get the excel string
+    total_matches = get_total_number_matches({'sheet_index': sheet_index, 'search_value': search_value }, test_wrapper.mito_backend.steps_manager)
+    
+    # Check that the excel string is not empty
+    assert total_matches == expected

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -39,6 +39,12 @@ NUMBER_MATCHES_TESTS = [
         'ef',
         1
     ),
+    (
+        ['abc', 'def', 'fgh', 'ABC'],
+        0, 
+        'abc',
+        2
+    ),
 
     # Tests for numbers
     (

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -7,6 +7,7 @@
 Contains tests for the add_formatting_to_excel_sheet function.
 """
 
+import pandas as pd
 import pytest
 
 from mitosheet.tests.test_utils import create_mito_wrapper_with_data
@@ -37,6 +38,8 @@ NUMBER_MATCHES_TESTS = [
         'ef',
         1
     ),
+
+    # Tests for numbers
     (
         [1234, 123, 345, 456],
         0, 
@@ -80,6 +83,34 @@ NUMBER_MATCHES_TESTS = [
         0, 
         '1230',
         1
+    ),
+
+    # Tests for booleans
+    (
+        [True, False, True, False],
+        0,
+        'True',
+        2
+    ),
+    (
+        [True, False, True, False],
+        0,
+        'False',
+        2
+    ),
+
+    # Tests for dates
+    (
+        [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03'), pd.Timestamp('2021-01-04')],
+        0,
+        '2021-01-01',
+        1
+    ),
+    (
+        [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02'), pd.Timestamp('2021-01-03'), pd.Timestamp('2021-01-04')],
+        0,
+        '2021-01',
+        4
     ),
 ]
 

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -12,6 +12,7 @@ import pytest
 
 from mitosheet.tests.test_utils import create_mito_wrapper_with_data
 from mitosheet.api.get_total_number_matches import get_total_number_matches
+from mitosheet.tests.decorators import pandas_post_1_only
 
 NUMBER_MATCHES_TESTS = [
     (
@@ -114,6 +115,7 @@ NUMBER_MATCHES_TESTS = [
     ),
 ]
 
+@pandas_post_1_only
 @pytest.mark.parametrize("data,sheet_index,search_value,expected", NUMBER_MATCHES_TESTS)
 # This tests exporting as excel without formatting
 def test_get_number_matches(data, sheet_index, search_value, expected):

--- a/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
+++ b/mitosheet/mitosheet/tests/api/test_get_total_number_matches.py
@@ -14,32 +14,80 @@ from mitosheet.api.get_total_number_matches import get_total_number_matches
 
 NUMBER_MATCHES_TESTS = [
     (
+        ['abc', 'def', 'fgh', 'abc'],
         0, 
         'abc',
         2
     ),
     (
+        ['abcdef', 'def', 'fgh', 'abc'],
         0, 
         'def',
-        1
+        2
     ),
     (
+        ['abc', 'def', 'fgh', 'abc'],
         0, 
         'f',
         2
     ),
     (
+        ['abc', 'def', 'fgh', 'abc'],
         0, 
         'ef',
         1
     ),
+    (
+        [1234, 123, 345, 456],
+        0, 
+        '123',
+        2
+    ),
+    (
+        [1234, 123.456, 345, 456],
+        0, 
+        '456',
+        2
+    ),
+    (
+        [123, 123.456, 345, 456],
+        0, 
+        '123',
+        2
+    ),
+    (
+        [123, 123.456, 345, 456],
+        0, 
+        '45',
+        3
+    ),
+    (
+        [123, 123.0, 345, 456],
+        0, 
+        '123',
+        2
+    ),
+
+    # TODO: This test shows a case that doesn't align with the frontend.
+    (
+        [123, 123.0, 345, 456],
+        0, 
+        '123.0',
+        2
+    ),
+    (
+        [123000, 123, 345, 456],
+        0, 
+        '1230',
+        1
+    ),
 ]
 
-@pytest.mark.parametrize("sheet_index,search_value,expected", NUMBER_MATCHES_TESTS)
+@pytest.mark.parametrize("data,sheet_index,search_value,expected", NUMBER_MATCHES_TESTS)
 # This tests exporting as excel without formatting
-def test_get_number_matches(sheet_index, search_value, expected):
+def test_get_number_matches(data, sheet_index, search_value, expected):
     # Create a mito wrapper with data
-    test_wrapper = create_mito_wrapper_with_data(['abc', 'def', 'fgh', 'abc'])
+    test_wrapper = create_mito_wrapper_with_data(data)
 
     # Get the excel string
     total_matches = get_total_number_matches({'sheet_index': sheet_index, 'search_value': search_value }, test_wrapper.mito_backend.steps_manager)

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1077,6 +1077,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                         <SearchBar
                             uiState={uiState}
                             setUIState={setUIState}
+                            mitoAPI={mitoAPI}
                         />
                     }
                 </div>

--- a/mitosheet/src/mito/api/api.tsx
+++ b/mitosheet/src/mito/api/api.tsx
@@ -252,6 +252,20 @@ export class MitoAPI {
     }
 
     /*
+        Returns a string encoding of the CSV file to download
+    */
+    async getTotalNumberMatches(sheetIndex: number, searchValue: string): Promise<MitoAPIResult<string>> {
+        return await this.send<string>({
+            'event': 'api_call',
+            'type': 'get_total_number_matches',
+            'params': {
+                'sheet_index': sheetIndex,
+                'search_value': searchValue
+            },
+        })
+    }
+
+    /*
         Returns a string encoding of the excel file to download
 
         See the download taskpane to how to use this string, but it

--- a/mitosheet/src/mito/components/SearchBar.tsx
+++ b/mitosheet/src/mito/components/SearchBar.tsx
@@ -17,7 +17,7 @@ interface SearchBarProps {
 
 export const SearchBar: React.FC<SearchBarProps> = (props) => {
     const { setUIState, uiState, mitoAPI } = props;
-    const [totalMatches, setTotalMatches] = React.useState<number | null>(null);
+    const [totalMatches, setTotalMatches] = React.useState<number | undefined>(undefined);
     const searchValue = uiState.currOpenSearch.searchValue;
 
     /**
@@ -34,7 +34,7 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
                 return;
             }
             const total = response.result;
-            if (total !== null && !isNaN(Number(total))) {
+            if (total !== undefined && !isNaN(Number(total))) {
                 setTotalMatches(Number(total));
             }
         });

--- a/mitosheet/src/mito/components/SearchBar.tsx
+++ b/mitosheet/src/mito/components/SearchBar.tsx
@@ -29,7 +29,7 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
             setTotalMatches(0);
             return;
         }
-        mitoAPI.getTotalNumberMatches(uiState.selectedSheetIndex, searchValue ?? '').then((response) => {
+        void mitoAPI.getTotalNumberMatches(uiState.selectedSheetIndex, searchValue ?? '').then((response) => {
             if ('error' in response) {
                 return;
             }
@@ -57,7 +57,7 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
             placeholder='Find...'
             autoFocus
         />
-        <span>{totalMatches ?? '...'} matches</span>
+        <span>{totalMatches ?? '...'} match{totalMatches === 1 ? '' : 'es'}</span>
         <button
             className='mito-close-search-button'
             onClick={() => {

--- a/mitosheet/src/mito/components/SearchBar.tsx
+++ b/mitosheet/src/mito/components/SearchBar.tsx
@@ -8,6 +8,8 @@ import '../../../css/elements/SearchBar.css';
 import { classNames } from '../utils/classNames';
 import Input from './elements/Input';
 import { MitoAPI } from '../api/api';
+import { useDebouncedEffect } from '../hooks/useDebouncedEffect';
+import LoadingDots from './elements/LoadingDots';
 
 interface SearchBarProps {
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
@@ -23,7 +25,7 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
     /**
      * Update the total number of matches when the search value changes
      */
-    React.useEffect(() => {
+    useDebouncedEffect(() => {
         // If the search value is empty, set the total matches to 0
         if (searchValue === undefined || searchValue === '') {
             setTotalMatches(0);
@@ -38,7 +40,7 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
                 setTotalMatches(Number(total));
             }
         });
-    }, [searchValue, uiState.selectedSheetIndex]);
+    }, [searchValue, uiState.selectedSheetIndex], 500);
 
     return (<div className='mito-search-bar'>
         <Input
@@ -52,12 +54,17 @@ export const SearchBar: React.FC<SearchBarProps> = (props) => {
                         searchValue: e.target.value
                     }
                 })
+                if (e.target.value === '') {
+                    setTotalMatches(0)
+                } else {
+                    setTotalMatches(undefined);
+                }
             }}
             className={classNames('mito-input')}
             placeholder='Find...'
             autoFocus
         />
-        <span>{totalMatches ?? '...'} match{totalMatches === 1 ? '' : 'es'}</span>
+        <span>{totalMatches ?? <LoadingDots />} match{totalMatches === 1 ? '' : 'es'}</span>
         <button
             className='mito-close-search-button'
             onClick={() => {

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -1104,6 +1104,8 @@ export const createActions = (
                 if (uiState.currOpenSearch.isOpen) {
                     const searchInput = mitoContainerRef.current?.querySelector<HTMLInputElement>('#mito-search-bar-input');
                     if (searchInput) {
+                        // If the search bar is already open, then we focus on the input and select all
+                        // to make it easier to search something new without removing the previous search
                         searchInput.focus();
                         searchInput.select();
                     }

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -1102,7 +1102,11 @@ export const createActions = (
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
                 if (uiState.currOpenSearch.isOpen) {
-                    mitoContainerRef.current?.querySelector<HTMLInputElement>('#mito-search-bar-input')?.focus();
+                    const searchInput = mitoContainerRef.current?.querySelector<HTMLInputElement>('#mito-search-bar-input');
+                    if (searchInput) {
+                        searchInput.focus();
+                        searchInput.select();
+                    }
                 } else {
                     setUIState(prevUIState => {
                         return {


### PR DESCRIPTION
This adds a backend API to get the total number of matches to a string for a given sheet, and displays it in the search bar like this: 
![image](https://github.com/mito-ds/mito/assets/6673460/2dcc8b98-0673-429d-87b6-222fcf8fa871)

**Note**: When we add in jumping to the next match, the text displayed will update from "*m* matches" to "n of m".