### PR TITLE
Glossary functions page

### DIFF
--- a/trymito.io/components/CodeBlock/CodeBlock.tsx
+++ b/trymito.io/components/CodeBlock/CodeBlock.tsx
@@ -15,17 +15,17 @@ const CodeBlock = (props:{code: string}) => {
   }, [copied])
 
   return (
-    <div className={codeBlockStyles.container_div} >
-      <pre className={codeBlockStyles.code_container} onClick={async () => {
+    <div className={codeBlockStyles.container_div} onClick={async () => {
 
-        // Undefined on some mobile devices so we disable it as to not error
-        if (navigator.clipboard === undefined) {
-          return;
-        }
-        
-        await navigator.clipboard.writeText(props.code);
-        setCopied(true);
-      }}>
+      // Undefined on some mobile devices so we disable it as to not error
+      if (navigator.clipboard === undefined) {
+        return;
+      }
+      
+      await navigator.clipboard.writeText(props.code);
+      setCopied(true);
+    }}>
+      <pre className={codeBlockStyles.code_container} >
         <code className={classNames("language-python")}>{props.code}</code>
       </pre>
       <div className={codeBlockStyles.clipboard_container}>

--- a/trymito.io/components/Footer/Footer.tsx
+++ b/trymito.io/components/Footer/Footer.tsx
@@ -71,7 +71,7 @@ const Footer = (): JSX.Element => {
                         <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <Link href='/excel-to-python/functions/math/ABS'>Excel to Python</Link>
+                        <Link href='/excel-to-python/'>Excel to Python</Link>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
                         <Link href='/blog'>Blog</Link>

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -145,6 +145,12 @@ const Header = (): JSX.Element => {
                     iconSrc='/blog.svg'
                     altText="Blog"
                   />
+                  <HeaderDropdownItem
+                    title='Excel to Python Glossary'
+                    href='/excel-to-python'
+                    iconSrc='/blog.svg'
+                    altText="Excel to Python Glossary"
+                  />
                 </HeaderDropdown>
 
                 <li className={classNames('highlight-on-hover', headerStyles.nav_item)}>
@@ -225,6 +231,9 @@ const Header = (): JSX.Element => {
                 </li>
                 <li className='highlight-on-hover'>
                   <Link href='/blog'>Blog</Link>
+                </li>
+                <li className='highlight-on-hover'>
+                  <Link href='/excel-to-python'>Excel to Python Glossary</Link>
                 </li>
                 <li className='highlight-on-hover'>
                   <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>

--- a/trymito.io/components/TextButton/TextButton.tsx
+++ b/trymito.io/components/TextButton/TextButton.tsx
@@ -9,18 +9,20 @@ const TextButton = (props : {
     variant?: 'primary'
     fontSize?: 'small'
     buttonSize?: 'small' 
+    openInNewTab?: boolean
 }): JSX.Element => {
 
     const colorStyle = props.variant === 'primary' ? textButtonStyles.primary : textButtonStyles.highlight;
     const fontStyle = props.fontSize === 'small' ? textButtonStyles.small : textButtonStyles.large;
     const widthStyle = props.buttonSize === 'small' ? textButtonStyles.button_size_small : undefined
+    const openInNewTab = props.openInNewTab ?? true
 
     if (props.action === undefined) {
         return (
             <a 
                 className={classNames(textButtonStyles.text_button, colorStyle, fontStyle, widthStyle)} 
                 href={props.href}
-                target="_blank"
+                target={openInNewTab ? "_blank": undefined}
                 rel="noreferrer"
                 onClick={(e) => props.onClick !== undefined ? props.onClick() : undefined}
             >
@@ -29,7 +31,7 @@ const TextButton = (props : {
         )
     } else {
         return (
-            <form action={props.action} method="POST" target="_blank">
+            <form action={props.action} method="POST" target={openInNewTab ? "_blank": undefined}>
                 <button className={classNames(textButtonStyles.text_button, colorStyle, fontStyle, widthStyle)} type="submit">
                     {props.text}
                 </button>

--- a/trymito.io/excel-to-python-page-contents/ABS.json
+++ b/trymito.io/excel-to-python-page-contents/ABS.json
@@ -3,6 +3,7 @@
     "functionNameShort": "ABS",
     "functionNameLong": "Absolute Value",
     "relatedFunctions": ["SUM", "ROUND", "CEIL"],
+    "purpose": "Find the absolute value of a number",
     "titleCardParagraphs": [
         "Excel's ABS function finds the absolute value of a number. The absolute value of a function is the non-negative value of a number. The absolute value function is commonly used, for example, to calculate the distance between two points. Regardless of the order we look at the points, the distance should always be positive.",
         "This page explains how to implement Excel's ABS function in Python, so you can automate Excel reports using Python and Pandas."

--- a/trymito.io/excel-to-python-page-contents/CONCAT.json
+++ b/trymito.io/excel-to-python-page-contents/CONCAT.json
@@ -3,6 +3,7 @@
     "functionNameShort": "CONCAT",
     "functionNameLong": "String Concatenation",
     "relatedFunctions": ["JOIN", "MERGE", "APPEND"],
+    "purpose": "Join text together",
     "titleCardParagraphs": [
         "Excel's CONCAT function combines two or more strings into one. It's a powerful tool in text-based data analysis, and is often used to combine fields or create unique identifiers.",
         "This page explains how to implement Excel's CONCAT function in Python using pandas."

--- a/trymito.io/excel-to-python-page-contents/COUNT.json
+++ b/trymito.io/excel-to-python-page-contents/COUNT.json
@@ -3,6 +3,7 @@
     "functionNameShort": "COUNT",
     "functionNameLong": "COUNT",
     "relatedFunctions": ["IFNA", "AVERAGE", "PRODUCT"],
+    "purpose": "Count number of cells that contain numbers",
     "titleCardParagraphs": [
         "Excel's COUNT function calculates the number of cells that contain numbers. It's a pivotal function for various data analysis tasks, from understanding data distribution to ensuring data quality.",
         "This page explains how to implement Excel's COUNT function in Python using pandas, making the transition to automating Excel reports in Python smoother."

--- a/trymito.io/excel-to-python-page-contents/HOUR.json
+++ b/trymito.io/excel-to-python-page-contents/HOUR.json
@@ -3,6 +3,7 @@
     "functionNameShort": "HOUR",
     "functionNameLong": "Hour Extraction",
     "relatedFunctions": ["MINUTE", "SECOND", "DATE"],
+    "purpose": "Extract the hour from a datetime",
     "titleCardParagraphs": [
         "Excel's HOUR function extracts the hour as a number from a time value. It's especially useful when working with large datasets where you need to analyze data at an hourly granularity.",
         "This page explains how to implement Excel's HOUR function in Python using pandas, easing the transition from Excel to Python and helping automate Excel reports."

--- a/trymito.io/excel-to-python-page-contents/IF.json
+++ b/trymito.io/excel-to-python-page-contents/IF.json
@@ -3,6 +3,7 @@
     "functionNameShort": "IF",
     "functionNameLong": "IF",
     "relatedFunctions": ["VLOOKUP", "AND", "OR"],
+    "purpose": "Use a conditional check to return one of two values.",
     "titleCardParagraphs": [
         "Excel's IF function allows you take different actions depending on the value of your data. It's a way to make dynamic decisions in your data analysis, and is often used in financial modeling and other analytical tasks.",
         "This page explains how to implement Excel's IF function in Python using pandas."

--- a/trymito.io/excel-to-python-page-contents/ISNA.json
+++ b/trymito.io/excel-to-python-page-contents/ISNA.json
@@ -3,6 +3,7 @@
     "functionNameShort": "ISNA",
     "functionNameLong": "Detecting Missing Data",
     "relatedFunctions": ["FILLNA", "IF", "COUNT"],
+    "purpose": "Detect if a value is missing",
     "titleCardParagraphs": [
         "Excel's ISNA function checks if a value is #N/A (not available). In Python, the equivalent concept of missing data is represented by NaN (Not a Number). Knowing how to detect and handle missing data is crucial for data cleaning and analysis.",
         "This page explains how to identify and manage missing data in Python using pandas, making it easier to transition and automate Excel processes in Python."

--- a/trymito.io/excel-to-python-page-contents/LOWER.json
+++ b/trymito.io/excel-to-python-page-contents/LOWER.json
@@ -3,6 +3,7 @@
     "functionNameShort": "LOWER",
     "functionNameLong": "Convert to Lowercase",
     "relatedFunctions": ["UPPER", "CAPITALIZE", "LEN"],
+    "purpose": "Converts a text string to lowercase.",
     "titleCardParagraphs": [
         "Excel users often rely on the LOWER function to convert text to lowercase. While Pandas doesn't have a direct function named LOWER, it offers a method called `str.lower()` that performs the same operation.",
         "This page explains how to use the `str.lower()` method in pandas to emulate Excel's LOWER function, guiding you in automating your Excel tasks with Python."

--- a/trymito.io/excel-to-python-page-contents/RANK.json
+++ b/trymito.io/excel-to-python-page-contents/RANK.json
@@ -3,6 +3,7 @@
     "functionNameShort": "RANK",
     "functionNameLong": "Ranking",
     "relatedFunctions": ["COUNT", "SUM"],
+    "purpose": "Returns the rank of a number in a list of numbers.",
     "titleCardParagraphs": [
         "Excel's RANK function assigns a rank to a number from a list. The rank can be either in ascending or descending order and can handle ties and missing values.",
         "This page demonstrates how to replicate the RANK function from Excel in Python using pandas"

--- a/trymito.io/excel-to-python-page-contents/REPLACE.json
+++ b/trymito.io/excel-to-python-page-contents/REPLACE.json
@@ -3,6 +3,7 @@
     "functionNameShort": "REPLACE",
     "functionNameLong": "replace",
     "relatedFunctions": ["SUBSTITUTE", "FILLNA", "FIND"],
+    "purpose": "Replaces characters in a string by location.",
     "titleCardParagraphs": [
         "There are several formulas in Excel designed to help you replace characters in a string.", 
         "The REPLACE function in Excel replaces characters in a string by location.",

--- a/trymito.io/excel-to-python-page-contents/SUM.json
+++ b/trymito.io/excel-to-python-page-contents/SUM.json
@@ -3,6 +3,7 @@
     "functionNameShort": "SUM",
     "functionNameLong": "Addition",
     "relatedFunctions": ["ABS", "AVERAGE", "PRODUCT"],
+    "purpose": "Calculates the sum of numbers",
     "titleCardParagraphs": [
         "Excel's SUM function calculates the sum of a range of values. This simple yet powerful function is essential in many analytical tasks, ranging from financial modeling to scientific data analysis.",
         "This page explains how to implement Excel's SUM function in Python using pandas, thus helping automate Excel reports with the power of Python."

--- a/trymito.io/excel-to-python-page-contents/types.tsx
+++ b/trymito.io/excel-to-python-page-contents/types.tsx
@@ -9,6 +9,7 @@ export type PageContent = {
     functionNameShort: string;
     functionNameLong: string;
     relatedFunctions: string[];
+    purpose: string;
     titleCardParagraphs: string[];
     excelExplanation: {
         paragraphs: string[],

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -59,7 +59,7 @@ const GlossaryPageCard = (props: {glossaryPageInfo: GlossaryPageInfo}) => {
                     {props.glossaryPageInfo.functionNameShort}
                 </p>
                 <p>
-                    &nbsp;&nbsp;{props.glossaryPageInfo.purpose}
+                    {props.glossaryPageInfo.purpose}
                 </p>
             </div>
         </Link>

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -12,6 +12,7 @@ import { getPageContentJsonArray } from '../utils/excel-to-python';
 import Link from 'next/link';
 import PageTOC from '../components/Glossary/PageTOC/PageTOC';
 import TextButton from '../components/TextButton/TextButton';
+import { PageContent } from '../excel-to-python-page-contents/types';
 
 export type GlossaryPageInfo = {
     functionNameShort: string,
@@ -19,23 +20,27 @@ export type GlossaryPageInfo = {
     slug: string[],
 }
 
-export const getGlossaryPageInfo = (glossaryPageInfo: GlossaryPageInfo[], section: string) => {
+export const getGlossaryPageInfoForSection = (glossaryPageInfo: GlossaryPageInfo[], section: string) => {
     return glossaryPageInfo.filter((glossaryPageInfo) => {
         return glossaryPageInfo.slug[1] === section
     })
 }
 
-export const getStaticProps: GetStaticProps<{glossaryPageInfo: GlossaryPageInfo[]}> = async () => {
-    const pageContentsJsonArray = await getPageContentJsonArray()
+export const getGlossaryPageInfo = async (pageContentsJsonArray: PageContent[]): Promise<GlossaryPageInfo[]> => {
   
     // Get information about each glossay page
-    const glossaryPageInfo: GlossaryPageInfo[] = pageContentsJsonArray.map((pageContentsJson) => {
+    return pageContentsJsonArray.map((pageContentsJson) => {
       return {
         functionNameShort: pageContentsJson.functionNameShort,
         purpose: pageContentsJson.purpose,
         slug: [...pageContentsJson.slug]
       }
     })
+}
+
+export const getStaticProps: GetStaticProps<{glossaryPageInfo: GlossaryPageInfo[]}> = async () => {
+    const pageContentsJsonArray = await getPageContentJsonArray()
+    const glossaryPageInfo = await getGlossaryPageInfo(pageContentsJsonArray)
     
     return {
         props: { glossaryPageInfo },
@@ -63,11 +68,11 @@ const GlossaryPageCard = (props: {glossaryPageInfo: GlossaryPageInfo}) => {
 
 const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) => {
 
-    const mathFucntionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'math')
-    const textFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'text')
-    const dateFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'date')
-    const conditionalFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'conditional')
-    const miscFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'misc')
+    const mathFucntionsPageInfo = getGlossaryPageInfoForSection(props.glossaryPageInfo, 'math')
+    const textFunctionsPageInfo = getGlossaryPageInfoForSection(props.glossaryPageInfo, 'text')
+    const dateFunctionsPageInfo = getGlossaryPageInfoForSection(props.glossaryPageInfo, 'date')
+    const conditionalFunctionsPageInfo = getGlossaryPageInfoForSection(props.glossaryPageInfo, 'conditional')
+    const miscFunctionsPageInfo = getGlossaryPageInfoForSection(props.glossaryPageInfo, 'misc')
 
     return (
         <>

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -129,31 +129,31 @@ const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) =>
                             </section>
                             <section style={{marginTop: '2rem'}}>
                                 <h2 id="Functions" style={{marginBottom: '2rem'}}>Functions</h2>
-                                <h3 id="Math Functions" className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
+                                <h3 id="Math" className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
                                 {mathFucntionsPageInfo.map((glossaryPageInfo) => {
                                     return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
-                                <h3 id="Text Functions" className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
+                                <h3 id="Text" className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
                                 {textFunctionsPageInfo.map((glossaryPageInfo) => {
                                     return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
-                                <h3 id="Date Functions" className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
+                                <h3 id="Date" className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
                                 {dateFunctionsPageInfo.map((glossaryPageInfo) => {
                                     return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
-                                <h3 id="Conditional Functions" className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
+                                <h3 id="Conditional" className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
                                 {conditionalFunctionsPageInfo.map((glossaryPageInfo) => {
                                     return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
-                                <h3 id="Misc. Functions" className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
+                                <h3 id="Misc" className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
                                 {miscFunctionsPageInfo.map((glossaryPageInfo) => {
                                     return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
                                 })}

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -1,0 +1,123 @@
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import Footer from '../components/Footer/Footer';
+import Header from '../components/Header/Header';
+import pageStyles from '../styles/Page.module.css';
+import titleStyles from '../styles/Title.module.css';
+import { GetStaticProps } from 'next';
+import excelToPythonStyles from '../styles/ExcelToPython.module.css';
+
+// Import Icons & Background Grid
+import { classNames } from '../utils/classNames';
+import { getPageContentJsonArray } from '../utils/excel-to-python';
+import Link from 'next/link';
+
+export type GlossaryPageInfo = {
+    functionNameShort: string,
+    purpose: string,
+    slug: string[],
+}
+
+export const getGlossaryPageInfo = (glossaryPageInfo: GlossaryPageInfo[], section: string) => {
+    return glossaryPageInfo.filter((glossaryPageInfo) => {
+        return glossaryPageInfo.slug[1] === section
+    })
+}
+
+export const getStaticProps: GetStaticProps<{glossaryPageInfo: GlossaryPageInfo[]}> = async () => {
+    const pageContentsJsonArray = await getPageContentJsonArray()
+  
+    // Get information about each glossay page
+    const glossaryPageInfo: GlossaryPageInfo[] = pageContentsJsonArray.map((pageContentsJson) => {
+      return {
+        functionNameShort: pageContentsJson.functionNameShort,
+        purpose: pageContentsJson.purpose,
+        slug: [...pageContentsJson.slug]
+      }
+    })
+    
+    return {
+        props: { glossaryPageInfo },
+        revalidate: 60, // Revalidate every 1 minute
+    }
+}
+
+const GlossaryPageCard = (props: {glossaryPageInfo: GlossaryPageInfo}) => {
+    // TODO: This works, but maybe there is a better way...
+    const slug = 'excel-to-python/' + props.glossaryPageInfo.slug.join('/')
+
+    return (
+        <Link href={slug}>
+            <div className={excelToPythonStyles.glossary_page_card_container}>
+                <p className={excelToPythonStyles.glossary_page_card_function_name}>
+                    {props.glossaryPageInfo.functionNameShort}
+                </p>
+                <p>
+                    &nbsp;&nbsp;{props.glossaryPageInfo.purpose}
+                </p>
+            </div>
+        </Link>
+    )
+}
+
+const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) => {
+
+    const mathFucntionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'math')
+    const textFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'text')
+    const dateFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'date')
+    const conditionalFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'conditional')
+    const miscFunctionsPageInfo = getGlossaryPageInfo(props.glossaryPageInfo, 'misc')
+
+    return (
+        <>
+            <Head>      
+                {/* TODO: Add meta tags */}
+            </Head>
+            
+            <Header/>
+
+            <div className={pageStyles.container}>
+                <main className={pageStyles.main}>
+                    <section className={classNames(titleStyles.title_card)}>
+                        <h1 className={titleStyles.title}>
+                            Excel to Python Glossary
+                        </h1>
+                    </section>
+                    <section>
+                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
+                        {mathFucntionsPageInfo.map((glossaryPageInfo) => {
+                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                        })}
+                    </section>
+                    <section>
+                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
+                        {textFunctionsPageInfo.map((glossaryPageInfo) => {
+                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                        })}
+                    </section>
+                    <section>
+                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
+                        {dateFunctionsPageInfo.map((glossaryPageInfo) => {
+                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                        })}
+                    </section>
+                    <section>
+                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
+                        {conditionalFunctionsPageInfo.map((glossaryPageInfo) => {
+                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                        })}
+                    </section>
+                    <section>
+                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
+                        {miscFunctionsPageInfo.map((glossaryPageInfo) => {
+                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                        })}
+                    </section>
+                </main>
+                <Footer />
+            </div>
+        </>
+    )
+}
+
+export default ExcelToPythonHomePage

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -71,10 +71,48 @@ const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) =>
 
     return (
         <>
-            <Head>      
-                {/* TODO: Add meta tags */}
+            <Head>
+                {/* Title Tag */}
+                <title>{`Excel to Python: Using Excel's functions in Python - A Complete Guide | Mito`}</title>
+                
+                {/* Meta Description */}
+                <meta
+                    name="description"
+                    content={`Learn how to convert Excel's functions to Python using Pandas. This comprehensive guide provides step-by-step instructions and practical examples for every Excel formula.`}
+                />
+
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                
+                {/* Canonical URL */}
+                <link rel="canonical" href={`https://www.trymito.io/excel-to-python`} />
+                
+                {/* Open Graph Tags (for social media sharing) */}
+                <meta
+                    property="og:title"
+                    content={`Excel to Python: Using Excel's functions in Python - A Complete Guide`}
+                />
+                <meta
+                    property="og:description"
+                    content={`Learn how to convert Excel's function to Python using Pandas. This comprehensive guide provides step-by-step instructions and practical examples.`}
+                />
+                {/* Add more Open Graph tags as needed */}
+                
+                {/* Twitter Card Tags (for Twitter sharing) */}
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta
+                    name="twitter:title"
+                    content={`Excel to Python: Using Excel's function in Python - A Complete Guide`}
+                />
+                <meta
+                    name="twitter:description"
+                    content={`Learn how to convert Excel's function to Python using Pandas. This comprehensive guide provides step-by-step instructions and practical examples.`}
+                />
+                {/* Add more Twitter Card tags as needed */}
+                
+                {/* Other SEO-related tags (structured data, robots meta, etc.) */}
+                {/* Add other SEO-related tags here */}
             </Head>
-            
+                    
             <Header/>
 
             <div className={pageStyles.container}>

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -129,38 +129,38 @@ const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) =>
                                     Excel to Python Glossary
                                 </h1>
                                 <p className={titleStyles.description}>
-                                    Looking to use Excel formulas in Python? You've come to the right place. Click on a function below to learn how to use it in Python.
+                                    Looking to use Excel formulas in Python? You&apos;ve come to the right place. Click on a function below to learn how to use it in Python.
                                 </p>
                             </section>
                             <section style={{marginTop: '2rem'}}>
                                 <h2 id="Functions" style={{marginBottom: '2rem'}}>Functions</h2>
                                 <h3 id="Math" className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
                                 {mathFucntionsPageInfo.map((glossaryPageInfo) => {
-                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                    return <GlossaryPageCard key={glossaryPageInfo.functionNameShort} glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
                                 <h3 id="Text" className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
                                 {textFunctionsPageInfo.map((glossaryPageInfo) => {
-                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                    return <GlossaryPageCard key={glossaryPageInfo.functionNameShort} glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
                                 <h3 id="Date" className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
                                 {dateFunctionsPageInfo.map((glossaryPageInfo) => {
-                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                    return <GlossaryPageCard key={glossaryPageInfo.functionNameShort} glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
                                 <h3 id="Conditional" className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
                                 {conditionalFunctionsPageInfo.map((glossaryPageInfo) => {
-                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                    return <GlossaryPageCard key={glossaryPageInfo.functionNameShort} glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                             <section>
                                 <h3 id="Misc" className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
                                 {miscFunctionsPageInfo.map((glossaryPageInfo) => {
-                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                    return <GlossaryPageCard key={glossaryPageInfo.functionNameShort} glossaryPageInfo={glossaryPageInfo} />
                                 })}
                             </section>
                         </div>

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -1,7 +1,6 @@
-import type { NextPage } from 'next';
 import Head from 'next/head';
 import Footer from '../components/Footer/Footer';
-import Header from '../components/Header/Header';
+import Header, { MITO_INSTALLATION_DOCS_LINK } from '../components/Header/Header';
 import pageStyles from '../styles/Page.module.css';
 import titleStyles from '../styles/Title.module.css';
 import { GetStaticProps } from 'next';
@@ -11,6 +10,8 @@ import excelToPythonStyles from '../styles/ExcelToPython.module.css';
 import { classNames } from '../utils/classNames';
 import { getPageContentJsonArray } from '../utils/excel-to-python';
 import Link from 'next/link';
+import PageTOC from '../components/Glossary/PageTOC/PageTOC';
+import TextButton from '../components/TextButton/TextButton';
 
 export type GlossaryPageInfo = {
     functionNameShort: string,
@@ -78,41 +79,56 @@ const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) =>
 
             <div className={pageStyles.container}>
                 <main className={pageStyles.main}>
-                    <section className={classNames(titleStyles.title_card)}>
-                        <h1 className={titleStyles.title}>
-                            Excel to Python Glossary
-                        </h1>
-                    </section>
-                    <section>
-                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
-                        {mathFucntionsPageInfo.map((glossaryPageInfo) => {
-                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
-                        })}
-                    </section>
-                    <section>
-                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
-                        {textFunctionsPageInfo.map((glossaryPageInfo) => {
-                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
-                        })}
-                    </section>
-                    <section>
-                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
-                        {dateFunctionsPageInfo.map((glossaryPageInfo) => {
-                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
-                        })}
-                    </section>
-                    <section>
-                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
-                        {conditionalFunctionsPageInfo.map((glossaryPageInfo) => {
-                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
-                        })}
-                    </section>
-                    <section>
-                        <h3 className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
-                        {miscFunctionsPageInfo.map((glossaryPageInfo) => {
-                            return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
-                        })}
-                    </section>
+                    <div className={excelToPythonStyles.content_and_table_of_contents_container}>
+                        <div className={excelToPythonStyles.excel_to_python_glossary_content}>
+                            <section className={classNames(titleStyles.title_card)}>
+                                <h1 className={titleStyles.title}>
+                                    Excel to Python Glossary
+                                </h1>
+                                <p className={titleStyles.description}>
+                                    Looking to use Excel formulas in Python? You've come to the right place. Click on a function below to learn how to use it in Python.
+                                </p>
+                            </section>
+                            <section style={{marginTop: '2rem'}}>
+                                <h2 id="Functions" style={{marginBottom: '2rem'}}>Functions</h2>
+                                <h3 id="Math Functions" className={excelToPythonStyles.glossary_function_category_header}>Math Functions</h3>
+                                {mathFucntionsPageInfo.map((glossaryPageInfo) => {
+                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                })}
+                            </section>
+                            <section>
+                                <h3 id="Text Functions" className={excelToPythonStyles.glossary_function_category_header}>Text Functions</h3>
+                                {textFunctionsPageInfo.map((glossaryPageInfo) => {
+                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                })}
+                            </section>
+                            <section>
+                                <h3 id="Date Functions" className={excelToPythonStyles.glossary_function_category_header}>Date Functions</h3>
+                                {dateFunctionsPageInfo.map((glossaryPageInfo) => {
+                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                })}
+                            </section>
+                            <section>
+                                <h3 id="Conditional Functions" className={excelToPythonStyles.glossary_function_category_header}>Conditional Functions</h3>
+                                {conditionalFunctionsPageInfo.map((glossaryPageInfo) => {
+                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                })}
+                            </section>
+                            <section>
+                                <h3 id="Misc. Functions" className={excelToPythonStyles.glossary_function_category_header}>Misc. Functions</h3>
+                                {miscFunctionsPageInfo.map((glossaryPageInfo) => {
+                                    return <GlossaryPageCard glossaryPageInfo={glossaryPageInfo} />
+                                })}
+                            </section>
+                        </div>
+                        <div className={excelToPythonStyles.table_of_contents_container}>
+                            <PageTOC />
+                            <p className={classNames('text-primary', 'margin-bottom-1')}>
+                                <b>Don&apos;t re-invent the wheel. Use Excel formulas in Python.</b> 
+                            </p>
+                            <TextButton text={'Install Mito'} href={MITO_INSTALLATION_DOCS_LINK} buttonSize='small'/>
+                        </div>
+                    </div>
                 </main>
                 <Footer />
             </div>

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -316,7 +316,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
 export async function getStaticPaths() {
   const pageContentsJsonArray = await getPageContentJsonArray()
 
-  // Get the paths we want to create based on posts
+  // Get the paths we want to create based on json files in the excel-to-python-page-content directory 
   const paths = pageContentsJsonArray.map((pageContentsJson) => {
     return {
       // We allow the slug to be an array so we can support paths like /functions/math/abs
@@ -325,7 +325,8 @@ export async function getStaticPaths() {
     }
   })
 
-  // { fallback: false } means posts not found should 404.
+  // { fallback: false } means posts not found should 404. 
+  // TODO: Update the fallback so if they entire an invalid URL with the /excel-to-python/ prefix, it returns them to the excel-to-python page
   return { paths, fallback: false }
 }
 

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -27,9 +27,22 @@ import { PageContent } from '../../excel-to-python-page-contents/types';
 import Prism from 'prismjs';
 import 'prism-themes/themes/prism-coldark-dark.css'
 import { arraysContainSameValueAndOrder } from '../../utils/arrays';
+import { getGlossaryPageInfo, GlossaryPageInfo } from '../excel-to-python';
 require('prismjs/components/prism-python');
 
-const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
+const getRelatedFunctionHref = (relatedFunctionShortName: string, glossaryPageInfo: GlossaryPageInfo[]) => {
+  const relatedFunction = glossaryPageInfo.filter((glossaryPageInfo) => {
+    return glossaryPageInfo.functionNameShort === relatedFunctionShortName
+  })[0]
+
+  if (relatedFunction == null) {
+    return '/excel-to-python/'
+  }
+
+  return '/excel-to-python/' + relatedFunction.slug.join('/')
+}
+
+const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPageInfo: GlossaryPageInfo[]}) => {
 
   const pageContent = props.pageContent
 
@@ -120,6 +133,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
                       text={pageContent.relatedFunctions[0]}
                       variant='primary'
                       fontSize='small'
+                      href={getRelatedFunctionHref(pageContent.relatedFunctions[0], props.glossaryPageInfo)}
                     />
                   }
                   {pageContent.relatedFunctions.length > 1 && 
@@ -127,6 +141,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
                       text={pageContent.relatedFunctions[1]}
                       variant='primary'
                       fontSize='small'
+                      href={getRelatedFunctionHref(pageContent.relatedFunctions[1], props.glossaryPageInfo)}
                     />
                   } 
                   {pageContent.relatedFunctions.length > 2 && 
@@ -134,6 +149,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
                       text={pageContent.relatedFunctions[2]}
                       variant='primary'
                       fontSize='small'
+                      href={getRelatedFunctionHref(pageContent.relatedFunctions[2], props.glossaryPageInfo)}
                     />
                   }
                 </div>
@@ -353,6 +369,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
     return false
   })
 
+  const glossaryPageInfo = await getGlossaryPageInfo(pageContentsJsonArray)
+
   if (!pageContent) {
     return {
       notFound: true,
@@ -360,7 +378,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
   }
 
   return {
-    props: { pageContent }
+    props: { 
+      pageContent: pageContent,
+      glossaryPageInfo: glossaryPageInfo
+    }
   }
 }
 

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -96,8 +96,8 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
 
       <div className={pageStyles.container}>
         <main className={classNames(pageStyles.main, excelToPythonStyles.main)}>
-          <div className={excelToPythonStyles.blog_content_and_table_of_contents_container}>
-            <div className={excelToPythonStyles.blog_content}>
+          <div className={excelToPythonStyles.content_and_table_of_contents_container}>
+            <div className={excelToPythonStyles.excel_to_python_glossary_content}>
               <section className={classNames(excelToPythonStyles.title_card, excelToPythonStyles.section)}>
                 <div className={excelToPythonStyles.horizontal_navbar_container}>
                   <GlossayHorizontalNavbar>

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -49,6 +49,10 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
     Prism.highlightAll();
   }, []);
 
+  // Make first character uppercase
+  const slugComponent0 = pageContent.slug[0].charAt(0).toUpperCase() + pageContent.slug[0].slice(1);
+  const slugComponent1 = pageContent.slug[1].charAt(0).toUpperCase() + pageContent.slug[1].slice(1);
+
   return (
     <>
       <Head>
@@ -102,9 +106,9 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent}) => {
                 <div className={excelToPythonStyles.horizontal_navbar_container}>
                   <GlossayHorizontalNavbar>
                     {/* TODO: Update hrefs to actual path once we implement the correct pages */}
-                    <HorizontalNavItem title={'Function'} href={'/spreadsheet-automation'} />
-                    <HorizontalNavItem title={'Math'} href={'/spreadsheet-automation'} />
-                    <HorizontalNavItem title={'ABS'} href={'/excel-to-python/functions/math/ABS'} />
+                    <HorizontalNavItem title={slugComponent0} href={'/excel-to-python'} />
+                    <HorizontalNavItem title={slugComponent1} href={`/excel-to-python#${slugComponent1}`} />
+                    <HorizontalNavItem title={props.pageContent.slug[2]} href={path} />
                   </GlossayHorizontalNavbar>
                 </div>
                 

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -134,6 +134,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPag
                       variant='primary'
                       fontSize='small'
                       href={getRelatedFunctionHref(pageContent.relatedFunctions[0], props.glossaryPageInfo)}
+                      openInNewTab={false}
                     />
                   }
                   {pageContent.relatedFunctions.length > 1 && 
@@ -142,6 +143,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPag
                       variant='primary'
                       fontSize='small'
                       href={getRelatedFunctionHref(pageContent.relatedFunctions[1], props.glossaryPageInfo)}
+                      openInNewTab={false}
                     />
                   } 
                   {pageContent.relatedFunctions.length > 2 && 
@@ -150,6 +152,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPag
                       variant='primary'
                       fontSize='small'
                       href={getRelatedFunctionHref(pageContent.relatedFunctions[2], props.glossaryPageInfo)}
+                      openInNewTab={false}
                     />
                   }
                 </div>

--- a/trymito.io/styles/ExcelToPython.module.css
+++ b/trymito.io/styles/ExcelToPython.module.css
@@ -81,7 +81,7 @@
     margin-top: 4rem;
 }
 
-.blog_content {
+.excel_to_python_glossary_content {
     width: 100%;
 }
 
@@ -130,7 +130,7 @@
 
 @media only screen and (min-width: 50em) {
 
-    .blog_content_and_table_of_contents_container {
+    .content_and_table_of_contents_container {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -146,7 +146,7 @@
         height: fit-content;
     }
 
-    .blog_content {
+    .excel_to_python_glossary_content {
         padding: 0 1rem;
         width: 75%;
     }

--- a/trymito.io/styles/ExcelToPython.module.css
+++ b/trymito.io/styles/ExcelToPython.module.css
@@ -98,7 +98,7 @@
 
 .glossary_page_card_container {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: baseline;
     background-color: var(--color-light-background);
     border-radius: 5px;
@@ -115,7 +115,7 @@
 
 .glossary_page_card_function_name {
     color: var(--color-purple);
-    font-size: 1.5rem;
+    font-size: 2.5rem;
     margin-top: 0rem;
 }
 
@@ -177,6 +177,16 @@
 
     .section_h3_tag {
         font-size: 1.25rem;
+    }
+
+    .glossary_page_card_container {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .glossary_page_card_function_name {
+        font-size: 1.5rem;
+        margin-right: 10px;
     }
 
 }

--- a/trymito.io/styles/ExcelToPython.module.css
+++ b/trymito.io/styles/ExcelToPython.module.css
@@ -96,6 +96,38 @@
     padding: 0;
 }
 
+.glossary_page_card_container {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    background-color: var(--color-light-background);
+    border-radius: 5px;
+    padding: 2rem;
+    width: 100%;
+    margin-top: 1rem;
+    cursor: pointer;
+}
+
+.glossary_page_card_container:hover {
+    background-color: var(--color-light-background-accent);
+}
+
+
+.glossary_page_card_function_name {
+    color: var(--color-purple);
+    font-size: 1.5rem;
+    margin-top: 0rem;
+}
+
+.glossary_page_card_container p {
+    margin-top: 0;
+}
+
+.glossary_function_category_header {
+    width: 100%;
+    margin-left: 5px;
+}
+
 @media only screen and (min-width: 50em) {
 
     .blog_content_and_table_of_contents_container {

--- a/trymito.io/utils/excel-to-python.tsx
+++ b/trymito.io/utils/excel-to-python.tsx
@@ -2,9 +2,8 @@ import path from 'path'
 import fs from 'fs'
 import { PageContent } from '../excel-to-python-page-contents/types'
 
-
 export async function getPageContentJsonArray() {
-    const relativePath = '/excel-to-python-page-contents/'
+    const relativePath = './excel-to-python-page-contents/'
 
     const fileNames = fs.readdirSync(path.join(process.cwd(), relativePath))
     const jsonFileNames = fileNames.filter(fileName => fileName.endsWith('.json'))


### PR DESCRIPTION
# Description

- Adds the home page for the Excel to Python glossary 
- Makes the related functions buttons works
- Adds this glossary to the `About` toolbar because it's pretty cool and useful

With this, I think we are finished all of the required infrastructure for these pages + we've implemented all of the most import page optimizations, so we are good to write more useful pages for functions that people are commonly looking to create! 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.