### PR TITLE
Add function to backend to get fully parameterized function

### DIFF
--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -121,8 +121,9 @@ class MitoBackend():
     @property
     def fully_parameterized_function(self) -> List[str]:
         """
-        Returns the fully parameterized function string, which is the string
-        that is used to call the function in the code.
+        Returns the fully parameterized function string. This is used for
+        cases where we want to get the function string regardless of the 
+        code options the user provided. 
         """
         return get_script_as_function(
             self.steps_manager,

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -40,6 +40,8 @@ from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_FIFTY_USAGES,
                                     UJ_USER_EMAIL, UJ_AI_PRIVACY_POLICY)
 from mitosheet.user.utils import get_pandas_version, is_enterprise, is_pro, is_running_test
 from mitosheet.utils import get_new_id
+from mitosheet.transpiler.transpile_utils import get_script_as_function
+from mitosheet.transpiler.transpile import transpile
 from mitosheet.step_performers.utils.user_defined_functionality import get_functions_from_path, get_non_validated_custom_sheet_functions
 from mitosheet.api.get_validate_snowflake_credentials import get_cached_snowflake_credentials
 
@@ -115,6 +117,27 @@ class MitoBackend():
         self.mito_send: Callable = lambda x: None # type: ignore
 
         self.theme = theme
+
+    @property
+    def fully_parameterized_function(self) -> List[str]:
+        """
+        Returns the fully parameterized function string, which is the string
+        that is used to call the function in the code.
+        """
+        return get_script_as_function(
+            self.steps_manager,
+            [],
+            transpile(self.steps_manager, add_comments=False),
+            self.steps_manager.code_options.get('function_name'),
+            [
+                'import_dataframe',
+                'file_name_export_excel',
+                'file_name_export_csv',
+                'file_name_import_excel',
+                'file_name_import_csv',
+            ],
+            False
+        )
 
     @property
     def analysis_name(self):

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -130,13 +130,7 @@ class MitoBackend():
             [],
             transpile(self.steps_manager, add_comments=False),
             self.steps_manager.code_options['function_name'],
-            [
-                'import_dataframe',
-                'file_name_export_excel',
-                'file_name_export_csv',
-                'file_name_import_excel',
-                'file_name_import_csv',
-            ],
+            'all',
             False
         )
 

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -129,7 +129,7 @@ class MitoBackend():
             self.steps_manager,
             [],
             transpile(self.steps_manager, add_comments=False),
-            self.steps_manager.code_options.get('function_name'),
+            self.steps_manager.code_options['function_name'],
             [
                 'import_dataframe',
                 'file_name_export_excel',

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -119,20 +119,20 @@ class MitoBackend():
         self.theme = theme
 
     @property
-    def fully_parameterized_function(self) -> List[str]:
+    def fully_parameterized_function(self) -> str:
         """
         Returns the fully parameterized function string. This is used for
         cases where we want to get the function string regardless of the 
         code options the user provided. 
         """
-        return get_script_as_function(
+        return '\n'.join(get_script_as_function(
             self.steps_manager,
             [],
             transpile(self.steps_manager, add_comments=False),
             self.steps_manager.code_options['function_name'],
             'all',
             False
-        )
+        ))
 
     @property
     def analysis_name(self):

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -560,7 +560,7 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
     mito = create_mito_wrapper()
     mito.simple_import([tmp_file1])
     mito.simple_import([tmp_file2])
-    mito.code_options_update({'as_function': False, 'import_custom_python_code': False, 'call_function': False, 'function_name': 'function', 'function_params': {'var_name1': f"r'{tmp_file1}'", 'var_name2': f"r'{tmp_file2}'"}})
+    mito.code_options_update({'as_function': False, 'import_custom_python_code': False, 'call_function': False, 'function_name': 'function', 'function_params': {}})
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
         "import pandas as pd",

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -594,7 +594,7 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         '',
     ]
 
-    assert mito.mito_backend.fully_parameterized_function == [
+    assert mito.mito_backend.fully_parameterized_function == '\n'.join([
         "",
         "def function(import_dataframe_0, file_name_import_csv_0, "
         "file_name_import_excel_0, file_name_export_csv_0, file_name_export_excel_0):",
@@ -617,7 +617,7 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         f'{TAB}',
         f"{TAB}return import_dataframe_0, txt, Sheet1",
         "",
-    ]
+    ])
 
 def test_transpile_as_function_multiple_params(tmp_path):
     tmp_file1 = str(tmp_path / 'txt.csv')

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 import os
-from mitosheet.transpiler.transpile_utils import NEWLINE_TAB, TAB
+from mitosheet.transpiler.transpile_utils import NEWLINE_TAB, TAB, NEWLINE
 import pytest
 import pandas as pd
 
