### PR TITLE
trymito: remove h1 from footer

### DIFF
--- a/trymito.io/components/Footer/Footer.module.css
+++ b/trymito.io/components/Footer/Footer.module.css
@@ -4,8 +4,16 @@
     flex-wrap: wrap;
 }
 
-.footer_container h1 {
+.home_container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.footer_mito_text {
+    font-size: 2rem !important;
     margin-right: 2rem;
+    margin-top: 0rem !important;
 }
 
 /* 
@@ -76,8 +84,8 @@
         margin-top: 2rem;
     }
 
-    .footer_container h1 {
-        font-size: 2rem;
+    .footer_mito_text {
+        font-size: 2rem !important;
         margin-right: 1rem;
     }
 

--- a/trymito.io/components/Footer/Footer.tsx
+++ b/trymito.io/components/Footer/Footer.tsx
@@ -11,10 +11,10 @@ const Footer = (): JSX.Element => {
     return (
         <footer className={footerStyle.footer_container}>
             <div className='flex-column'>
-                <div className='flex-row'>
-                    <h1>
-                        Mito
-                    </h1>
+                <div className={footerStyle.home_container}>
+                    <p className={footerStyle.footer_mito_text}>
+                        <b>Mito</b>
+                    </p>
                     <Link href='/'>
                         <a className={footerStyle.logo_container}> 
                             <Image src="/Mito.svg" alt="Mito Logo" width={50} height={30}/>


### PR DESCRIPTION
# Description

Having multiple `H1`s on a page delutes their SEO effect, so we don't want to waste an H1 on each page with that is just "Mito". 

# Testing

# Documentation
