### PR TITLE
Move icons into the action type

### DIFF
--- a/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
@@ -3,7 +3,6 @@
 
 import React from 'react'
 
-import { ToolbarButtonType } from './utils';
 import ToolbarButton from './ToolbarButton';
 import { getSelectedColumnIDsWithEntireSelectedColumn, getSelectedNumberSeriesColumnIDs } from '../endo/selectionUtils';
 import { getDtypeSelectOptions } from '../taskpanes/ControlPanel/FilterAndSortTab/DtypeCard';
@@ -82,7 +81,6 @@ export const HomeTabContents = (
     return (<div className='mito-toolbar-bottom'>
         <div className='mito-toolbar-bottom-left-half'>
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.IMPORT}
                 action={props.actions.buildTimeActions[ActionEnum.Import_Dropdown]}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Import_Dropdown].isDisabled()}
@@ -108,7 +106,6 @@ export const HomeTabContents = (
                 </Dropdown>
             </ToolbarButton>
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.EXPORT}
                 action={props.actions.buildTimeActions[ActionEnum.Export_Dropdown]}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Export_Dropdown].isDisabled()}
@@ -164,13 +161,11 @@ export const HomeTabContents = (
                 </Select>
                 <div className='mito-toolbar-number-precision'>
                     <ToolbarButton
-                        toolbarButtonType={ToolbarButtonType.LESS}
                         action={props.actions.buildTimeActions[ActionEnum.Precision_Decrease]}
                         setEditorState={props.setEditorState}
                         disabledTooltip={props.actions.buildTimeActions[ActionEnum.Precision_Decrease].isDisabled()}
                     />
                     <ToolbarButton
-                        toolbarButtonType={ToolbarButtonType.MORE}
                         action={props.actions.buildTimeActions[ActionEnum.Precision_Increase]}
                         setEditorState={props.setEditorState}
                         disabledTooltip={props.actions.buildTimeActions[ActionEnum.Precision_Increase].isDisabled()}
@@ -180,21 +175,18 @@ export const HomeTabContents = (
             <div className="toolbar-vertical-line" style={{ marginLeft: '5px'}}></div>
 
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.ADD_COL}
                 action={props.actions.buildTimeActions[ActionEnum.Add_Column]}
                 highlightToolbarButton={props.highlightAddColButton}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Add_Column].isDisabled()}
             />
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.DEL_COL}
                 action={props.actions.buildTimeActions[ActionEnum.Delete_Column]}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Delete_Column].isDisabled()}
 
             />
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.DTYPE}
                 action={props.actions.buildTimeActions[ActionEnum.Change_Dtype]}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Change_Dtype].isDisabled()}