@@ -553,13 +553,21 @@ def test_transpile_as_function_single_param_multiple_times(tmp_path):
 def test_transpile_fully_parameterized_function_string(tmp_path):
     tmp_file1 = str(tmp_path / 'txt.csv')
     tmp_file2 = str(tmp_path / 'file.xlsx')
+    tmp_exportfile1 = str(tmp_path / 'export.csv')
+    tmp_exportfile2 = str(tmp_path / 'export.xlsx')
     df1 = pd.DataFrame({'A': [1], 'B': [2]})
     df1.to_csv(tmp_file1, index=False)
     df1.to_excel(tmp_file2, index=False)
 
     mito = create_mito_wrapper()
+    # Test imports for excel and CSV
     mito.simple_import([tmp_file1])
     mito.excel_import(tmp_file2, sheet_names=['Sheet1'], has_headers=True, skiprows=0)
+
+    # Test exports for excel and CSV
+    mito.export_to_file('csv', [0], tmp_exportfile1)
+    mito.export_to_file('excel', [1], tmp_exportfile2)
+
     mito.code_options_update({'as_function': False, 'import_custom_python_code': False, 'call_function': False, 'function_name': 'function', 'function_params': {}})
     assert mito.transpiled_code == [
         'from mitosheet.public.v3 import *',
@@ -570,15 +578,24 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         f"sheet_df_dictonary = "
         f"pd.read_excel(r'{tmp_file2}', "
         "engine='openpyxl', sheet_name=[\n"
-        "    'Sheet1'\n"
+        f"{TAB}'Sheet1'{NEWLINE}"
         '], skiprows=0)',
         "Sheet1 = sheet_df_dictonary['Sheet1']",
-        ""
+        "",
+        f"txt.to_csv(r'{tmp_exportfile1}', "
+        'index=False)',
+        '',
+        'with '
+        f"pd.ExcelWriter(r'{tmp_exportfile2}', "
+        'engine="openpyxl") as writer:',
+        '    Sheet1.to_excel(writer, sheet_name="Sheet1", index=False)',
+        '',
     ]
 
     assert mito.mito_backend.fully_parameterized_function == [
         "",
-        "def function(file_name_import_csv_0, file_name_import_excel_0):",
+        "def function(file_name_import_csv_0, file_name_import_excel_0,"
+        " file_name_export_csv_0, file_name_export_excel_0):",
         f'{TAB}from mitosheet.public.v3 import *',
         f"{TAB}import pandas as pd",
         f"{TAB}",
@@ -586,9 +603,15 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         f"{TAB}",
         f"{TAB}sheet_df_dictonary = pd.read_excel(file_name_import_excel_0, "
         "engine='openpyxl', sheet_name=[\n"
-        "        'Sheet1'\n"
-        '    ], skiprows=0)',
-        "    Sheet1 = sheet_df_dictonary['Sheet1']",
+        f"{TAB}    'Sheet1'{NEWLINE}"
+        f'{TAB}], skiprows=0)',
+        f"{TAB}Sheet1 = sheet_df_dictonary['Sheet1']",
+        f'{TAB}',
+        f'{TAB}txt.to_csv(file_name_export_csv_0, index=False)',
+        f'{TAB}',
+        f'{TAB}with pd.ExcelWriter(file_name_export_excel_0, engine="openpyxl") as '
+        'writer:',
+        f'{TAB}    Sheet1.to_excel(writer, sheet_name="Sheet1", index=False)',
         f'{TAB}',
         f"{TAB}return txt, Sheet1",
         "",

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -570,8 +570,6 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         ""
     ]
 
