### PR TITLE
Add ParamData type

### DIFF
--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -47,6 +47,8 @@ def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List
                         'initial_value': param[0],
                         'type': param[1],
                         'subtype': param[2],
+                        # If the param is a df_name, then it is required for the function
+                        # because we won't be able to store the initial value in the MitoAnalysis for streamlit.
                         'required': param[1] == 'df_name',
                         'name': param_name
                 }

--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -7,7 +7,7 @@
 import json
 from typing import Any, Dict, List, Tuple
 from mitosheet.code_chunks.code_chunk_utils import get_code_chunks
-from mitosheet.types import ParamSubtype, ParamType, ParamName, ParamValue, StepsManagerType, ParamData
+from mitosheet.types import ParamSubtype, ParamType, ParamName, ParamValue, StepsManagerType, ParamMetadata
 from mitosheet.updates.args_update import is_string_arg_to_mitosheet_call
 from mitosheet.transpiler.transpile_utils import get_final_function_params_with_subtypes_turned_to_parameters
 
@@ -29,13 +29,13 @@ def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManag
 
         return all_parameterizable_params
 
-def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List[ParamData]:
+def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List[ParamMetadata]:
         # First, get all the parameterizable params and the function params
         all_parameterizable_params = get_parameterizable_params({}, steps_manager)
         function_params: Dict[ParamName, ParamValue] = get_final_function_params_with_subtypes_turned_to_parameters(steps_manager, 'all')
         param_names = list(function_params.keys())
 
-        # Now, we need to map the parameterizable params to the ParamData type. 
+        # Now, we need to map the parameterizable params to the ParamMetadata type. 
         def map_tuple_to_param_data(args):
                 param = args[0]
                 param_name = args[1] 

--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -29,6 +29,10 @@ def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManag
 
         return all_parameterizable_params
 
+# This function is used to get the parameterizable params for the UI in streamlit. 
+# It returns a list of ParamMetadata objects, which are defined in mitosheet/types.py
+# The ParamMetadata object includes various information that a streamlit developer might
+# need to display the parameterizable params in the UI.
 def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List[ParamMetadata]:
         # First, get all the parameterizable params and the function params
         all_parameterizable_params = get_parameterizable_params({}, steps_manager)

--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -7,8 +7,9 @@
 import json
 from typing import Any, Dict, List, Tuple
 from mitosheet.code_chunks.code_chunk_utils import get_code_chunks
-from mitosheet.types import ParamSubtype, ParamType, ParamValue, StepsManagerType, ParamData
+from mitosheet.types import ParamSubtype, ParamType, ParamName, ParamValue, StepsManagerType, ParamData
 from mitosheet.updates.args_update import is_string_arg_to_mitosheet_call
+from mitosheet.transpiler.transpile_utils import get_final_function_params_with_subtypes_turned_to_parameters
 
 def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManagerType) -> List[Tuple[ParamValue, ParamType, ParamSubtype]]:
 
@@ -29,25 +30,21 @@ def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManag
         return all_parameterizable_params
 
 def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List[ParamData]:
+        # First, get all the parameterizable params and the function params
+        all_parameterizable_params = get_parameterizable_params({}, steps_manager)
+        function_params: Dict[ParamName, ParamValue] = get_final_function_params_with_subtypes_turned_to_parameters(steps_manager, 'all')
+        param_names = list(function_params.keys())
 
-        all_parameterizable_params: List[ParamData] = []
+        # Now, we need to map the parameterizable params to the ParamData type. 
+        def map_tuple_to_param_data(args):
+                param = args[0]
+                param_name = args[1] 
+                return {
+                        'initial_value': param[0],
+                        'type': param[1],
+                        'subtype': param[2],
+                        'required': param[1] == 'df_name',
+                        'name': param_name
+                }
 
-        map_tuple_to_param_data = lambda param: {
-                'initial_value': param[0],
-                'type': param[1],
-                'subtype': param[2]
-        }
-
-        # First, get the original arguments to the mitosheet - we only let you parameterize df names for now
-        for arg in steps_manager.original_args_raw_strings:
-                if not is_string_arg_to_mitosheet_call(arg):
-                        all_parameterizable_params.append(map_tuple_to_param_data(arg)) # type: ignore
-    
-        # Get optimized code chunk, and get their parameterizable params
-        code_chunks = get_code_chunks(steps_manager.steps_including_skipped[:steps_manager.curr_step_idx + 1], optimize=True)
-
-        for code_chunk in code_chunks:
-                parameterizable_params = code_chunk.get_parameterizable_params()
-                all_parameterizable_params.extend(map(map_tuple_to_param_data, parameterizable_params))
-
-        return all_parameterizable_params
+        return list(map(map_tuple_to_param_data, zip(all_parameterizable_params, param_names)))