@@ -229,21 +221,18 @@ export const HomeTabContents = (
             </ToolbarButton>
             <div className="toolbar-vertical-line"></div>
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.PIVOT}
                 action={props.actions.buildTimeActions[ActionEnum.Pivot]}
                 highlightToolbarButton={props.highlightPivotTableButton}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Pivot].isDisabled()}
             />
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.GRAPH}
                 action={props.actions.buildTimeActions[ActionEnum.Graph]}
                 setEditorState={props.setEditorState}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Graph].isDisabled()}
             />
             {props.userProfile.mitoConfig.MITO_CONFIG_FEATURE_DISPLAY_AI_TRANSFORMATION && 
                 <ToolbarButton
-                    toolbarButtonType={ToolbarButtonType.AI_TRANSFORMATION}
                     action={props.actions.buildTimeActions[ActionEnum.AI_TRANSFORMATION]}
                     setEditorState={props.setEditorState}
                     disabledTooltip={props.actions.buildTimeActions[ActionEnum.AI_TRANSFORMATION].isDisabled()}
@@ -251,7 +240,6 @@ export const HomeTabContents = (
             }
             {props.userProfile.mitoConfig.MITO_CONFIG_CODE_SNIPPETS?.MITO_CONFIG_CODE_SNIPPETS_URL !== undefined && 
                 <ToolbarButton
-                    toolbarButtonType={ToolbarButtonType.CODE_SNIPPETS}
                     action={props.actions.buildTimeActions[ActionEnum.CODESNIPPETS]}
                     setEditorState={props.setEditorState}
                     disabledTooltip={props.actions.buildTimeActions[ActionEnum.CODESNIPPETS].isDisabled()}
@@ -261,18 +249,15 @@ export const HomeTabContents = (
         <div className='mito-toolbar-bottom-right-half'>
             <ToolbarButton
                 id={MITO_TOOLBAR_UNDO_ID} // NOTE: this is used to click the undo button in plugin.tsx
-                toolbarButtonType={ToolbarButtonType.UNDO}
                 action={props.actions.buildTimeActions[ActionEnum.Undo]}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Undo].isDisabled()}
             />
             <ToolbarButton
                 id={MITO_TOOLBAR_REDO_ID} // NOTE: this is used to click the redo button in plugin.tsx
-                toolbarButtonType={ToolbarButtonType.REDO}
                 action={props.actions.buildTimeActions[ActionEnum.Redo]}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Redo].isDisabled()}
             />
             <ToolbarButton
-                toolbarButtonType={ToolbarButtonType.CLEAR}
                 action={props.actions.buildTimeActions[ActionEnum.Clear]}
                 disabledTooltip={props.actions.buildTimeActions[ActionEnum.Clear].isDisabled()}
             />

--- a/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
@@ -83,7 +83,6 @@ export const HomeTabContents = (
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Import_Dropdown]}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Import_Dropdown].isDisabled()}
             >
                 <Dropdown
                     display={props.uiState.toolbarDropdown === 'import'}
@@ -108,7 +107,6 @@ export const HomeTabContents = (
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Export_Dropdown]}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Export_Dropdown].isDisabled()}
             >
                 <Dropdown
                     display={props.uiState.toolbarDropdown === 'export'}
@@ -163,12 +161,10 @@ export const HomeTabContents = (
                     <ToolbarButton
                         action={props.actions.buildTimeActions[ActionEnum.Precision_Decrease]}
                         setEditorState={props.setEditorState}
-                        disabledTooltip={props.actions.buildTimeActions[ActionEnum.Precision_Decrease].isDisabled()}
                     />
                     <ToolbarButton
                         action={props.actions.buildTimeActions[ActionEnum.Precision_Increase]}
                         setEditorState={props.setEditorState}
-                        disabledTooltip={props.actions.buildTimeActions[ActionEnum.Precision_Increase].isDisabled()}
                     />
                 </div>
             </div>
@@ -178,18 +174,15 @@ export const HomeTabContents = (
                 action={props.actions.buildTimeActions[ActionEnum.Add_Column]}
                 highlightToolbarButton={props.highlightAddColButton}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Add_Column].isDisabled()}
             />
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Delete_Column]}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Delete_Column].isDisabled()}
 
             />
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Change_Dtype]}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Change_Dtype].isDisabled()}
             >  
                 <Dropdown
                     display={props.uiState.toolbarDropdown === 'dtype'}
@@ -224,25 +217,21 @@ export const HomeTabContents = (
                 action={props.actions.buildTimeActions[ActionEnum.Pivot]}
                 highlightToolbarButton={props.highlightPivotTableButton}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Pivot].isDisabled()}
             />
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Graph]}
                 setEditorState={props.setEditorState}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Graph].isDisabled()}
             />
             {props.userProfile.mitoConfig.MITO_CONFIG_FEATURE_DISPLAY_AI_TRANSFORMATION && 
                 <ToolbarButton
                     action={props.actions.buildTimeActions[ActionEnum.AI_TRANSFORMATION]}
                     setEditorState={props.setEditorState}
-                    disabledTooltip={props.actions.buildTimeActions[ActionEnum.AI_TRANSFORMATION].isDisabled()}
                 />
             }
             {props.userProfile.mitoConfig.MITO_CONFIG_CODE_SNIPPETS?.MITO_CONFIG_CODE_SNIPPETS_URL !== undefined && 
                 <ToolbarButton
                     action={props.actions.buildTimeActions[ActionEnum.CODESNIPPETS]}
                     setEditorState={props.setEditorState}
-                    disabledTooltip={props.actions.buildTimeActions[ActionEnum.CODESNIPPETS].isDisabled()}
                 />
             }
         </div>
