### PR TITLE
Add custom editors tab to the toolbar

### DIFF
--- a/mitosheet/app.py
+++ b/mitosheet/app.py
@@ -29,6 +29,7 @@ analysis = spreadsheet(
     df_names=['df'],
     import_folder='datasets',
     sheet_functions=[ADD_ONE],
+    editors=[add_number_to_df, add_diff_number_to_df_and_this_is_a_long_name],
     return_type='analysis'
 )
 

--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -350,3 +350,8 @@
   stroke: var(--mito-text-medium)!important;
   stroke-width: 0.75px;
 }
+
+#mito-editor-tab .mito-toolbar-button-label {
+  overflow: hidden;
+  max-height: 27px;
+}

--- a/mitosheet/src/mito/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/mito/components/toolbar/Toolbar.tsx
@@ -69,7 +69,7 @@ export const Toolbar = (
         'Code': <CodeTabContents {...props}/>,
     };
     if (props.actions.runtimeEditActionsList.length > 0) {
-        tabs['Editor'] = <div className='mito-toolbar-bottom' id='mito-editor-tab'>
+        tabs['Custom Edits'] = <div className='mito-toolbar-bottom' id='mito-editor-tab'>
             {props.actions.runtimeEditActionsList.map((action) => {
                 return <ToolbarButton
                     action={action}

--- a/mitosheet/src/mito/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/mito/components/toolbar/Toolbar.tsx
@@ -18,6 +18,7 @@ import PlanButton from './PlanButton';
 import ToolbarButton from './ToolbarButton';
 import CheckmarkIcon from '../icons/CheckmarkIcon';
 import LoadingDots from '../elements/LoadingDots';
+import EditIcon from '../icons/EditIcon';
 
 export const MITO_TOOLBAR_OPEN_SEARCH_ID = 'mito-open-search';
 export const MITO_TOOLBAR_UNDO_ID = 'mito-undo-button';
@@ -67,6 +68,16 @@ export const Toolbar = (
         'Formulas': <FormulaTabContents {...props}/>,
         'Code': <CodeTabContents {...props}/>,
     };
+    if (props.actions.runtimeEditActionsList.length > 0) {
+        tabs['Editor'] = <div className='mito-toolbar-bottom' id='mito-editor-tab'>
+            {props.actions.runtimeEditActionsList.map((action) => {
+                return <ToolbarButton
+                    action={action}
+                    iconOverride={action.icon === undefined ? <EditIcon/> : undefined}
+                />
+            })}
+        </div>
+    }
     const isLoading = () => {
         if (props.uiState.loading.length > 0) {
             for (const loadingInfo of props.uiState.loading) {

--- a/mitosheet/src/mito/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/mito/components/toolbar/Toolbar.tsx
@@ -73,6 +73,7 @@ export const Toolbar = (
             {props.actions.runtimeEditActionsList.map((action) => {
                 return <ToolbarButton
                     action={action}
+                    key={action.staticType}
                     iconOverride={action.icon === undefined ? <EditIcon/> : undefined}
                 />
             })}

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -88,7 +88,7 @@ const ToolbarButton = (
                     
                     If the icons have different heights, the text won't line up. 
                 */}
-                <span title={disabledTooltip || props.action.tooltip}>
+                <span title={disabledTooltip ?? props.action.tooltip ?? props.action.toolbarTitle}>
                     <div className='mito-toolbar-button-icon-container'>
                         {props.iconOverride ?? (props.action.icon !== undefined ? <props.action.icon /> : <StepsIcon />)}
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}


### PR DESCRIPTION
Adds a tab for the custom editors. If there are none, the tab doesn't appear. 
![image](https://github.com/mito-ds/mito/assets/6673460/d88af1ce-f13b-4a1e-94f6-ca2a0253a10e)