--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -7,9 +7,8 @@
 import json
 from typing import Any, Dict, List, Tuple
 from mitosheet.code_chunks.code_chunk_utils import get_code_chunks
-from mitosheet.types import ParamSubtype, ParamType, ParamValue, StepsManagerType
+from mitosheet.types import ParamSubtype, ParamType, ParamValue, StepsManagerType, ParamData
 from mitosheet.updates.args_update import is_string_arg_to_mitosheet_call
-
 
 def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManagerType) -> List[Tuple[ParamValue, ParamType, ParamSubtype]]:
 
@@ -26,5 +25,29 @@ def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManag
         for code_chunk in code_chunks:
                 parameterizable_params = code_chunk.get_parameterizable_params()
                 all_parameterizable_params.extend(parameterizable_params)
+
+        return all_parameterizable_params
+
+def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List[ParamData]:
+
+        all_parameterizable_params: List[ParamData] = []
+
+        map_tuple_to_param_data = lambda param: {
+                'initial_value': param[0],
+                'type': param[1],
+                'subtype': param[2]
+        }
+
+        # First, get the original arguments to the mitosheet - we only let you parameterize df names for now
+        for arg in steps_manager.original_args_raw_strings:
+                if not is_string_arg_to_mitosheet_call(arg):
+                        all_parameterizable_params.append(map_tuple_to_param_data(arg)) # type: ignore
+    
+        # Get optimized code chunk, and get their parameterizable params
+        code_chunks = get_code_chunks(steps_manager.steps_including_skipped[:steps_manager.curr_step_idx + 1], optimize=True)
+
+        for code_chunk in code_chunks:
+                parameterizable_params = code_chunk.get_parameterizable_params()
+                all_parameterizable_params.extend(map(map_tuple_to_param_data, parameterizable_params))
 
         return all_parameterizable_params

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -29,7 +29,7 @@ from mitosheet.saved_analyses import write_analysis
 from mitosheet.steps_manager import StepsManager
 from mitosheet.telemetry.telemetry_utils import (log, log_event_processed,
                                                  telemetry_turned_on)
-from mitosheet.types import CodeOptions, MitoTheme, ParamData
+from mitosheet.types import CodeOptions, MitoTheme, ParamMetadata
 from mitosheet.updates.replay_analysis import REPLAY_ANALYSIS_UPDATE
 from mitosheet.user import is_local_deployment
 from mitosheet.user.create import try_create_user_json_file

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -29,7 +29,7 @@ from mitosheet.saved_analyses import write_analysis
 from mitosheet.steps_manager import StepsManager
 from mitosheet.telemetry.telemetry_utils import (log, log_event_processed,
                                                  telemetry_turned_on)
-from mitosheet.types import CodeOptions, MitoTheme
+from mitosheet.types import CodeOptions, MitoTheme, ParamData
 from mitosheet.updates.replay_analysis import REPLAY_ANALYSIS_UPDATE
 from mitosheet.user import is_local_deployment
 from mitosheet.user.create import try_create_user_json_file
@@ -42,6 +42,7 @@ from mitosheet.user.utils import get_pandas_version, is_enterprise, is_pro, is_r
 from mitosheet.utils import get_new_id
 from mitosheet.transpiler.transpile_utils import get_script_as_function
 from mitosheet.transpiler.transpile import transpile
+from mitosheet.api.get_parameterizable_params import get_parameterizable_params_metadata
 from mitosheet.step_performers.utils.user_defined_functionality import get_functions_from_path, get_non_validated_custom_sheet_functions
 from mitosheet.api.get_validate_snowflake_credentials import get_cached_snowflake_credentials
 
@@ -133,6 +134,10 @@ class MitoBackend():
             'all',
             False
         ))
+
+    @property
+    def param_metadata(self) -> str:
+        return get_parameterizable_params_metadata(self.steps_manager)
 
     @property
     def analysis_name(self):

--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -136,7 +136,7 @@ class MitoBackend():
         ))
 
     @property
-    def param_metadata(self) -> str:
+    def param_metadata(self) -> List[ParamMetadata]:
         return get_parameterizable_params_metadata(self.steps_manager)
 
     @property

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -618,6 +618,33 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
         f"{TAB}return import_dataframe_0, txt, Sheet1",
         "",
     ])