@@ -250,16 +239,13 @@ export const HomeTabContents = (
             <ToolbarButton
                 id={MITO_TOOLBAR_UNDO_ID} // NOTE: this is used to click the undo button in plugin.tsx
                 action={props.actions.buildTimeActions[ActionEnum.Undo]}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Undo].isDisabled()}
             />
             <ToolbarButton
                 id={MITO_TOOLBAR_REDO_ID} // NOTE: this is used to click the redo button in plugin.tsx
                 action={props.actions.buildTimeActions[ActionEnum.Redo]}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Redo].isDisabled()}
             />
             <ToolbarButton
                 action={props.actions.buildTimeActions[ActionEnum.Clear]}
-                disabledTooltip={props.actions.buildTimeActions[ActionEnum.Clear].isDisabled()}
             />
         </div>
     </div>);

--- a/mitosheet/src/mito/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/mito/components/toolbar/Toolbar.tsx
@@ -21,8 +21,8 @@ import ToolbarUserDefinedEditsDropdown from './ToolbarUserDefinedEditsDropdown';
 import { HomeTabContents } from './HomeTabContents';
 import { classNames } from '../../utils/classNames';
 import ToolbarButton from './ToolbarButton';
-import { ToolbarButtonType } from './utils';
 import fscreen from 'fscreen';
+import { CloseFullscreenIcon, OpenFullscreenIcon } from '../icons/FullscreenIcons';
 
 export const MITO_TOOLBAR_OPEN_SEARCH_ID = 'mito-open-search';
 export const MITO_TOOLBAR_UNDO_ID = 'mito-undo-button';
@@ -188,11 +188,10 @@ export const Toolbar = (
                 <div className='mito-toolbar-tabbar-right'>
                     <ToolbarButton
                         id={MITO_TOOLBAR_OPEN_SEARCH_ID} // NOTE: this is used to click the open search button in plugin.tsx
-                        toolbarButtonType={ToolbarButtonType.OPEN_SEARCH}
                         action={props.actions.buildTimeActions[ActionEnum.OpenSearch]}
                     />
                     <ToolbarButton
-                        toolbarButtonType={fscreen.fullscreenElement ? ToolbarButtonType.CLOSE_FULLSCREEN : ToolbarButtonType.OPEN_FULLSCREEN}
+                        iconOverride={fscreen.fullscreenElement ? <CloseFullscreenIcon /> : <OpenFullscreenIcon />}
                         action={props.actions.buildTimeActions[ActionEnum.Fullscreen]}
                     />
                 </div>

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { BuildTimeAction, EditorState } from '../../types';
 import { classNames } from '../../utils/classNames';
-import { getToolbarItemIcon, ToolbarButtonType } from './utils';
+import { getToolbarItemIcon } from './utils';
 
 /**
  * The ToolbarButton component is used to create each
@@ -15,10 +15,11 @@ const ToolbarButton = (
         * @param id - An option id to put on the element, so we can grab it elsewhere 
         */
         id?: string;
-        /** 
-        * @param toolbarButtonType - The toolbaryItemType is used to determine the correct icon to display. 
-        */
-        toolbarButtonType: ToolbarButtonType;
+
+        /**
+         * If there is a special case for the icon (see FullScreen)
+         */
+        iconOverride?: JSX.Element;
 
         /** 
         * @param action - The action to run when the toolbar button is clicked
@@ -79,7 +80,7 @@ const ToolbarButton = (
                 */}
                 <span title={props.disabledTooltip || props.action.tooltip}>
                     <div className='mito-toolbar-button-icon-container'>
