### PR TITLE
Add MitoAnalysis class

### DIFF
--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -11,5 +11,5 @@ def ADD_ONE():
 
 
 df = pd.DataFrame({'A': [1, 2, 3]})
-selection = spreadsheet(df, return_type='selection')
-st.write(selection)
+analysis = spreadsheet(df, return_type='analysis')
+st.write(analysis)

--- a/mitosheet/mitosheet/streamlit/v1/__init__.py
+++ b/mitosheet/mitosheet/streamlit/v1/__init__.py
@@ -1,1 +1,1 @@
-from mitosheet.streamlit.v1.spreadsheet import spreadsheet
+from mitosheet.streamlit.v1.spreadsheet import spreadsheet, MitoAnalysis

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -115,8 +115,8 @@ class MitoAnalysis:
     code: str
     code_options: CodeOptions
     def __init__(self, code, code_options, fully_parameterized_code, param_metadata):
-        self.code = code
-        self.code_options = code_options
+        self.__code = code
+        self.__code_options = code_options
         self.__fully_parameterized_code: str = fully_parameterized_code
         self.__param_metadata: List[ParamMetadata] = param_metadata
 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -112,7 +112,7 @@ def get_function_from_code_unsafe(code: str) -> Optional[Callable]:
 # It contains data that could be relevant to the streamlit developer, and is 
 # used for replaying analyses. 
 class MitoAnalysis:
-    def __init__(self, code: str, code_options: CodeOptions | None, fully_parameterized_code: str, param_metadata: List[ParamMetadata]):
+    def __init__(self, code: str, code_options: Optional[CodeOptions], fully_parameterized_code: str, param_metadata: List[ParamMetadata]):
         self.__code = code
         self.__code_options = code_options
         self.__fully_parameterized_code = fully_parameterized_code

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -112,13 +112,11 @@ def get_function_from_code_unsafe(code: str) -> Optional[Callable]:
 # It contains data that could be relevant to the streamlit developer, and is 
 # used for replaying analyses. 
 class MitoAnalysis:
-    code: str
-    code_options: CodeOptions
-    def __init__(self, code, code_options, fully_parameterized_code, param_metadata):
+    def __init__(self, code: str, code_options: CodeOptions | None, fully_parameterized_code: str, param_metadata: List[ParamMetadata]):
         self.__code = code
         self.__code_options = code_options
-        self.__fully_parameterized_code: str = fully_parameterized_code
-        self.__param_metadata: List[ParamMetadata] = param_metadata
+        self.__fully_parameterized_code = fully_parameterized_code
+        self.__param_metadata = param_metadata
 
 try:
     import streamlit.components.v1 as components

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from mitosheet.mito_backend import MitoBackend
 from mitosheet.selectionUtils import get_selected_element
-from mitosheet.types import CodeOptions
+from mitosheet.types import CodeOptions, ParamMetadata
 from mitosheet.utils import get_new_id
 
 def _get_dataframe_hash(df: pd.DataFrame) -> bytes:
@@ -108,6 +108,17 @@ def get_function_from_code_unsafe(code: str) -> Optional[Callable]:
         
     raise ValueError(f'No functions defined in code: {code}')
 
+# This is the class that is returned when the user sets return_type='analysis'
+# It contains data that could be relevant to the streamlit developer, and is 
+# used for replaying analyses. 
+class MitoAnalysis:
+    code: str
+    code_options: CodeOptions
+    def __init__(self, code, code_options, fully_parameterized_code, param_metadata):
+        self.code = code
+        self.code_options = code_options
+        self.__fully_parameterized_code: str = fully_parameterized_code
+        self.__param_metadata: List[ParamMetadata] = param_metadata
 
 try:
     import streamlit.components.v1 as components
@@ -311,6 +322,8 @@ try:
                 raise ValueError(f"""You must set code_options with `as_function=True` and `call_function=False` in order to return a function.""")
             
             return get_function_from_code_unsafe(code)
+        elif return_type == 'analysis':
+            return MitoAnalysis(code, code_options, mito_backend.fully_parameterized_function, mito_backend.param_metadata)
         else:
             raise ValueError(f'Invalid value for return_type={return_type}. Must be "default", "default_list", "dfs", "code", "dfs_list", or "function".')
 

--- a/mitosheet/mitosheet/tests/streamlit/test_streamlit.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_streamlit.py
@@ -62,7 +62,7 @@ SPREADSHEET_PARAMS = [
         'return type of analysis',
         [df1], {'return_type': 'analysis'},
         (
-            MitoAnalysis('', {}, '', [])
+            MitoAnalysis('', None, '', [])
         )
     )
 ]

--- a/mitosheet/mitosheet/tests/streamlit/test_streamlit.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_streamlit.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import os
 import pandas as pd
 import pytest
-from mitosheet.streamlit.v1 import spreadsheet
+from mitosheet.streamlit.v1 import spreadsheet, MitoAnalysis
 from mitosheet.tests.decorators import requires_streamlit
 
 df1 = pd.DataFrame({'A': [123]})
@@ -58,6 +58,13 @@ SPREADSHEET_PARAMS = [
             [df1]
         )
     ),
+    (
+        'return type of analysis',
+        [df1], {'return_type': 'analysis'},
+        (
+            MitoAnalysis('', {}, '', [])
+        )
+    )
 ]
 
 @pytest.mark.parametrize('test, args, kwargs, expected', SPREADSHEET_PARAMS)
@@ -84,6 +91,8 @@ def test_creates_spreadsheet(test, args, kwargs, expected):
         assert len(result) == len(expected)
         for k in result:
             assert result[k].equals(expected[k])
+    elif isinstance(result, MitoAnalysis):
+        assert isinstance(expected, MitoAnalysis)
     else:
         assert result == expected
 


### PR DESCRIPTION
# Description
Adds a class that can be used by streamlit developers to store / access information about an analysis. 

# Testing
Updated the `streamlit.py` file to show usage. 

# Documentation
We should add documentation once we add some more functionality into this class. 