-    print(mito.mito_backend.fully_parameterized_function)
-
     assert mito.mito_backend.fully_parameterized_function == [
         "",
         "def function(file_name_import_csv_0, file_name_import_csv_1):",

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -561,7 +561,7 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
     df1.to_csv(tmp_file1, index=False)
     df1.to_excel(tmp_file2, index=False)
 
-    mito = create_mito_wrapper()
+    mito = create_mito_wrapper(df1, arg_names=['test_df_name'])
     # Test imports for excel and CSV
     mito.simple_import([tmp_file1])
     mito.excel_import(tmp_file2, sheet_names=['Sheet1'], has_headers=True, skiprows=0)
@@ -584,20 +584,20 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         '], skiprows=0)',
         "Sheet1 = sheet_df_dictonary['Sheet1']",
         "",
-        f"txt.to_csv(r'{tmp_exportfile1}', "
+        f"test_df_name.to_csv(r'{tmp_exportfile1}', "
         'index=False)',
         '',
         'with '
         f"pd.ExcelWriter(r'{tmp_exportfile2}', "
         'engine="openpyxl") as writer:',
-        '    Sheet1.to_excel(writer, sheet_name="Sheet1", index=False)',
+        '    txt.to_excel(writer, sheet_name="txt", index=False)',
         '',
     ]
 
     assert mito.mito_backend.fully_parameterized_function == [
         "",
-        "def function(file_name_import_csv_0, file_name_import_excel_0,"
-        " file_name_export_csv_0, file_name_export_excel_0):",
+        "def function(import_dataframe_0, file_name_import_csv_0, "
+        "file_name_import_excel_0, file_name_export_csv_0, file_name_export_excel_0):",
         f'{TAB}from mitosheet.public.v3 import *',
         f"{TAB}import pandas as pd",
         f"{TAB}",
@@ -609,13 +609,13 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         f'{TAB}], skiprows=0)',
         f"{TAB}Sheet1 = sheet_df_dictonary['Sheet1']",
         f'{TAB}',
-        f'{TAB}txt.to_csv(file_name_export_csv_0, index=False)',
+        f'{TAB}import_dataframe_0.to_csv(file_name_export_csv_0, index=False)',
         f'{TAB}',
         f'{TAB}with pd.ExcelWriter(file_name_export_excel_0, engine="openpyxl") as '
         'writer:',
-        f'{TAB}    Sheet1.to_excel(writer, sheet_name="Sheet1", index=False)',
+        f'{TAB}    txt.to_excel(writer, sheet_name="txt", index=False)',
         f'{TAB}',
-        f"{TAB}return txt, Sheet1",
+        f"{TAB}return import_dataframe_0, txt, Sheet1",
         "",
     ]
 

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -550,6 +550,8 @@ def test_transpile_as_function_single_param_multiple_times(tmp_path):
         f"txt, txt_1 = function(var_name)"
     ]
 
+@pandas_post_1_2_only
+@python_post_3_6_only
 def test_transpile_fully_parameterized_function_string(tmp_path):
     tmp_file1 = str(tmp_path / 'txt.csv')
     tmp_file2 = str(tmp_path / 'file.xlsx')

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -229,7 +229,7 @@ def get_final_function_params_with_subtypes_turned_to_parameters(
         number_of_params_of_subtype: Dict[ParamSubtype, int] = {}
         for param_value, param_type, param_subtype in parameterizable_params:
             param_index = number_of_params_of_subtype.get(param_subtype, 0)
-            if isinstance(function_params, str) and function_params == param_subtype:
+            if isinstance(function_params, str) and (function_params == param_subtype or function_params == 'all'):
                 final_params[f"{param_subtype}_{param_index}"] = param_value
                 number_of_params_of_subtype[param_subtype] = param_index + 1
             elif param_subtype in function_params:

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -340,6 +340,7 @@ if sys.version_info[:3] > (3, 8, 0):
         'file_name_export_csv',
         'file_name_import_excel',
         'file_name_import_csv',
+        'all' # This represents all of the above
     ]
     ParamValue = str
 

--- a/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsParameters.tsx
+++ b/mitosheet/src/mito/components/taskpanes/CodeOptions/CodeOptionsParameters.tsx
@@ -37,6 +37,8 @@ const getParamDescriptionString = (paramSubtype: ParamSubType): string => {
         return 'CSV Export File Path'
     } else if (paramSubtype === 'file_name_export_excel') {
         return 'Excel Export File Path'
+    } else if (paramSubtype === 'all') {
+        return 'All Possible Parameters'
     } else {
         return paramSubtype;
     }


### PR DESCRIPTION
# Description
Adds a function to the backend to get the transpiled code as a function (that isn't called) with all of the current parameterization added. This includes: 
```
[
                'import_dataframe',
                'file_name_export_excel',
                'file_name_export_csv',
                'file_name_import_excel',
                'file_name_import_csv',
]
```

# Testing
Added tests in `test_transpile.py` to check that the output is what we expect. 
