### PR TITLE
Sitemap

### DIFF
--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -9,37 +9,13 @@ import excelToPythonStyles from '../styles/ExcelToPython.module.css';
 
 // Import Icons & Background Grid
 import { classNames } from '../utils/classNames';
-import { getPageContentJsonArray } from '../utils/excel-to-python';
+import { getGlossaryPageInfo, getPageContentJsonArray, GlossaryPageInfo } from '../utils/excel-to-python';
 import Link from 'next/link';
 import PageTOC from '../components/Glossary/PageTOC/PageTOC';
 import TextButton from '../components/TextButton/TextButton';
 import { PageContent } from '../excel-to-python-page-contents/types';
 import textImageSplitStyles from '../styles/TextImageSplit.module.css';
 import CTAButtons from '../components/CTAButtons/CTAButtons';
-
-export type GlossaryPageInfo = {
-    functionNameShort: string,
-    purpose: string,
-    slug: string[],
-}
-
-export const getGlossaryPageInfoForSection = (glossaryPageInfo: GlossaryPageInfo[], section: string) => {
-    return glossaryPageInfo.filter((glossaryPageInfo) => {
-        return glossaryPageInfo.slug[1] === section
-    })
-}
-
-export const getGlossaryPageInfo = async (pageContentsJsonArray: PageContent[]): Promise<GlossaryPageInfo[]> => {
-  
-    // Get information about each glossay page
-    return pageContentsJsonArray.map((pageContentsJson) => {
-      return {
-        functionNameShort: pageContentsJson.functionNameShort,
-        purpose: pageContentsJson.purpose,
-        slug: [...pageContentsJson.slug]
-      }
-    })
-}
 
 export const getStaticProps: GetStaticProps<{glossaryPageInfo: GlossaryPageInfo[]}> = async () => {
     const pageContentsJsonArray = await getPageContentJsonArray()
@@ -49,6 +25,12 @@ export const getStaticProps: GetStaticProps<{glossaryPageInfo: GlossaryPageInfo[
         props: { glossaryPageInfo },
         revalidate: 60, // Revalidate every 1 minute
     }
+}
+
+export const getGlossaryPageInfoForSection = (glossaryPageInfo: GlossaryPageInfo[], section: string) => {
+    return glossaryPageInfo.filter((glossaryPageInfo) => {
+        return glossaryPageInfo.slug[1] === section
+    })
 }
 
 const GlossaryPageCard = (props: {glossaryPageInfo: GlossaryPageInfo}) => {

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -21,13 +21,12 @@ import PageTOC from '../../components/Glossary/PageTOC/PageTOC';
 import { useRouter } from 'next/router';
 import { GetStaticProps } from 'next';
 
-import { getPageContentJsonArray } from '../../utils/excel-to-python';
+import { getGlossaryPageInfo, getPageContentJsonArray, GlossaryPageInfo } from '../../utils/excel-to-python';
 import { PageContent } from '../../excel-to-python-page-contents/types';
 
 import Prism from 'prismjs';
 import 'prism-themes/themes/prism-coldark-dark.css'
 import { arraysContainSameValueAndOrder } from '../../utils/arrays';
-import { getGlossaryPageInfo, GlossaryPageInfo } from '../excel-to-python';
 import Link from 'next/link';
 require('prismjs/components/prism-python');
 

--- a/trymito.io/pages/robots.txt
+++ b/trymito.io/pages/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.trymito.io/sitemap.xml

--- a/trymito.io/pages/robots.txt
+++ b/trymito.io/pages/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://www.trymito.io/sitemap.xml

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -72,9 +72,6 @@ function generateSiteMap(glossarySlugs: string[], blogPostSlugs: string[]) {
     `;
 }
 
-function SiteMap() {
-  // getServerSideProps will do the heavy lifting
-}
 
 export const getServerSideProps = async ({res}: any) => {
     // Get the glossary pages
@@ -109,6 +106,3 @@ export const getServerSideProps = async ({res}: any) => {
     };
     
 }
-
-
-export default SiteMap;

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -1,0 +1,76 @@
+//pages/sitemap.xml.js
+
+import { getGlossaryPageInfo, getPageContentJsonArray } from '../utils/excel-to-python';
+import { getPosts } from '../utils/posts';
+import { SLUG_REDIRECTS } from './blog';
+
+
+const WEBSITE_HOST_URL = 'https://trymito.io';
+
+function generateSiteMap(glossarySlugs: string[], blogPostSlugs: string[]) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <!--We manually set the two URLs we know already-->
+            <url>
+                <loc>https://jsonplaceholder.typicode.com</loc>
+            </url>
+            <url>
+                <loc>https://jsonplaceholder.typicode.com/guide</loc>
+            </url>
+            ${glossarySlugs.map(glossarySlug => {
+                return `
+                <url>
+                    <loc>${`${WEBSITE_HOST_URL}/excel-to-python/${glossarySlug}`}</loc>
+                </url>
+                `;
+            }).join('')}
+            ${blogPostSlugs.map(blogPostSlug => {
+                return `
+                <url>
+                    <loc>${`${WEBSITE_HOST_URL}/blog/${blogPostSlug}`}</loc>
+                </url>
+                `;
+            }).join('')}
+        </urlset>
+    `;
+}
+
+function SiteMap() {
+  // getServerSideProps will do the heavy lifting
+}
+
+export const getStaticProps = async ({res}: any) => {
+    // Get the glossary pages
+    const pageContentsJsonArray = await getPageContentJsonArray()
+    const glossaryPageInfo = await getGlossaryPageInfo(pageContentsJsonArray)
+    const glossarySlugs = glossaryPageInfo.map((pageInfo) => pageInfo.slug.join('/'))
+
+    // Get the blog pages
+    const blogPostSlugs: string[] = []
+    const posts = await getPosts()
+    if (posts) {
+        // Redirect old slugs to new slugs
+        posts.forEach(post => {
+            if (SLUG_REDIRECTS[post.slug]) {
+                blogPostSlugs.push(SLUG_REDIRECTS[post.slug])
+            }
+        })
+    }
+
+    // We generate the XML sitemap with the posts data
+    const sitemap = generateSiteMap(glossarySlugs, blogPostSlugs);
+    console.log(sitemap)
+
+    res.setHeader('Content-Type', 'text/xml');
+    // we send the XML to the browser
+    res.write(sitemap);
+    res.end();
+
+    return {
+        props: {},
+    };
+    
+}
+
+
+export default SiteMap;

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -39,7 +39,7 @@ function SiteMap() {
   // getServerSideProps will do the heavy lifting
 }
 
-export const getStaticProps = async ({res}: any) => {
+export const getServerSideProps = async ({res}: any) => {
     // Get the glossary pages
     const pageContentsJsonArray = await getPageContentJsonArray()
     const glossaryPageInfo = await getGlossaryPageInfo(pageContentsJsonArray)

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -1,9 +1,10 @@
 //pages/sitemap.xml.js
+// Dynamically generate a sitemap.xml file for our site following
+// https://nextjs.org/learn-pages-router/seo/crawling-and-indexing/xml-sitemaps
 
 import { getGlossaryPageInfo, getPageContentJsonArray } from '../utils/excel-to-python';
 import { getPosts } from '../utils/posts';
 import { SLUG_REDIRECTS } from './blog';
-
 
 const WEBSITE_HOST_URL = 'https://trymito.io';
 
@@ -97,7 +98,6 @@ export const getServerSideProps = async ({res}: any) => {
 
     // We generate the XML sitemap with the posts data
     const sitemap = generateSiteMap(glossarySlugs, blogPostSlugs);
-    console.log(sitemap)
 
     res.setHeader('Content-Type', 'text/xml');
     // we send the XML to the browser

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -12,10 +12,46 @@ function generateSiteMap(glossarySlugs: string[], blogPostSlugs: string[]) {
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
             <!--We manually set the two URLs we know already-->
             <url>
-                <loc>https://jsonplaceholder.typicode.com</loc>
+                <loc>https://www.trymito.io/</loc>
             </url>
             <url>
-                <loc>https://jsonplaceholder.typicode.com/guide</loc>
+                <loc>https://www.trymito.io/plans</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/spreadsheet-automation</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/python-ai-tools</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/low-code-sql</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/data-app</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/infrastructure-integration-python-tool</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/industries/financial-services</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/industries/life-sciences</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/customers</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/security</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/blog</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/excel-to-python</loc>
+            </url>
+            <url>
+                <loc>https://www.trymito.io/teams</loc>
             </url>
             ${glossarySlugs.map(glossarySlug => {
                 return `
@@ -53,6 +89,8 @@ export const getServerSideProps = async ({res}: any) => {
         posts.forEach(post => {
             if (SLUG_REDIRECTS[post.slug]) {
                 blogPostSlugs.push(SLUG_REDIRECTS[post.slug])
+            } else {
+                blogPostSlugs.push(post.slug)
             }
         })
     }

--- a/trymito.io/pages/sitemap.xml.tsx
+++ b/trymito.io/pages/sitemap.xml.tsx
@@ -72,6 +72,10 @@ function generateSiteMap(glossarySlugs: string[], blogPostSlugs: string[]) {
     `;
 }
 
+function SiteMap() {
+  // getServerSideProps will do the heavy lifting
+  // TODO: Understand why this function is needed for the build to succeed
+}
 
 export const getServerSideProps = async ({res}: any) => {
     // Get the glossary pages
@@ -106,3 +110,6 @@ export const getServerSideProps = async ({res}: any) => {
     };
     
 }
+
+
+export default SiteMap;

--- a/trymito.io/public/robots.txt
+++ b/trymito.io/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.trymito.io/sitemap.xml

--- a/trymito.io/tsconfig.json
+++ b/trymito.io/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/sitemap.xml.js", "pages/sitemap.xml.js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/sitemap.xml.js"],
   "exclude": ["node_modules"]
 }

--- a/trymito.io/tsconfig.json
+++ b/trymito.io/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/sitemap.xml.js", "pages/sitemap.xml.js"],
   "exclude": ["node_modules"]
 }

--- a/trymito.io/utils/excel-to-python.tsx
+++ b/trymito.io/utils/excel-to-python.tsx
@@ -2,6 +2,24 @@ import path from 'path'
 import fs from 'fs'
 import { PageContent } from '../excel-to-python-page-contents/types'
 
+export type GlossaryPageInfo = {
+    functionNameShort: string,
+    purpose: string,
+    slug: string[],
+}
+
+export const getGlossaryPageInfo = async (pageContentsJsonArray: PageContent[]): Promise<GlossaryPageInfo[]> => {
+  
+    // Get information about each glossay page
+    return pageContentsJsonArray.map((pageContentsJson) => {
+      return {
+        functionNameShort: pageContentsJson.functionNameShort,
+        purpose: pageContentsJson.purpose,
+        slug: [...pageContentsJson.slug]
+      }
+    })
+}
+
 export async function getPageContentJsonArray() {
     const relativePath = './excel-to-python-page-contents/'
 


### PR DESCRIPTION
# Description

Sitemaps allow Google to figure out what pages exist on our website so it can show them to users. This approach dynamically generates the sitemap so we don't need to remember to update it when we create new blogs or glossary pages. 

Hardcodes all of our landing pages that should not change.

Implemented according to this guide: https://nextjs.org/learn-pages-router/seo/crawling-and-indexing/xml-sitemaps

Also adds a `robots.txt` file with default settings + a pointer to the new sitemap file. We can evolve the other rules as we learn more. 
 
# Testing

1. Test the `sitemap` by opening the preview site and then adding `/sitemap.xml` then test the URLs to make sure they are correct. Test some of the foundational pages, glossary pages, and blogs. 
2. Test the `robots.txt` file by opening the preview site and then adding `/robots.xml`

# Documentation

No. 