### PR TITLE
Fix cursor bug

### DIFF
--- a/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/mito/components/endo/celleditor/CellEditor.tsx
@@ -105,7 +105,7 @@ const CellEditor = (props: {
             // If there is a pendingSelections, then we set the selection to be 
             // at the _end_ of them!
             if (props.editorState.pendingSelections !== undefined) {
-                const index = props.editorState.pendingSelections.inputSelectionStart + getSelectionFormulaString(props.editorState.pendingSelections.selections, sheetData, props.editorState.sheetIndex).length;
+                const index = props.editorState.pendingSelections.inputSelectionStart + getSelectionFormulaString(props.editorState.pendingSelections.selections, props.sheetDataArray[props.sheetIndex], props.editorState.sheetIndex).length;
                 cellEditorInputRef.current?.setSelectionRange(
                     index, index
                 )


### PR DESCRIPTION
Fixes a bug that occurs with the cursor of the cell editor when selecting a range of columns in a cross-sheet reference. The cursor was using the `editorState` sheet's name to generate the cursor location when it should be using the current sheet index's name. 