+    assert mito.mito_backend.param_metadata == [
+        {
+            'initial_value': 't',
+            'type': 'e',
+            'subtype': 's'
+        },
+        {
+            'initial_value': f"r'{tmp_file1}'",
+            'type': 'file_name',
+            'subtype': 'file_name_import_csv'
+        },
+        {
+            'initial_value': f"r'{tmp_file2}'",
+            'type': 'file_name',
+            'subtype': 'file_name_import_excel'
+        },
+        {
+            'initial_value': f"r'{tmp_exportfile1}'",
+            'type': 'file_name',
+            'subtype': 'file_name_export_csv'
+        },
+        {
+            'initial_value': f"r'{tmp_exportfile2}'",
+            'type': 'file_name',
+            'subtype': 'file_name_export_excel'
+        }
+    ]
 
 def test_transpile_as_function_multiple_params(tmp_path):
     tmp_file1 = str(tmp_path / 'txt.csv')

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -620,29 +620,39 @@ def test_transpile_fully_parameterized_function_string(tmp_path):
     ])
     assert mito.mito_backend.param_metadata == [
         {
-            'initial_value': 't',
-            'type': 'e',
-            'subtype': 's'
+            'initial_value': 'test_df_name',
+            'type': 'df_name',
+            'subtype': 'import_dataframe',
+            'required': True,
+            'name': 'import_dataframe_0'
         },
         {
             'initial_value': f"r'{tmp_file1}'",
             'type': 'file_name',
-            'subtype': 'file_name_import_csv'
+            'subtype': 'file_name_import_csv',
+            'name': 'file_name_import_csv_0',
+            'required': False
         },
         {
             'initial_value': f"r'{tmp_file2}'",
             'type': 'file_name',
-            'subtype': 'file_name_import_excel'
+            'subtype': 'file_name_import_excel',
+            'name': 'file_name_import_excel_0',
+            'required': False
         },
         {
             'initial_value': f"r'{tmp_exportfile1}'",
             'type': 'file_name',
-            'subtype': 'file_name_export_csv'
+            'subtype': 'file_name_export_csv',
+            'name': 'file_name_export_csv_0',
+            'required': False
         },
         {
             'initial_value': f"r'{tmp_exportfile2}'",
             'type': 'file_name',
-            'subtype': 'file_name_export_excel'
+            'subtype': 'file_name_export_excel',
+            'name': 'file_name_export_excel_0',
+            'required': False
         }
     ]
 

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -7,7 +7,7 @@
 from copy import copy
 import inspect
 import re
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, OrderedDict, Set, Tuple, Union
 
 import pandas as pd
 import numpy as np
@@ -212,7 +212,7 @@ def replace_newlines_with_newline_and_tab(text: str) -> str:
 def get_final_function_params_with_subtypes_turned_to_parameters(
         steps_manager: StepsManagerType, 
         function_params: CodeOptionsFunctionParams # type: ignore
-    ) -> Dict[ParamName, ParamValue]:
+    ) -> OrderedDict[ParamName, ParamValue]:
     """
     It's often useful in Streamlit dashboards to allow app creators to specify things like: 
     1. Turn all of the imported CSV files into parameters
@@ -221,7 +221,7 @@ def get_final_function_params_with_subtypes_turned_to_parameters(
     As such, we let users specify the subtype they want to generate params for.
     """
     if isinstance(function_params, str) or isinstance(function_params, list):
-        final_params = {}
+        final_params: OrderedDict[ParamName, ParamValue] = OrderedDict()
 
         from mitosheet.api.get_parameterizable_params import get_parameterizable_params
         parameterizable_params = get_parameterizable_params({}, steps_manager)
@@ -347,6 +347,6 @@ def get_default_code_options(analysis_name: str) -> CodeOptions:
         'as_function': False,
         'call_function': True,
         'function_name': 'function_' + analysis_name[-4:], # Give it a random name, just so we don't overwrite them
-        'function_params': dict(),
+        'function_params': OrderedDict(),
         'import_custom_python_code': False
     }

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -7,7 +7,8 @@
 from copy import copy
 import inspect
 import re
-from typing import Any, Dict, List, Optional, OrderedDict, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from collections import OrderedDict
 
 import pandas as pd
 import numpy as np

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -213,7 +213,7 @@ def replace_newlines_with_newline_and_tab(text: str) -> str:
 def get_final_function_params_with_subtypes_turned_to_parameters(
         steps_manager: StepsManagerType, 
         function_params: CodeOptionsFunctionParams # type: ignore
-    ) -> OrderedDict[ParamName, ParamValue]:
+    ) -> OrderedDict:
     """
     It's often useful in Streamlit dashboards to allow app creators to specify things like: 
     1. Turn all of the imported CSV files into parameters
@@ -222,7 +222,7 @@ def get_final_function_params_with_subtypes_turned_to_parameters(
     As such, we let users specify the subtype they want to generate params for.
     """
     if isinstance(function_params, str) or isinstance(function_params, list):
