### PR TITLE
mitoinstaller: add better messaging

### DIFF
--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - 'mitoinstaller/**'
+  workflow_dispatch:
+
 
 jobs:
   test-mitoinstaller:

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -34,7 +34,7 @@ def install_step_mitosheet_check_dependencies():
         return
     
     else:
-        raise Exception('Installed extensions {extension_names}'.format(extension_names=extension_names))
+        raise Exception("You're running JupyterLab {jupyterlab_version}. Mito requires JupyterLab 3.0 or higher. Please upgrade your JupyterLab installation or install Mito in a new virtual environment: https://docs.trymito.io/getting-started/installing-mito") 
 
 def remove_mitosheet_3_if_present():
     """


### PR DESCRIPTION
# Description

Adds a more helpful and action oriented error message when the Mito installer cannot automatically upgrade from an old version of JupyterLab. 

# Testing

Try it. 

# Documentation

No.