### PR TITLE
Add get_param_metadata to MitoAnalysis class

### DIFF
--- a/mitosheet/mitosheet/api/get_parameterizable_params.py
+++ b/mitosheet/mitosheet/api/get_parameterizable_params.py
@@ -18,7 +18,7 @@ def get_parameterizable_params(params: Dict[str, Any], steps_manager: StepsManag
         # First, get the original arguments to the mitosheet - we only let you parameterize df names for now
         for arg in steps_manager.original_args_raw_strings:
                 if not is_string_arg_to_mitosheet_call(arg):
-                        all_parameterizable_params.append((arg, 'df_name', "import_dataframe")) # type: ignore
+                        all_parameterizable_params.append((arg, 'import', "import_dataframe")) # type: ignore
     
         # Get optimized code chunk, and get their parameterizable params
         code_chunks = get_code_chunks(steps_manager.steps_including_skipped[:steps_manager.curr_step_idx + 1], optimize=True)
@@ -50,7 +50,7 @@ def get_parameterizable_params_metadata(steps_manager: StepsManagerType) -> List
                         'subtype': param[2],
                         # If the param is a df_name, then it is required for the function
                         # because we won't be able to store the initial value in the MitoAnalysis for streamlit.
-                        'required': param[1] == 'df_name',
+                        'required': param[2] == 'import_dataframe',
                         'name': param_name
                 }
 

--- a/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/export_to_file_code_chunk.py
@@ -88,9 +88,9 @@ class ExportToFileCodeChunk(CodeChunk):
     def get_parameterizable_params(self) -> List[Tuple[ParamValue, ParamType, ParamSubtype]]:
         if self.export_type == 'csv':
             return [
-                (f"r{get_column_header_as_transpiled_code(export_location)}", 'file_name', 'file_name_export_csv') for export_location in self.sheet_index_to_export_location.values()
+                (f"r{get_column_header_as_transpiled_code(export_location)}", 'export', 'file_name_export_csv') for export_location in self.sheet_index_to_export_location.values()
             ]
         elif self.export_type == 'excel':
-            return [(f"r{get_column_header_as_transpiled_code(self.file_name)}", 'file_name', 'file_name_export_excel')]
+            return [(f"r{get_column_header_as_transpiled_code(self.file_name)}", 'export', 'file_name_export_excel')]
         else:
             raise ValueError(f'Not a valid file type: {self.export_type}')

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
@@ -60,7 +60,7 @@ class ExcelImportCodeChunk(CodeChunk):
         return [i for i in range(len(self.post_state.dfs) - len(self.sheet_names), len(self.post_state.dfs))]
     
     def get_parameterizable_params(self) -> List[Tuple[ParamValue, ParamType, ParamSubtype]]:
-        return [(f'r{get_column_header_as_transpiled_code(self.file_name)}', 'file_name', 'file_name_import_excel')]
+        return [(f'r{get_column_header_as_transpiled_code(self.file_name)}', 'import', 'file_name_import_excel')]
 
     
 def build_read_excel_params(

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_range_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_range_import_code_chunk.py
@@ -214,5 +214,5 @@ class ExcelRangeImportCodeChunk(CodeChunk):
         return None
     
     def get_parameterizable_params(self) -> List[Tuple[ParamValue, ParamType, ParamSubtype]]:
-        return [(f'r{get_column_header_as_transpiled_code(self.file_path)}', 'file_name', 'file_name_import_excel')]
+        return [(f'r{get_column_header_as_transpiled_code(self.file_path)}', 'import', 'file_name_import_excel')]
     

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -138,7 +138,7 @@ class SimpleImportCodeChunk(CodeChunk):
         return list(
             zip(
                 map(lambda x: f"r{get_column_header_as_transpiled_code(x)}", self.file_names), 
-                ['file_name'] * len(self.file_names),
+                ['import'] * len(self.file_names),
                 ['file_name_import_csv'] * len(self.file_names),
             )
         )

--- a/mitosheet/mitosheet/steps_manager.py
+++ b/mitosheet/mitosheet/steps_manager.py
@@ -231,8 +231,10 @@ class StepsManager:
         for index, arg in enumerate(self.original_args):
             if isinstance(arg, str):
                 self.original_args_raw_strings.append(f'"{arg}"')
-            else:
+            elif df_names is not None and len(df_names) > index:
                 self.original_args_raw_strings.append(df_names[index])
+            else:
+                self.original_args_raw_strings.append('')
 
         # Then, we check user defined functions. Check them for validity, and wrap them in the correct wrappers,
         self.user_defined_functions = validate_and_wrap_sheet_functions(user_defined_functions) 

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -27,6 +27,7 @@ df = pd.DataFrame({ 'A': [1, 2, 3], 'B': [4, 5, 6] })
 analysis = spreadsheet(
     df,
     df_names=['df'],
+    import_folder='/Users/marthacryan/gitrepos/mito/mitosheet/datasets',
     editors=[add_number_to_df],
     importers=[get_data_from_database, do_import_with_a_really_long_name],
     return_type='analysis'

--- a/mitosheet/mitosheet/streamlit/streamlit.py
+++ b/mitosheet/mitosheet/streamlit/streamlit.py
@@ -27,7 +27,7 @@ df = pd.DataFrame({ 'A': [1, 2, 3], 'B': [4, 5, 6] })
 analysis = spreadsheet(
     df,
     df_names=['df'],
-    import_folder='/Users/marthacryan/gitrepos/mito/mitosheet/datasets',
+    import_folder='datasets',
     editors=[add_number_to_df],
     importers=[get_data_from_database, do_import_with_a_really_long_name],
     return_type='analysis'

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -118,16 +118,12 @@ class MitoAnalysis:
         self.__fully_parameterized_function = fully_parameterized_function
         self.__param_metadata = param_metadata
         
-    @property
-    def param_metadata(self) -> List[ParamMetadata]:
-        return self.__param_metadata
-    
-    def get_param_metadata(self, type: Optional[ParamType]=None):
-        if type is None:
+    def get_param_metadata(self, param_type: Optional[ParamType]=None) -> List[ParamMetadata]:
+        if param_type is None:
             return self.__param_metadata
-        if type not in ['import', 'export']:
+        if param_type not in ['import', 'export']:
             raise TypeError('Invalid args passed to get_param_metadata. Type must be "import" or "export"')
-        return [param for param in self.__param_metadata if param['type'] == type]
+        return [param for param in self.__param_metadata if param['type'] == param_type]
     
     def run(self, *args, **kwargs):
         params = {}

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from mitosheet.mito_backend import MitoBackend
 from mitosheet.selectionUtils import get_selected_element
-from mitosheet.types import CodeOptions, ParamMetadata
+from mitosheet.types import CodeOptions, ParamMetadata, ParamType
 from mitosheet.utils import get_new_id
 
 def _get_dataframe_hash(df: pd.DataFrame) -> bytes:
@@ -121,6 +121,13 @@ class MitoAnalysis:
     @property
     def param_metadata(self) -> List[ParamMetadata]:
         return self.__param_metadata
+    
+    def get_param_metadata(self, type: Optional[ParamType]=None):
+        if type is None:
+            return self.__param_metadata
+        if type not in ['import', 'export']:
+            raise TypeError('Invalid args passed to get_param_metadata. Type must be "import" or "export"')
+        return [param for param in self.__param_metadata if param['type'] == type]
     
     def run(self, *args, **kwargs):
         params = {}

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -420,7 +420,6 @@ def test_to_and_from_json():
     # Test that the from_json function works
     new_analysis = MitoAnalysis.from_json(json)
     assert new_analysis is not None
-    assert new_analysis.param_metadata == simple_param_metadata
     
     df = pd.DataFrame({'A': [1], 'B': [2]})
     result = new_analysis.run(df)
@@ -452,5 +451,4 @@ def function(vari\abl"e_name{}):
     # Test that the from_json function works
     new_analysis = MitoAnalysis.from_json(json)
     assert new_analysis is not None
-    assert new_analysis.param_metadata == special_characters_metadata
     assert new_analysis.fully_parameterized_function == special_characters_fn

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -104,28 +104,28 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     param_metadata = [
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -135,6 +135,15 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     new_export_file_0 = str(tmp_path / 'new_export.csv')
     new_export_file_1 = str(tmp_path / 'new_export.xlsx')
     analysis = MitoAnalysis('', None, fully_parameterized_function, param_metadata)
+
+    # Test that get_param_metadata works
+    assert analysis.get_param_metadata() == param_metadata
+    assert analysis.get_param_metadata(type='import') == param_metadata[:2]
+    assert analysis.get_param_metadata(type='export') == param_metadata[2:]
+
+    with pytest.raises(TypeError):
+        analysis.get_param_metadata(type='invalid')
+
     result = analysis.run(file_name_export_csv_0=new_export_file_0)
     assert result is not None
     assert os.path.exists(new_export_file_0)

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -37,28 +37,28 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     param_metadata = [
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -165,7 +165,7 @@ def function_ctqm(import_dataframe_0):
     param_metadata = [
         {
             'initial_value': 'test_df_name',
-            'type': 'df_name',
+            'type': 'import',
             'subtype': 'import_dataframe',
             'required': True,
             'name': 'import_dataframe_0'
@@ -173,6 +173,11 @@ def function_ctqm(import_dataframe_0):
     ]
 
     analysis = MitoAnalysis('', None, fully_parameterized_function, param_metadata)
+
+    assert analysis.get_param_metadata() == param_metadata
+    assert analysis.get_param_metadata('import') == param_metadata
+    assert analysis.get_param_metadata('export') == []
+
     result = analysis.run(df)
     expected_df = pd.DataFrame({'A': [1], 'Test': [0], 'B': [2]})
     assert result is not None
@@ -211,35 +216,35 @@ def function(import_dataframe_0, file_name_import_csv_0, file_name_import_excel_
     param_metadata = [
         {
             'initial_value': 'test_df_name',
-            'type': 'df_name',
+            'type': 'import',
             'subtype': 'import_dataframe',
             'required': True,
             'name': 'import_dataframe_0'
         },
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -249,6 +254,12 @@ def function(import_dataframe_0, file_name_import_csv_0, file_name_import_excel_
     new_export_file_0 = str(tmp_path / 'new_export.csv')
     new_export_file_1 = str(tmp_path / 'new_export.xlsx')
     analysis = MitoAnalysis('', None, fully_parameterized_function, param_metadata)
+
+    # Test that get_param_metadata works
+    assert analysis.get_param_metadata() == param_metadata
+    assert analysis.get_param_metadata(type='import') == param_metadata[:3]
+    assert analysis.get_param_metadata(type='export') == param_metadata[3:]
+
     new_df = pd.DataFrame({'A': [1], 'B': [2]})
     result = analysis.run(df1, file_name_export_csv_0=new_export_file_0)
     assert result is not None
@@ -292,35 +303,35 @@ def function(import_dataframe_0, file_name_import_csv_0, file_name_import_excel_
     param_metadata = [
         {
             'initial_value': 'test_df_name',
-            'type': 'df_name',
+            'type': 'import',
             'subtype': 'import_dataframe',
             'required': True,
             'name': 'import_dataframe_0'
         },
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -345,7 +356,7 @@ def function(import_dataframe_0):
     param_metadata = [
         {
             'initial_value': 'test_df_name',
-            'type': 'df_name',
+            'type': 'import',
             'subtype': 'import_dataframe',
             'required': True,
             'name': 'import_dataframe_0'
@@ -368,7 +379,7 @@ def function(import_dataframe_0):
     param_metadata = [
         {
             'initial_value': "xyz",
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -138,11 +138,11 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
 
     # Test that get_param_metadata works
     assert analysis.get_param_metadata() == param_metadata
-    assert analysis.get_param_metadata(type='import') == param_metadata[:2]
-    assert analysis.get_param_metadata(type='export') == param_metadata[2:]
+    assert analysis.get_param_metadata(param_type='import') == param_metadata[:2]
+    assert analysis.get_param_metadata(param_type='export') == param_metadata[2:]
 
     with pytest.raises(TypeError):
-        analysis.get_param_metadata(type='invalid')
+        analysis.get_param_metadata(param_type='invalid')
 
     result = analysis.run(file_name_export_csv_0=new_export_file_0)
     assert result is not None
@@ -257,8 +257,8 @@ def function(import_dataframe_0, file_name_import_csv_0, file_name_import_excel_
 
     # Test that get_param_metadata works
     assert analysis.get_param_metadata() == param_metadata
-    assert analysis.get_param_metadata(type='import') == param_metadata[:3]
-    assert analysis.get_param_metadata(type='export') == param_metadata[3:]
+    assert analysis.get_param_metadata(param_type='import') == param_metadata[:3]
+    assert analysis.get_param_metadata(param_type='export') == param_metadata[3:]
 
     new_df = pd.DataFrame({'A': [1], 'B': [2]})
     result = analysis.run(df1, file_name_export_csv_0=new_export_file_0)

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -615,35 +615,35 @@ def function(import_dataframe_0, file_name_import_csv_0, file_name_import_excel_
     assert mito.mito_backend.param_metadata == [
         {
             'initial_value': 'test_df_name',
-            'type': 'df_name',
+            'type': 'import',
             'subtype': 'import_dataframe',
             'required': True,
             'name': 'import_dataframe_0'
         },
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -716,28 +716,28 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     assert mito.mito_backend.param_metadata == [
         {
             'initial_value': tmp_file1,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_csv',
             'name': 'file_name_import_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_file2,
-            'type': 'file_name',
+            'type': 'import',
             'subtype': 'file_name_import_excel',
             'name': 'file_name_import_excel_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile1,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_csv',
             'name': 'file_name_export_csv_0',
             'required': False
         },
         {
             'initial_value': tmp_exportfile2,
-            'type': 'file_name',
+            'type': 'export',
             'subtype': 'file_name_export_excel',
             'name': 'file_name_export_excel_0',
             'required': False
@@ -894,7 +894,7 @@ def test_transpiled_with_export_to_csv_singular():
     mito = create_mito_wrapper(df, arg_names=['df'])
     mito.export_to_file('csv', [0], 'te"st.csv')
 
-    assert [('df', 'df_name', 'import_dataframe'), ("r'te" + '"' + "st.csv'", 'file_name', 'file_name_export_csv')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
+    assert [('df', 'import', 'import_dataframe'), ("r'te" + '"' + "st.csv'", 'export', 'file_name_export_csv')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
     mito.code_options_update({'as_function': True, 'import_custom_python_code': False, 'call_function': True, 'function_name': 'function', 'function_params': {'path': "r'te" + '"' + "st.csv'"}})
 
@@ -914,7 +914,7 @@ def test_transpiled_with_export_to_csv_multiple():
     mito = create_mito_wrapper(df, df, arg_names=['df1', 'df2'])
     mito.export_to_file('csv', [0, 1], 'test.csv')
 
-    assert [('df1', 'df_name', 'import_dataframe'), ('df2', 'df_name', 'import_dataframe'), ("r'test_0.csv'", 'file_name', 'file_name_export_csv'), ("r'test_1.csv'", 'file_name', 'file_name_export_csv')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
+    assert [('df1', 'import', 'import_dataframe'), ('df2', 'import', 'import_dataframe'), ("r'test_0.csv'", 'export', 'file_name_export_csv'), ("r'test_1.csv'", 'export', 'file_name_export_csv')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
     mito.code_options_update({'as_function': True, 'import_custom_python_code': False, 'call_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test_0.csv'", 'path_1': "r'test_1.csv'"}})
 
@@ -936,7 +936,7 @@ def test_transpiled_with_export_to_xlsx_single():
     mito = create_mito_wrapper(df, arg_names=['df'])
     mito.export_to_file('excel', [0], "te'st.xlsx")
 
-    assert [('df', 'df_name', 'import_dataframe'), ('r"te' + "'" + 'st.xlsx"', 'file_name', 'file_name_export_excel')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
+    assert [('df', 'import', 'import_dataframe'), ('r"te' + "'" + 'st.xlsx"', 'export', 'file_name_export_excel')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
     mito.code_options_update({'as_function': True, 'import_custom_python_code': False, 'call_function': True, 'function_name': 'function', 'function_params': {'path': 'r"te' + "'" + 'st.xlsx"'}})
 
@@ -958,7 +958,7 @@ def test_transpiled_with_export_to_xlsx_multiple():
     mito = create_mito_wrapper(df, df, arg_names=['df1', 'df2'])
     mito.export_to_file('excel', [0, 1], 'test.xlsx')
 
-    assert [('df1', 'df_name', 'import_dataframe'), ('df2', 'df_name', 'import_dataframe'), ("r'test.xlsx'", 'file_name', 'file_name_export_excel')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
+    assert [('df1', 'import', 'import_dataframe'), ('df2', 'import', 'import_dataframe'), ("r'test.xlsx'", 'export', 'file_name_export_excel')] == get_parameterizable_params({}, mito.mito_backend.steps_manager)
 
     mito.code_options_update({'as_function': True, 'import_custom_python_code': False, 'call_function': True, 'function_name': 'function', 'function_params': {'path_0': "r'test.xlsx'"}})
 

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -333,7 +333,8 @@ if sys.version_info[:3] > (3, 8, 0):
     # function param specification - where you can pass the param subtype, to automatically generate params for all 
     # of that subtype
     ParamType = Literal[
-        'file_name'
+        'import',
+        'export'
     ]
     ParamSubtype = Literal[
         'import_dataframe',


### PR DESCRIPTION
# Description
This makes the API clearer for streamlit developers to access the `param_metadata` by type. It also changes the `ParamType` to facilitate these changes to the API.

# Testing
Added a test into the existing `MitoAnalysis` tests that checks that:
* When no type is passed, the entire array of param metadata is returned
* When 'import' type is passed, the imports are returned. 
* When 'export' type is passed, the exports are returned. 
* When 'export' type is passed but there are no export param metadata, an empty array is passed. 

# Documentation
This should be added when we add the `MitoAnalysis` / streamlit docs. 