-        final_params: OrderedDict[ParamName, ParamValue] = OrderedDict()
+        final_params = OrderedDict()
 
         from mitosheet.api.get_parameterizable_params import get_parameterizable_params
         parameterizable_params = get_parameterizable_params({}, steps_manager)

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -354,7 +354,7 @@ if sys.version_info[:3] > (3, 8, 0):
         name: str
         original_value: Optional[str]
 
-    CodeOptionsFunctionParams = Union[OrderedDict[ParamName, ParamValue], ParamSubtype, List[ParamSubtype]]
+    CodeOptionsFunctionParams = Union[OrderedDict, ParamSubtype, List[ParamSubtype]]
 
     class CodeOptions(TypedDict):
         as_function: bool

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -346,7 +346,7 @@ if sys.version_info[:3] > (3, 8, 0):
 
     # For streamlit applications, when we want to display the parameters to the user, 
     # we need to know various metadata about the parameter
-    class ParamData(TypedDict):
+    class ParamMetadata(TypedDict):
         type: ParamType
         subtype: ParamSubtype
         required: bool

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -344,6 +344,8 @@ if sys.version_info[:3] > (3, 8, 0):
     ]
     ParamValue = str
 
+    # For streamlit applications, when we want to display the parameters to the user, 
+    # we need to know various metadata about the parameter
     class ParamData(TypedDict):
         type: ParamType
         subtype: ParamSubtype

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -14,7 +14,7 @@ continous integration
 
 import pandas as pd
 import numpy as np
-from typing import TYPE_CHECKING, Dict, List, Optional, OrderedDict, Union, Tuple, Any
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple, Any
 
 GraphID = str
 ColumnID = str
@@ -127,7 +127,7 @@ FC_DATETIME_LESS_THAN_OR_EQUAL = "datetime_less_than_or_equal"
 
 import sys
 if sys.version_info[:3] > (3, 8, 0):
-    from typing import TypedDict, Literal
+    from typing import TypedDict, Literal, OrderedDict
 
 
     BooleanFilterCondition = Literal[

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -14,7 +14,7 @@ continous integration
 
 import pandas as pd
 import numpy as np
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple, Any
+from typing import TYPE_CHECKING, Dict, List, Optional, OrderedDict, Union, Tuple, Any
 
 GraphID = str
 ColumnID = str
@@ -353,7 +353,7 @@ if sys.version_info[:3] > (3, 8, 0):
         name: str
         original_value: Optional[str]
 
-    CodeOptionsFunctionParams = Union[Dict[ParamName, ParamValue], ParamSubtype, List[ParamSubtype]]
+    CodeOptionsFunctionParams = Union[OrderedDict[ParamName, ParamValue], ParamSubtype, List[ParamSubtype]]
 
     class CodeOptions(TypedDict):
         as_function: bool

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -344,6 +344,11 @@ if sys.version_info[:3] > (3, 8, 0):
     ]
     ParamValue = str
 
+    class ParamData(TypedDict):
+        type: ParamType
+        subtype: ParamSubtype
+        original_value: str
+
     CodeOptionsFunctionParams = Union[Dict[ParamName, ParamValue], ParamSubtype, List[ParamSubtype]]
 
     class CodeOptions(TypedDict):

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -15,6 +15,7 @@ continous integration
 import pandas as pd
 import numpy as np
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Tuple, Any
+from collections import OrderedDict
 
 GraphID = str
 ColumnID = str
@@ -127,7 +128,7 @@ FC_DATETIME_LESS_THAN_OR_EQUAL = "datetime_less_than_or_equal"
 
 import sys
 if sys.version_info[:3] > (3, 8, 0):
-    from typing import TypedDict, Literal, OrderedDict
+    from typing import TypedDict, Literal
 
 
     BooleanFilterCondition = Literal[

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -347,7 +347,9 @@ if sys.version_info[:3] > (3, 8, 0):
     class ParamData(TypedDict):
         type: ParamType
         subtype: ParamSubtype
-        original_value: str
+        required: bool
+        name: str
+        original_value: Optional[str]
 
     CodeOptionsFunctionParams = Union[Dict[ParamName, ParamValue], ParamSubtype, List[ParamSubtype]]
 

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -423,6 +423,7 @@ else:
     ParamType = str # type: ignore
     ParamSubtype = str # type: ignore
     ParamValue = str # type: ignore
+    ParamMetadata = Any # type: ignore
 
     CodeOptionsFunctionParams = Any # type: ignore
 


### PR DESCRIPTION
# Description
Adds a `ParamData` type. Adds a `mito_backend.param_metadata` property. 

# Testing
Adds a test with the `fully_parameterized_function_string` tests to check that the expected params show up in the `param_metadata` as well. 
