### PR TITLE
mitosheet: add custom edit imports

### DIFF
--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -1074,21 +1074,27 @@ def ADDONE(x):
 def custom_import():
     return pd.DataFrame({'A': [1, 2, 3]})
 
+def custom_edit(df: pd.DataFrame) -> pd.DataFrame:
+    return df + 1
+
 def test_code_options_include_functions():
     
-    mito = create_mito_wrapper(sheet_functions=[ADDONE], importers=[custom_import])
+    mito = create_mito_wrapper(sheet_functions=[ADDONE], importers=[custom_import], editors=[custom_edit])
     mito.user_defined_import('custom_import', {})
     mito.set_formula('=ADDONE(A)', 0, 'B', add_column=True)
+    mito.user_defined_edit('custom_edit', {'df': 'df0'})
 
     mito.code_options_update({'as_function': True, 'import_custom_python_code': True, 'call_function': True, 'function_name': 'function', 'function_params': {}})
-    print("\n".join(mito.transpiled_code))
+    print(mito.transpiled_code)
     assert "\n".join(mito.transpiled_code) == """from mitosheet.public.v3 import *
-from mitosheet.tests.test_transpile import custom_import, ADDONE
+from mitosheet.tests.test_transpile import custom_import, ADDONE, custom_edit
 
 def function():
     df0 = custom_import()
     
     df0.insert(1, 'B', ADDONE(df0['A']))
+    
+    df0 = custom_edit(df=df0)
     
     return df0
 

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -321,7 +321,7 @@ def get_imports_for_custom_python_code(code: List[str], steps_manager: StepsMana
 
     import_map: Dict[str, List[str]] = {}
 
-    all_custom_python_code = (steps_manager.user_defined_importers or []) + (steps_manager.user_defined_functions or [])
+    all_custom_python_code = (steps_manager.user_defined_importers or []) + (steps_manager.user_defined_functions or []) + (steps_manager.user_defined_editors or [])
 
     for func in all_custom_python_code:
         if any(func.__name__ in line for line in code):


### PR DESCRIPTION
# Description

Adds user defined editors to the import statement we create in generated code so that we can use them in automations! 

# Testing

See tests

# Documentation

No. 