### PR TITLE
Add support for MitoAnalysis class in Dash

### DIFF
--- a/mitosheet/dash_app.py
+++ b/mitosheet/dash_app.py
@@ -13,8 +13,6 @@ app.layout = html.Div([
     html.Div(id='output-run-analysis')
 ])
 
-analysis = None
-
 @mito_callback(
     Output('output', 'children'),
     Input('sheet', 'spreadsheet_result'),
@@ -22,7 +20,6 @@ analysis = None
 def update_code(spreadsheet_result):
     return html.Div([
         html.Code(spreadsheet_result.analysis().fully_parameterized_function),
-        html.Code(spreadsheet_result.analysis().get_param_metadata())
     ])
 
 @mito_callback(
@@ -33,6 +30,8 @@ def update_code(spreadsheet_result):
 )
 def update_output(n_clicks, spreadsheet_result):
     result = spreadsheet_result.analysis().run()
+    if result is None:
+        return None
     return html.Div([
         html.H3('Analysis Result'),
         dash_table.DataTable(result.to_dict('records'), [{"name": i, "id": i} for i in result.columns])

--- a/mitosheet/dash_app.py
+++ b/mitosheet/dash_app.py
@@ -1,0 +1,42 @@
+from dash import Dash, callback, Input, Output, html, dash_table
+from mitosheet.mito_dash.v1 import Spreadsheet, mito_callback
+
+app = Dash(__name__)
+
+CSV_URL = '/Users/marthacryan/gitrepos/mito/mitosheet/datasets/small-datasets/loans.csv'
+
+app.layout = html.Div([
+    html.H1("Stock Analysis"),
+    Spreadsheet(import_folder='datasets', id='sheet'),
+    html.Div(id='output'),
+    html.Button('Run', id='rerun-analysis'),
+    html.Div(id='output-run-analysis')
+])
+
+analysis = None
+
+@mito_callback(
+    Output('output', 'children'),
+    Input('sheet', 'spreadsheet_result'),
+)
+def update_code(spreadsheet_result):
+    return html.Div([
+        html.Code(spreadsheet_result.analysis().fully_parameterized_function),
+        html.Code(spreadsheet_result.analysis().get_param_metadata())
+    ])
+
+@mito_callback(
+    Output('output-run-analysis', 'children'),
+    Input('rerun-analysis', 'n_clicks'),
+    Input('sheet', 'spreadsheet_result'),
+    prevent_initial_call=True
+)
+def update_output(n_clicks, spreadsheet_result):
+    result = spreadsheet_result.analysis().run()
+    return html.Div([
+        html.H3('Analysis Result'),
+        dash_table.DataTable(result.to_dict('records'), [{"name": i, "id": i} for i in result.columns])
+    ])
+    
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
@@ -42,7 +42,7 @@ class SpreadsheetResult():
         return get_selected_element(self.__dfs, self.__index_and_selections)
     
     def analysis(self) -> MitoAnalysis:
-        return MitoAnalysis(self.__code, self.__code_options, self.__fully_parameterized_function, self.__param_metadata)
+        return MitoAnalysis(self.code(), self.__code_options, self.__fully_parameterized_function, self.__param_metadata)
     
 WRONG_CALLBACK_ERROR_MESSAGE = """Error: Registering a callback with an Input or State referencing a Mito Spreadsheet requires using the @mito_callback decorator, rather than the @callback decorator.
 

--- a/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
@@ -10,8 +10,8 @@ import pandas as pd
 from mitosheet.mito_backend import MitoBackend
 from mitosheet.selectionUtils import get_selected_element
 from mitosheet.utils import get_new_id, get_new_id
-from mitosheet.types import CodeOptions, MitoTheme, MitoFrontendIndexAndSelections
-
+from mitosheet.types import CodeOptions, MitoTheme, MitoFrontendIndexAndSelections, ParamMetadata
+from mitosheet.streamlit.v1 import MitoAnalysis
 
 
 class SpreadsheetResult():
@@ -20,11 +20,17 @@ class SpreadsheetResult():
         self, 
         dfs: List[pd.DataFrame],
         code: List[str],
+        fully_parameterized_function: str,
+        param_metadata: List[ParamMetadata],
+        code_options: CodeOptions,
         index_and_selections: Optional[MitoFrontendIndexAndSelections]=None
     ):
         self.__dfs = dfs
         self.__code = code
         self.__index_and_selections = index_and_selections
+        self.__fully_parameterized_function = fully_parameterized_function
+        self.__param_metadata = param_metadata
+        self.__code_options = code_options
 
     def dfs(self) -> List[pd.DataFrame]:
         return self.__dfs
@@ -34,6 +40,9 @@ class SpreadsheetResult():
     
     def selection(self) -> Optional[Union[pd.DataFrame, pd.Series]]:
         return get_selected_element(self.__dfs, self.__index_and_selections)
+    
+    def analysis(self) -> MitoAnalysis:
+        return MitoAnalysis(self.__code, self.__code_options, self.__fully_parameterized_function, self.__param_metadata)
     
 WRONG_CALLBACK_ERROR_MESSAGE = """Error: Registering a callback with an Input or State referencing a Mito Spreadsheet requires using the @mito_callback decorator, rather than the @callback decorator.
 
@@ -259,7 +268,10 @@ try:
             return SpreadsheetResult(
                 dfs=self.mito_backend.steps_manager.dfs,
                 code=self.mito_backend.steps_manager.code(),
-                index_and_selections=self.index_and_selections
+                index_and_selections=self.index_and_selections,
+                fully_parameterized_function=self.mito_backend.fully_parameterized_function,
+                param_metadata=self.mito_backend.param_metadata,
+                code_options=self.code_options
             )
         
 except ImportError:

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -122,6 +122,7 @@ class MitoAnalysis:
             param_metadata: List[ParamMetadata],
             mito_analysis_version: int=CURRENT_MITO_ANALYSIS_VERSION
         ):
+        print(f'param_metadata: {param_metadata}')
         self.__code = code
         self.__code_options = code_options
         self.__fully_parameterized_function = fully_parameterized_function
@@ -195,6 +196,7 @@ class MitoAnalysis:
 
             params[name] = value
 
+        print(params)
         return get_function_from_code_unsafe(self.__fully_parameterized_function)(**params)
 
 try:

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -122,7 +122,6 @@ class MitoAnalysis:
             param_metadata: List[ParamMetadata],
             mito_analysis_version: int=CURRENT_MITO_ANALYSIS_VERSION
         ):
-        print(f'param_metadata: {param_metadata}')
         self.__code = code
         self.__code_options = code_options
         self.__fully_parameterized_function = fully_parameterized_function
@@ -196,7 +195,6 @@ class MitoAnalysis:
 
             params[name] = value
 
-        print(params)
         return get_function_from_code_unsafe(self.__fully_parameterized_function)(**params)
 
 try:


### PR DESCRIPTION
# Description
Adds `MitoAnalysis` into the `SpreadsheetResult` class:
* adds `analysis()` to access the `MitoAnalysis`
* adds 3 new arguments to the `SpreadsheetResult.init()` function to support initializing the `MitoAnalysis`. 

# Testing
See `dash_app.py`. 

# Documentation
We'll want to add this into the dash docs!