### PR TITLE
mitosheet: make runnable analysis take more flexible types

### DIFF
--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -218,7 +218,7 @@ class RunnableAnalysis:
         for param_name, param_value in params.items():
             param = next(param for param in self.__param_metadata if param['name'] == param_name)
             # If the user passed in a dataframe, and the param subtype starts with file, we convert it to a StringIO object
-            if param['subtype'].startswith('file') and isinstance(param_value, pd.DataFrame):
+            if param['subtype'] == 'file_name_import_csv' and isinstance(param_value, pd.DataFrame):
                 from io import StringIO
                 params[param_name] = StringIO(param_value.to_csv(index=False))
 

--- a/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/streamlit/v1/spreadsheet.py
@@ -163,13 +163,12 @@ class RunnableAnalysis:
             mito_analysis_version=json_dict['mito_analysis_version']
         )
     
-    def run(self, *args, **kwargs):
-        params = {}
-
-        # First, set the default values for all params.
-        for param in self.__param_metadata:
-            params[param['name']] = param['original_value']
-
+    def _check_correct_args_and_kwargs(self, *args: List[Any], **kwargs: Dict[str, Any]) -> None:
+        """
+        Checks that all the required arguments are passed, and that
+        no unexpected arguments are passed, and that no arguments
+        are passed multiple times.
+        """
         # Error handling for required arguments
         required_args = [param['name'] for param in self.__param_metadata if param['required']]
         for index, required_arg in enumerate(required_args):
@@ -177,8 +176,6 @@ class RunnableAnalysis:
 
             # First, check if the arg was passed in as a positional argument
             if index < len(args):
-                params[required_arg] = args[index]
-
                 # Check if the arg was passed in as a keyword argument as well. 
                 if is_kwarg:
                     raise TypeError(f'RunnableAnalysis.run() got multiple values for argument {required_arg}')
@@ -187,13 +184,43 @@ class RunnableAnalysis:
             elif not is_kwarg:
                 raise TypeError(f'RunnableAnalysis.run() missing required argument {required_arg}. You passed a dataframe to this analysis, but did not pass in a value for {required_arg}.')
 
-        # Then, overwrite the default values with the user provided values
-        for name, value in kwargs.items():
+        # Then, check the correct kwargs were passed
+        for name in kwargs:
             # Raise an error if the user passes in an unexpected argument
             if not any(param for param in self.__param_metadata if param['name'] == name):
                 raise TypeError(f'RunnableAnalysis.run() got an unexpected keyword argument {name}')
 
+
+    
+    def run(self, *args, **kwargs):
+        params = {}
+
+        # First, set the default values for all params.
+        for param in self.__param_metadata:
+            params[param['name']] = param['original_value']
+
+        self._check_correct_args_and_kwargs(*args, **kwargs)
+
+        # Then, overwrite the default values with the user provided values
+        required_args = [param['name'] for param in self.__param_metadata if param['required']]
+
+        for index, required_arg in enumerate(required_args):
+            if index < len(args):
+                params[required_arg] = args[index]
+
+        # Then, overwrite the default values with the user provided values
+        for name, value in kwargs.items():
             params[name] = value
+
+        # Then, before we call the function, we make sure that the arguments are the correct types. 
+        # Notably, we want to allow users to pass in dataframes for file paths (as this is often very
+        # convenient), but we need to convert them to StringIO object before calling the function
+        for param_name, param_value in params.items():
+            param = next(param for param in self.__param_metadata if param['name'] == param_name)
+            # If the user passed in a dataframe, and the param subtype starts with file, we convert it to a StringIO object
+            if param['subtype'].startswith('file') and isinstance(param_value, pd.DataFrame):
+                from io import StringIO
+                params[param_name] = StringIO(param_value.to_csv(index=False))
 
         return get_function_from_code_unsafe(self.__fully_parameterized_function)(**params)
 

--- a/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
@@ -417,7 +417,7 @@ def test_to_and_from_json():
     # Test that the to_json function 
     json = analysis.to_json()
     assert json is not None
-    assert json == r'{"code": "", "code_options": null, "fully_parameterized_function": "from mitosheet.public.v3 import *\nimport pandas as pd\n\ndef function(import_dataframe_0):\n    return import_dataframe_0\n", "param_metadata": [{"initial_value": "test_df_name", "type": "df_name", "subtype": "import_dataframe", "required": true, "name": "import_dataframe_0"}], "mito_analysis_version": 1}'
+    assert json == r'{"code": "", "code_options": null, "fully_parameterized_function": "from mitosheet.public.v3 import *\nimport pandas as pd\n\ndef function(import_dataframe_0):\n    return import_dataframe_0\n", "param_metadata": [{"original_value": "test_df_name", "type": "df_name", "subtype": "import_dataframe", "required": true, "name": "import_dataframe_0"}], "mito_analysis_version": 1}'
 
     # Test that the from_json function works
     new_analysis = RunnableAnalysis.from_json(json)
@@ -470,3 +470,25 @@ def function():
     analysis = RunnableAnalysis('', None, fully_parameterized_code, [])
     result = analysis.run()
     pd.testing.assert_frame_equal(result, pd.DataFrame({'A': [1, 2, 3], 'B': [2, 3, 4]}))
+
+@requires_streamlit
+def test_can_pass_dataframe_to_file_path_in_run_auto_conversion():
+
+    analysis = RunnableAnalysis(
+        '',
+        None,
+        """from mitosheet.public.v3 import *
+import pandas as pd
+
+def function_srjr(file_name_import_csv_0):
+    df_export = pd.read_csv(file_name_import_csv_0)
+    
+    return df_export
+""",
+    [{"original_value": "datasets/df_export.csv", "type": "import", "subtype": "file_name_import_csv", "required": False, "name": "file_name_import_csv_0"}]
+    )
+
+    # Run with a df rather than a file path
+    df = pd.DataFrame({'A': [1, 2, 3]})
+    result = analysis.run(df)
+    assert result is not None

--- a/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
@@ -491,4 +491,4 @@ def function_srjr(file_name_import_csv_0):
     # Run with a df rather than a file path
     df = pd.DataFrame({'A': [1, 2, 3]})
     result = analysis.run(file_name_import_csv_0=df)
-    assert result is not None
+    assert result.equals(df)

--- a/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
@@ -490,5 +490,5 @@ def function_srjr(file_name_import_csv_0):
 
     # Run with a df rather than a file path
     df = pd.DataFrame({'A': [1, 2, 3]})
-    result = analysis.run(df)
+    result = analysis.run(file_name_import_csv_0=df)
     assert result is not None

--- a/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
+++ b/mitosheet/mitosheet/tests/streamlit/test_runnable_analysis.py
@@ -486,7 +486,7 @@ def function_srjr(file_name_import_csv_0):
     return df_export
 """,
     [{"original_value": "datasets/df_export.csv", "type": "import", "subtype": "file_name_import_csv", "required": False, "name": "file_name_import_csv_0"}]
-    )
+)
 
     # Run with a df rather than a file path
     df = pd.DataFrame({'A': [1, 2, 3]})


### PR DESCRIPTION
# Description

Makes it so you can pass a dataframe to the `run` function for file path argument, and the `.run` function automatically converts it to a string that can be read by the pd.read_csv call in the function. 

In general, I think should continue to improve the flexibility of this interface. Users should be able to create an analysis from one datasource, and then rerun it easily off of another datasource.

# Testing

See new test.

# Documentation

I think we can make this clear in the docs, just with a little section called **Input Flexibility**