### PR TITLE
Add to_json and from_json to MitoAnalysis

### DIFF
--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -132,6 +132,10 @@ class MitoAnalysis:
     def param_metadata(self) -> List[ParamMetadata]:
         return self.__param_metadata
     
+    @property
+    def fully_parameterized_function(self) -> str:
+        return self.__fully_parameterized_function
+    
     def to_json(self) -> str:
         return json.dumps({
             'code': self.__code,

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -122,6 +122,28 @@ class MitoAnalysis:
     def param_metadata(self) -> List[ParamMetadata]:
         return self.__param_metadata
     
+    def to_json(self) -> str:
+        return json.dumps({
+            'code': self.__code,
+            'code_options': self.__code_options,
+            'fully_parameterized_function': self.__fully_parameterized_function,
+            'param_metadata': self.__param_metadata
+        })
+    
+    @staticmethod
+    def from_json(json_str: str) -> 'MitoAnalysis':
+        json_dict = json.loads(json_str)
+        required_keys = ['code', 'code_options', 'fully_parameterized_function', 'param_metadata']
+        for key in required_keys:
+            if key not in json_dict:
+                raise ValueError(f'Invalid json_str passed to MitoAnalysis.from_json. Missing key {key}.')
+        return MitoAnalysis(
+            json_dict['code'],
+            json_dict['code_options'],
+            json_dict['fully_parameterized_function'],
+            json_dict['param_metadata']
+        )
+    
     def run(self, *args, **kwargs):
         params = {}
 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -16,6 +16,8 @@ from mitosheet.selectionUtils import get_selected_element
 from mitosheet.types import CodeOptions, ParamMetadata
 from mitosheet.utils import get_new_id
 
+CURRENT_MITO_ANALYSIS_VERSION = 1
+
 def _get_dataframe_hash(df: pd.DataFrame) -> bytes:
     """
     Returns a hash for a pandas dataframe that is consistent across runs, notably including:
@@ -112,11 +114,19 @@ def get_function_from_code_unsafe(code: str) -> Optional[Callable]:
 # It contains data that could be relevant to the streamlit developer, and is 
 # used for replaying analyses. 
 class MitoAnalysis:
-    def __init__(self, code: str, code_options: Optional[CodeOptions], fully_parameterized_function: str, param_metadata: List[ParamMetadata]):
+    def __init__(
+            self,
+            code: str,
+            code_options: Optional[CodeOptions],
+            fully_parameterized_function: str,
+            param_metadata: List[ParamMetadata],
+            mito_analysis_version: int=CURRENT_MITO_ANALYSIS_VERSION
+        ):
         self.__code = code
         self.__code_options = code_options
         self.__fully_parameterized_function = fully_parameterized_function
         self.__param_metadata = param_metadata
+        self.mito_analysis_version = mito_analysis_version
         
     @property
     def param_metadata(self) -> List[ParamMetadata]:
@@ -127,7 +137,8 @@ class MitoAnalysis:
             'code': self.__code,
             'code_options': self.__code_options,
             'fully_parameterized_function': self.__fully_parameterized_function,
-            'param_metadata': self.__param_metadata
+            'param_metadata': self.__param_metadata,
+            'mito_analysis_version': self.mito_analysis_version
         })
     
     @staticmethod
@@ -141,7 +152,8 @@ class MitoAnalysis:
             json_dict['code'],
             json_dict['code_options'],
             json_dict['fully_parameterized_function'],
-            json_dict['param_metadata']
+            json_dict['param_metadata'],
+            mito_analysis_version=json_dict['mito_analysis_version']
         )
     
     def run(self, *args, **kwargs):

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -371,6 +371,6 @@ def test_to_and_from_json():
     assert new_analysis.param_metadata == simple_param_metadata
     
     df = pd.DataFrame({'A': [1], 'B': [2]})
-    result = analysis.run(df)
+    result = new_analysis.run(df)
     assert result is not None
     pd.testing.assert_frame_equal(result, df)

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -374,3 +374,31 @@ def test_to_and_from_json():
     result = new_analysis.run(df)
     assert result is not None
     pd.testing.assert_frame_equal(result, df)
+
+@requires_streamlit
+def test_to_and_from_json_special_characters():
+    special_characters_fn = """from mitosheet.public.v3 import *
+import pandas as pd
+
+def function(vari\abl"e_name{}):
+    return vari\abl"e_name{}
+"""
+    special_characters_metadata = [
+    {
+        'initial_value': 'test_df_name',
+        'type': 'df_name',
+        'subtype': 'import_dataframe',
+        'required': True,
+        'name': 'vari\ abl"e_name{}'
+    },
+]
+    analysis = MitoAnalysis('', None, special_characters_fn, special_characters_metadata)
+    # Test that the to_json function 
+    json = analysis.to_json()
+    assert json is not None
+
+    # Test that the from_json function works
+    new_analysis = MitoAnalysis.from_json(json)
+    assert new_analysis is not None
+    assert new_analysis.param_metadata == special_characters_metadata
+    assert new_analysis.fully_parameterized_function == special_characters_fn

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -363,7 +363,7 @@ def test_to_and_from_json():
     # Test that the to_json function 
     json = analysis.to_json()
     assert json is not None
-    assert json == r'{"code": "", "code_options": null, "fully_parameterized_function": "from mitosheet.public.v3 import *\nimport pandas as pd\n\ndef function(import_dataframe_0):\n    return import_dataframe_0\n", "param_metadata": [{"initial_value": "test_df_name", "type": "df_name", "subtype": "import_dataframe", "required": true, "name": "import_dataframe_0"}]}'
+    assert json == r'{"code": "", "code_options": null, "fully_parameterized_function": "from mitosheet.public.v3 import *\nimport pandas as pd\n\ndef function(import_dataframe_0):\n    return import_dataframe_0\n", "param_metadata": [{"initial_value": "test_df_name", "type": "df_name", "subtype": "import_dataframe", "required": true, "name": "import_dataframe_0"}], "mito_analysis_version": 1}'
 
     # Test that the from_json function works
     new_analysis = MitoAnalysis.from_json(json)


### PR DESCRIPTION
# Description
Adds a `to_json` and `from_json` method to the `MitoAnalysis` class for easier storage of the class in files. 

# Testing
Added basic test in `test_mito_analysis.py`. 

# Documentation
This should be added with the documentation for streamlit. 