-                        {getToolbarItemIcon(props.toolbarButtonType)}
+                        {props.iconOverride ?? getToolbarItemIcon(props.action)}
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}
                     </div>
                     {props.action.shortTitle && <p className='mito-toolbar-button-label'> 

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { BuildTimeAction, EditorState } from '../../types';
 import { classNames } from '../../utils/classNames';
-import { getToolbarItemIcon } from './utils';
+import StepsIcon from '../icons/StepsIcon';
 
 /**
  * The ToolbarButton component is used to create each
@@ -81,7 +81,7 @@ const ToolbarButton = (
                 */}
                 <span title={disabledTooltip || props.action.tooltip}>
                     <div className='mito-toolbar-button-icon-container'>
-                        {props.iconOverride ?? getToolbarItemIcon(props.action)}
+                        {props.iconOverride ?? (props.action.icon !== undefined ? <props.action.icon /> : <StepsIcon />)}
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}
                     </div>
                     {props.action.toolbarTitle && <p className='mito-toolbar-button-label'> 

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -49,6 +49,7 @@ const ToolbarButton = (
     }): JSX.Element => {
 
     const disabled = props.disabledTooltip !== undefined;
+    const disabledTooltip = props.disabledTooltip ?? props.action.isDisabled();
     const highlightToobarItemClass = props.highlightToolbarButton === true ? 'mito-toolbar-button-draw-attention' : ''
     const hasDropdown = props.children !== undefined;
     
@@ -78,7 +79,7 @@ const ToolbarButton = (
                     
                     If the icons have different heights, the text won't line up. 
                 */}
-                <span title={props.disabledTooltip || props.action.tooltip}>
+                <span title={disabledTooltip || props.action.tooltip}>
                     <div className='mito-toolbar-button-icon-container'>
                         {props.iconOverride ?? getToolbarItemIcon(props.action)}
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}

--- a/mitosheet/src/mito/components/toolbar/utils.tsx
+++ b/mitosheet/src/mito/components/toolbar/utils.tsx
@@ -3,25 +3,7 @@ import React from 'react';
 
 import { Action, UserProfile } from '../../types';
 import DropdownItem from '../elements/DropdownItem';
-import AIIcon from '../icons/AIIcon';
-import AddColumnIcon from '../icons/AddColumnIcon';
-import CatchUpIcon from '../icons/CatchUpIcon';
-import ClearIcon from '../icons/ClearIcon';
-import CodeSnippetIcon from '../icons/CodeSnippetIcon';
-import DeleteColumnIcon from '../icons/DeleteColumnIcon';
-import DtypeIcon from '../icons/DtypeIcon';
-import ExportIcon from '../icons/ExportIcon';
-import FormatIcon from '../icons/FormatIcon';
-import { CloseFullscreenIcon, OpenFullscreenIcon } from '../icons/FullscreenIcons';
-import GraphIcon from '../icons/GraphIcon';
-import ImportIcon from '../icons/ImportIcon';
-import LessIcon from '../icons/LessIcon';
-import MoreIcon from '../icons/MoreIcon';
-import PivotIcon from '../icons/PivotIcon';
-import RedoIcon from '../icons/RedoIcon';
-import SearchIcon from '../icons/SearchIcon';
 import StepsIcon from '../icons/StepsIcon';
