### PR TITLE
mitohseet: make vlookup case insensitive

### DIFF
--- a/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
@@ -214,11 +214,11 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
         )
 
     # If the series is a string, convert it to lowercase because Excel's vlookup is case insensitive
-    if is_string_dtype(value.dtype):
+    if is_string_dtype(str(value.dtype)):
         value = value.str.lower()
         where_first_column_case_insensitive = where_first_column_case_insensitive.str.lower()
 
-    # Add the where_first_column_case_insensitive to the front of the dataframe so we can use the case insensitive merge 
+    # Add where_first_column_case_insensitive to the front of the dataframe so we can use the case insensitive merge 
     # without effecting the return values
     where = pd.concat([where_first_column_case_insensitive, where], axis=1)
     indices_to_return_from_range = indices_to_return_from_range + 1

--- a/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
@@ -178,7 +178,9 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
         ]
     }
     """
-    where_first_column = where.iloc[:,0]
+    where_first_column_case_insensitive = where.iloc[:,0].copy()
+    where_first_column_case_insensitive.name = str(where_first_column_case_insensitive.name) + 'MITO_CASE_INSENSITIVE'
+
     # If the lookup value and index are both a primitive, we don't need to merge. 
     if not isinstance(lookup_value, pd.Series) and isinstance(index, int):
         if type(lookup_value) != type(where.iloc[0,0]):
@@ -187,7 +189,13 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
                 'VLOOKUP',
                 f'VLOOKUP requires the lookup value and the first column of the where range to be the same type. The lookup value is of type {type(lookup_value)} and the first column of the where range is of type {type(where.iloc[0,0])}.'
             )
-        matching_row = where.loc[where_first_column == lookup_value]
+
+        # If the lookup value and the first column are strings, make them lowecase for case-insensitive matching
+        if isinstance(lookup_value, str) and isinstance(where.iloc[0,0], str):
+            lookup_value = lookup_value.lower()
+            where_first_column_case_insensitive = where_first_column_case_insensitive.str.lower()
+
+        matching_row = where.loc[where_first_column_case_insensitive == lookup_value]
         if matching_row.empty:
             return None
         else:
@@ -195,26 +203,37 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
     
     value = get_series_from_primitive_or_series(lookup_value, where.index)
     value.name = 'lookup_value'
-    indices = get_series_from_primitive_or_series(index, value.index)
-
-    # Then we want to do a merge on the column we're looking up from, and the df we're looking up in.
-    where_deduplicated = where.drop_duplicates(subset=where_first_column.name)
-    
-    # Update first column to use the deduplicated version
-    where_first_column = where_deduplicated.iloc[:,0]
+    indices_to_return_from_range = get_series_from_primitive_or_series(index, value.index)
 
     # If the lookup value and the first column of the where range are different types, we raise an error
-    if value.dtype != where_first_column.dtype:
+    if value.dtype != where_first_column_case_insensitive.dtype:
         raise MitoError(
             'invalid_args_error',
             'VLOOKUP',
-            f'VLOOKUP requires the lookup value and the first column of the where range to be the same type. The lookup value is of type {value.dtype} and the first column of the where range is of type {where_first_column.dtype}.'
+            f'VLOOKUP requires the lookup value and the first column of the where range to be the same type. The lookup value is of type {value.dtype} and the first column of the where range is of type {where_first_column_case_insensitive.dtype}.'
         )
+
+    # If the series is a string, convert it to lowercase because Excel's vlookup is case insensitive
+    if is_string_dtype(value.dtype):
+        value = value.str.lower()
+        where_first_column_case_insensitive = where_first_column_case_insensitive.str.lower()
+
+    # Add the where_first_column_copy to the front of the dataframe so we can use the case insensitive merge 
+    # without effecting the return values
+    where = pd.concat([where_first_column_case_insensitive, where], axis=1)
+    indices_to_return_from_range = indices_to_return_from_range + 1
+
+    where_deduplicated = where.drop_duplicates(subset=where_first_column_case_insensitive.name)
     
+    # Update first column to use the deduplicated version
+    where_first_column = where_deduplicated.iloc[:,0]
+    
+    # Then merge on the column we're looking up from, and the df we're looking up in.
     merged = pd.merge(value, where_deduplicated, left_on='lookup_value', right_on=where_first_column, how='left')
+
     def get_value_at_index_in_row(row):
         try:
-            return row.iloc[indices[row.name]]
+            return row.iloc[indices_to_return_from_range[row.name]]
         # Because we can't control what the user puts in the index, we need to catch any errors
         except Exception:
             return None

--- a/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
@@ -218,7 +218,7 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
         value = value.str.lower()
         where_first_column_case_insensitive = where_first_column_case_insensitive.str.lower()
 
-    # Add the where_first_column_copy to the front of the dataframe so we can use the case insensitive merge 
+    # Add the where_first_column_case_insensitive to the front of the dataframe so we can use the case insensitive merge 
     # without effecting the return values
     where = pd.concat([where_first_column_case_insensitive, where], axis=1)
     indices_to_return_from_range = indices_to_return_from_range + 1

--- a/mitosheet/mitosheet/tests/public/v3/sheet_functions/misc_functions/test_vlookup.py
+++ b/mitosheet/mitosheet/tests/public/v3/sheet_functions/misc_functions/test_vlookup.py
@@ -41,6 +41,24 @@ VLOOKUP_VALID_TESTS = [
         ],
         'e'
     ),
+    # Tests for when the lookup value is a primitive, case insensitive
+    (
+        [
+            'A',
+            pd.DataFrame({0: ['c', 'a', 'b'], 1: ['d', 'e', 'f'], 2: ['h', 'i', 'j']}),
+            2
+        ],
+        'e'
+    ),
+    # Tests for when the lookup value is a primitive, case insensitive
+    (
+        [
+            'a',
+            pd.DataFrame({0: ['C', 'A', 'B'], 1: ['d', 'e', 'f'], 2: ['h', 'i', 'j']}),
+            2
+        ],
+        'e'
+    ),
     # Tests for when the index argument is a series
     (
         [
@@ -117,13 +135,51 @@ VLOOKUP_VALID_TESTS = [
         ],
         pd.Series([None, 'c', 'b'])
     ),
+    # Vlookup only returns first match
+    (
+        [
+            pd.Series(['A', 'A']),
+            pd.DataFrame({'Series to Look in': ['A', 'A'], 'Value to return': ['Match1', 'Match2']}),
+            2
+        ],
+        pd.Series(['Match1', 'Match1'])
+    ),
+    # Vlookup is case insensitive
+    (
+        [
+            pd.Series(['A', 'a']),
+            pd.DataFrame({'Series to Look in': ['a', 'A'], 'Value to return': ['Match1', 'Match2']}),
+            2
+        ],
+        pd.Series(['Match1', 'Match1'])
+    ),
+    # Vlookup is case insensitive, but the return value should be the original case
+    (
+        [
+            pd.Series(['A']),
+            pd.DataFrame({'Series to Look in': ['a']}),
+            1
+        ],
+        pd.Series(['a'])
+    ),
+    # Vlookup is case insensitive, but the return value should be the original case
+    (
+        [
+            pd.Series(['a']),
+            pd.DataFrame({'Series to Look in': ['A']}),
+            1
+        ],
+        pd.Series(['A'])
+    ),
 ]
 
 @pytest.mark.parametrize("_argv, expected", VLOOKUP_VALID_TESTS)
 def test_vlookup_direct(_argv, expected):
     result = VLOOKUP(*_argv)
+    print(result)
+    print(expected)
     if isinstance(result, pd.Series):
-        pd.testing.assert_series_equal(result,expected, check_names=False, check_series_type=False, check_dtype=False)
+        pd.testing.assert_series_equal(result, expected, check_names=False, check_series_type=False, check_dtype=False)
     else: 
         assert result == expected
 

--- a/mitosheet/mitosheet/tests/public/v3/sheet_functions/misc_functions/test_vlookup.py
+++ b/mitosheet/mitosheet/tests/public/v3/sheet_functions/misc_functions/test_vlookup.py
@@ -171,13 +171,29 @@ VLOOKUP_VALID_TESTS = [
         ],
         pd.Series(['A'])
     ),
+    # Vlookup is case insensitive, with a non-standard index
+    (
+        [
+            pd.Series(['a', 'b', 'a'], index=['i', 'j', 'k']),
+            pd.DataFrame({'A': ['a', 'b'], 'B': ['Match1', 'Match2']}, index=[10, 11]),
+            2
+        ],
+        pd.Series(['Match1', 'Match2', 'Match1'])
+    ),
+    # No matches
+    (
+        [
+            pd.Series(['C']),
+            pd.DataFrame({'Series to Look in': ['A']}),
+            1
+        ],
+        pd.Series([None])
+    ),
 ]
 
 @pytest.mark.parametrize("_argv, expected", VLOOKUP_VALID_TESTS)
 def test_vlookup_direct(_argv, expected):
     result = VLOOKUP(*_argv)
-    print(result)
-    print(expected)
     if isinstance(result, pd.Series):
         pd.testing.assert_series_equal(result, expected, check_names=False, check_series_type=False, check_dtype=False)
     else: 


### PR DESCRIPTION
# Description

Excel's VLOOKUP is case insensitive, even if exact match is turned on. Matching this behavior is important! 

This PR makes our VLOOKUP formula case insensitive as well. 

<img width="636" alt="Screenshot 2023-10-17 at 12 48 15 PM" src="https://github.com/mito-ds/mito/assets/18709905/de73172c-213c-4eff-84cd-e7b8e738c92c">

# Testing

See tests

# Documentation

No. 