### PR TITLE
Datetime fix

### DIFF
--- a/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
+++ b/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
@@ -87,6 +87,9 @@ def get_datetime_format(string_series: pd.Series) -> Optional[str]:
     # Import log function here to avoid circular import
     from mitosheet.telemetry.telemetry_utils import log
 
+    # Filter to only the strings, as this is all we're trying to convert really
+    string_series = string_series[string_series.apply(lambda x: isinstance(x, str))]
+
     # If we can convert all non null inputs, then we assume we guessed correctly
     non_null_inputs = string_series[~string_series.isna()]
 
@@ -100,7 +103,7 @@ def get_datetime_format(string_series: pd.Series) -> Optional[str]:
     # trying all of the formats below for performance.
 
     # Then we try a bunch of other formats it could be
-    sample_string_datetime = str(string_series[string_series.first_valid_index()])
+    sample_string_datetime = string_series[string_series.first_valid_index()]
     FORMATS = [
         '%m{s}%d{s}%Y', 
         '%d{s}%m{s}%Y', 

--- a/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
+++ b/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
@@ -100,7 +100,7 @@ def get_datetime_format(string_series: pd.Series) -> Optional[str]:
     # trying all of the formats below for performance.
 
     # Then we try a bunch of other formats it could be
-    sample_string_datetime = string_series[string_series.first_valid_index()]
+    sample_string_datetime = str(string_series[string_series.first_valid_index()])
     FORMATS = [
         '%m{s}%d{s}%Y', 
         '%d{s}%m{s}%Y', 

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -351,3 +351,22 @@ def test_change_multiple_dtype_fails_is_atomic():
     mito = create_mito_wrapper(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))
     mito.change_column_dtype(0, ['A', 'B'], 'timedelta')
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))
+
+def test_change_dtype_to_datetime_mixed_string_type():
+    # https://github.com/mito-ds/mito/issues/1006
+    df = pd.DataFrame({'Date': [pd.to_datetime('1648784800000', unit='ms'), pd.to_datetime('1648784800000', unit='ms'), 'Q1 2023']})
+    mito = create_mito_wrapper(df)
+
+    mito.change_column_dtype(0, ['Date'], 'datetime')
+
+    print(mito.dfs[0])
+
+    assert mito.dfs[0].equals(
+        pd.DataFrame({
+            'Date': [
+                pd.to_datetime('1648784800000', unit='ms'),
+                pd.to_datetime('1648784800000', unit='ms'),
+                pd.NaT
+            ]
+        })
+    )

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -370,3 +370,21 @@ def test_change_dtype_to_datetime_mixed_string_type():
             ]
         })
     )
+
+def test_change_dtype_to_datetime_finds_first_string():
+    df = pd.DataFrame({'Date': [pd.to_datetime('1648784800000', unit='ms'), pd.to_datetime('1648784800000', unit='ms'), '12/22/2023']})
+    mito = create_mito_wrapper(df)
+
+    mito.change_column_dtype(0, ['Date'], 'datetime')
+
+    print(mito.dfs[0])
+
+    assert mito.dfs[0].equals(
+        pd.DataFrame({
+            'Date': [
+                pd.to_datetime('1648784800000', unit='ms'),
+                pd.to_datetime('1648784800000', unit='ms'),
+                pd.to_datetime('12/22/2023')
+            ]
+        })
+    )


### PR DESCRIPTION
# Description

Closes https://github.com/mito-ds/mito/issues/1006, by making it so you can convert mixed types to date times.

Note that this doesn't fix the frontend display issue, for two reasons:
1. It's hard to do so in a performant way
2. Leaving it makes it more clear to these that they have to convert to a date time

# Testing

See new tests.

# Documentation

N/A.