-import UndoIcon from '../icons/UndoIcon';
 
 /* 
     Each toolbar button icon has both a light and dark option. 
@@ -32,73 +14,11 @@ import UndoIcon from '../icons/UndoIcon';
 export type IconVariant = 'light' | 'dark'
 
 /* 
-    Each button in the toolbar is one of the ToolbarButtonType.
-    We use the ToolbarButtonType to get the correct icons for each button. 
-
-    In the future, we will also use this type to do things like having one function
-    that can be used to specify any toolbar item to have attention drawn to. ie: 
-    through the tour. 
-*/
-export enum ToolbarButtonType {
-    UNDO = 'UNDO',
-    REDO = 'REDO',
-    CLEAR = 'CLEAR',
-
-    IMPORT = "IMPORT",
-    EXPORT = "EXPORT",
-
-    ADD_COL = "ADD COL",
-    DEL_COL = "DEL COL",
-    DTYPE = "DTYPE",
-
-    LESS = "LESS",
-    MORE = "MORE",
-    FORMAT = "FORMAT",
-
-    PIVOT = "PIVOT",
-    GRAPH = "GRAPH",
-    AI_TRANSFORMATION = "AI_TRANSFORMATION",
-    CODE_SNIPPETS = 'CODE_SNIPPETS',
-
-    CATCH_UP = "CATCH UP",
-    STEPS = "STEPS",
-    OPEN_FULLSCREEN = "OPEN FULLSCREEN",
-    CLOSE_FULLSCREEN = "CLOSE FULLSCREEN",
-    OPEN_SEARCH = "OPEN SEARCH",
-}
-
-/* 
     Helper function for getting the light and dark version of each 
     toolbar icon. 
 */
