### PR TITLE
Update flag to include custom python imports in MitoAnalysis

### DIFF
--- a/mitosheet/mitosheet/mito_backend.py
+++ b/mitosheet/mitosheet/mito_backend.py
@@ -133,7 +133,7 @@ class MitoBackend():
             add_comments=False,
             optimize=True,
             code_options_override={
-                'import_custom_python_code': False,
+                'import_custom_python_code': True,
                 'as_function': True,
                 'call_function': False,
                 'function_name': self.steps_manager.code_options.get('function_name', 'automate'),

--- a/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_mito_analysis.py
@@ -4,6 +4,8 @@ from mitosheet.streamlit.v1.spreadsheet import MitoAnalysis
 import pytest
 import pandas as pd
 
+from mitosheet.tests.test_transpile import custom_import
+
 
 simple_fn = f"""from mitosheet.public.v3 import *
 import pandas as pd
@@ -452,3 +454,19 @@ def function(vari\abl"e_name{}):
     new_analysis = MitoAnalysis.from_json(json)
     assert new_analysis is not None
     assert new_analysis.fully_parameterized_function == special_characters_fn
+
+@requires_streamlit
+def test_custom_imports():
+    fully_parameterized_code = """from mitosheet.public.v3 import *
+from mitosheet.tests.test_transpile import custom_import, ADDONE
+
+def function():
+    df1 = custom_import()
+    
+    df1.insert(1, 'B', ADDONE(df1['A']))
+    
+    return df1
+"""
+    analysis = MitoAnalysis('', None, fully_parameterized_code, [])
+    result = analysis.run()
+    pd.testing.assert_frame_equal(result, pd.DataFrame({'A': [1, 2, 3], 'B': [2, 3, 4]}))

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -746,6 +746,30 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     ]
 
 
+def test_fully_parameterized_function_custom_imports():
+    mito = create_mito_wrapper(sheet_functions=[ADDONE], importers=[custom_import])
+    mito.user_defined_import('custom_import', {})
+    mito.set_formula('=ADDONE(A)', 0, 'B', add_column=True)
+
+    mito.code_options_update({'as_function': False, 'import_custom_python_code': False, 'call_function': False, 'function_name': 'function', 'function_params': {}})
+    assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
+
+df1 = custom_import()
+
+df1.insert(1, 'B', ADDONE(df1['A']))
+"""
+
+    assert mito.mito_backend.fully_parameterized_function == """from mitosheet.public.v3 import *
+from mitosheet.tests.test_transpile import custom_import, ADDONE
+
+def function():
+    df1 = custom_import()
+    
+    df1.insert(1, 'B', ADDONE(df1['A']))
+    
+    return df1
+"""
+
 def test_transpile_as_function_multiple_params(tmp_path):
     tmp_file1 = str(tmp_path / 'txt.csv')
     tmp_file2 = str(tmp_path / 'file.csv')

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -746,6 +746,8 @@ def function(file_name_import_csv_0, file_name_import_excel_0, file_name_export_
     ]
 
 
+@pandas_post_1_2_only
+@python_post_3_6_only
 def test_fully_parameterized_function_custom_imports():
     mito = create_mito_wrapper(sheet_functions=[ADDONE], importers=[custom_import])
     mito.user_defined_import('custom_import', {})


### PR DESCRIPTION
# Description
Allows for custom python imports in the `fully_parameterized_function` of the `mito_backend` so that the `MitoAnalysis` class can use custom sheet functions. 

# Testing
See mito-ds/streamlit-recon-wizard#3. 