-export const getToolbarItemIcon = (toolbarButtonType: ToolbarButtonType): JSX.Element => {
-    switch (toolbarButtonType) {
-        case ToolbarButtonType.UNDO: {return <UndoIcon />}
-        case ToolbarButtonType.REDO: {return <RedoIcon />}
-        case ToolbarButtonType.CLEAR: {return <ClearIcon />}
-
-        case ToolbarButtonType.IMPORT: {return <ImportIcon />}
-        case ToolbarButtonType.EXPORT: {return <ExportIcon />}
-
-        case ToolbarButtonType.ADD_COL: {return <AddColumnIcon />}
-        case ToolbarButtonType.DEL_COL: {return <DeleteColumnIcon />}
-        case ToolbarButtonType.DTYPE: {return <DtypeIcon />}
-
-        case ToolbarButtonType.LESS: {return <LessIcon />}
-        case ToolbarButtonType.MORE: {return <MoreIcon />}
-        case ToolbarButtonType.FORMAT: {return <FormatIcon />}
-
-        case ToolbarButtonType.PIVOT: {return <PivotIcon />}
-        case ToolbarButtonType.GRAPH: {return <GraphIcon />}
-        case ToolbarButtonType.AI_TRANSFORMATION: {return <AIIcon />}
-        case ToolbarButtonType.CODE_SNIPPETS: {return <CodeSnippetIcon />}
-
-        case ToolbarButtonType.CATCH_UP: {return <CatchUpIcon />}
-        case ToolbarButtonType.STEPS: {return <StepsIcon />}
-        case ToolbarButtonType.OPEN_FULLSCREEN: {return <OpenFullscreenIcon />}
-        case ToolbarButtonType.CLOSE_FULLSCREEN: {return <CloseFullscreenIcon />}
-        case ToolbarButtonType.OPEN_SEARCH: {return <SearchIcon />}
-    }
+export const getToolbarItemIcon = (action: Action): JSX.Element => {
+    return action.icon !== undefined ? <action.icon /> : <StepsIcon />
 }
 
 /**

--- a/mitosheet/src/mito/components/toolbar/utils.tsx
+++ b/mitosheet/src/mito/components/toolbar/utils.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { Action, UserProfile } from '../../types';
 import DropdownItem from '../elements/DropdownItem';
-import StepsIcon from '../icons/StepsIcon';
 
 /* 
     Each toolbar button icon has both a light and dark option. 
@@ -12,14 +11,6 @@ import StepsIcon from '../icons/StepsIcon';
     on a light background (ie: at rest). 
 */
 export type IconVariant = 'light' | 'dark'
-
-/* 
-    Helper function for getting the light and dark version of each 
-    toolbar icon. 
-*/
-export const getToolbarItemIcon = (action: Action): JSX.Element => {
-    return action.icon !== undefined ? <action.icon /> : <StepsIcon />
-}
 
 /**
  * A helper function that makes dropdown items for the toolbar menus. This is

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -1002,6 +1002,9 @@ export interface BaseAction<Type, StaticType> {
     // The optional long title for the action.
     longTitle: string
 
+    // The optional icon to display for the action
+    icon?: React.FC<any>;
+
     /* 
         The function to call if the action is taken by the user. This should
         not require any parameters to be called, as all the necessary data

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -16,6 +16,21 @@ import { getCopyStringForClipboard, writeTextToClipboard } from "./copy";
 import { FORMAT_DISABLED_MESSAGE, decreasePrecision, increasePrecision } from "./format";
 import { SendFunctionStatus } from "../api/send";
 import {getDisplayNameOfPythonVariable} from './userDefinedFunctionUtils'
+import UndoIcon from "../components/icons/UndoIcon";
+import AddColumnIcon from "../components/icons/AddColumnIcon";
+import CatchUpIcon from "../components/icons/CatchUpIcon";
+import DtypeIcon from "../components/icons/DtypeIcon";
+import ClearIcon from "../components/icons/ClearIcon";
+import DeleteColumnIcon from "../components/icons/DeleteColumnIcon";
+import PivotIcon from "../components/icons/PivotIcon";
+import AIIcon from "../components/icons/AIIcon";
+import ImportIcon from "../components/icons/ImportIcon";
+import ExportIcon from "../components/icons/ExportIcon";
+import LessIcon from "../components/icons/LessIcon";
+import MoreIcon from "../components/icons/MoreIcon";
+import GraphIcon from "../components/icons/GraphIcon";
+import SearchIcon from "../components/icons/SearchIcon";
+import RedoIcon from "../components/icons/RedoIcon";
 
 /**
  * This is a wrapper class that holds all frontend actions. This allows us to create and register
@@ -107,6 +122,7 @@ export const getActions = (
         [ActionEnum.Add_Column]: {
             type: 'build-time',
             staticType: ActionEnum.Add_Column,
+            icon: AddColumnIcon,
             shortTitle: 'Add Col',
             longTitle: 'Add column',
             actionFunction: () => {
@@ -137,6 +153,7 @@ export const getActions = (
         [ActionEnum.Catch_Up]: {
             type: 'build-time',
             staticType: ActionEnum.Catch_Up,
+            icon: CatchUpIcon,
             shortTitle: 'Catch Up',
             longTitle: 'Catch up',
             actionFunction: () => {
@@ -151,6 +168,7 @@ export const getActions = (
         [ActionEnum.Change_Dtype]: {
             type: 'build-time',
             staticType: ActionEnum.Change_Dtype,
+            icon: DtypeIcon,
             shortTitle: 'Dtype',
             longTitle: 'Change column dtype',
             actionFunction: () => {
@@ -177,6 +195,7 @@ export const getActions = (
         [ActionEnum.Clear]: {
             type: 'build-time',
             staticType: ActionEnum.Clear,
+            icon: ClearIcon,
             shortTitle: 'Clear',
             longTitle: "Clear all edits",
             actionFunction: () => {
@@ -270,6 +289,7 @@ export const getActions = (
             type: 'build-time',
             staticType: ActionEnum.Delete_Column,
             shortTitle: 'Del Col',
+            icon: DeleteColumnIcon,
             longTitle: 'Delete columns',
             actionFunction: async () => {
                 // We turn off editing mode, if it is on
@@ -458,6 +478,7 @@ export const getActions = (
         [ActionEnum.Export]: {
             type: 'build-time',
             staticType: ActionEnum.Export,
+            icon: ExportIcon,
             shortTitle: 'Download',
             longTitle: 'Download File Now',
             actionFunction: () => {
@@ -486,6 +507,7 @@ export const getActions = (
             type: 'build-time',
             staticType: ActionEnum.Export_Dropdown,
             shortTitle: 'Export',
+            icon: ExportIcon,
             longTitle: 'Open Export Dropdown',
             actionFunction: () => {
                 setEditorState(undefined);
@@ -618,6 +640,7 @@ export const getActions = (
         [ActionEnum.Graph]: {
             type: 'build-time',
             staticType: ActionEnum.Graph,
+            icon: GraphIcon,
             shortTitle: 'Graph',
             longTitle: 'Create new graph',
             actionFunction: async () => {
@@ -677,6 +700,7 @@ export const getActions = (
         [ActionEnum.Import_Dropdown]: {
             type: 'build-time',
             staticType: ActionEnum.Import_Dropdown,
+            icon: ImportIcon,
             shortTitle: 'Import',
             longTitle: 'Open import dropdown',
             actionFunction: () => {
@@ -771,6 +795,7 @@ export const getActions = (
         [ActionEnum.Pivot]: {
             type: 'build-time',
             staticType: ActionEnum.Pivot,
+            icon: PivotIcon,
             shortTitle: 'Pivot',
             longTitle: 'Pivot table',
             actionFunction: async () => {
@@ -837,6 +862,7 @@ export const getActions = (
         [ActionEnum.Precision_Decrease]: {
             type: 'build-time',
             staticType: ActionEnum.Precision_Decrease,
+            icon: LessIcon,
             longTitle: 'Decrease decimal places displayed',
             actionFunction: async () => {  
                 closeOpenEditingPopups();
@@ -864,6 +890,7 @@ export const getActions = (
         [ActionEnum.Precision_Increase]: {
             type: 'build-time',
             staticType: ActionEnum.Precision_Increase,
+            icon: MoreIcon,
             longTitle: 'Increase decimal places displayed',
             actionFunction: async () => {  
                 closeOpenEditingPopups();
@@ -911,6 +938,7 @@ export const getActions = (
         [ActionEnum.Redo]: {
             type: 'build-time',
             staticType: ActionEnum.Redo,
+            icon: RedoIcon,
             shortTitle: 'Redo',
             longTitle: 'Redo',
             actionFunction: () => {
@@ -1161,6 +1189,7 @@ export const getActions = (
         [ActionEnum.OpenSearch]: {
             type: 'build-time',
             staticType: ActionEnum.OpenSearch,
+            icon: SearchIcon,
             longTitle: 'Search',
             actionFunction: () => {
                 // We turn off editing mode, if it is on
@@ -1193,6 +1222,7 @@ export const getActions = (
         [ActionEnum.Undo]: {
             type: 'build-time',
             staticType: ActionEnum.Undo,
+            icon: UndoIcon,
             shortTitle: 'Undo',
             longTitle: 'Undo',
             actionFunction: () => {
@@ -1507,6 +1537,7 @@ export const getActions = (
         [ActionEnum.AI_TRANSFORMATION]: {
             type: 'build-time',
             staticType: ActionEnum.AI_TRANSFORMATION,
+            icon: AIIcon,
             shortTitle: 'AI',
             longTitle: 'AI Transformation',
             actionFunction: () => {


### PR DESCRIPTION
# Description
This adds an optional field into the `BaseAction` type to prepare for adding icons for many of the actions that are currently in the main menu at the top. Defaults to the `StepsIcon` because it looks pretty generic. 

Also, adds the default behavior for `disabledTooltip` into the `ToolbarButton` class to avoid a bunch of extra lines of code for passing it as a prop. 

# Testing
Check that the toolbar has all of the icons you expect. 
