### PR TITLE
Add Insert column to left and right to the column header dropdown

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1078,6 +1078,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                             closeOpenEditingPopups={closeOpenEditingPopups}
                             sendFunctionStatus={sendFunctionStatus}
                             analysisData={analysisData}
+                            actions={actions}
                         />
                     </div>
                     {uiState.currOpenTaskpane.type !== TaskpaneType.NONE && 

--- a/mitosheet/src/mito/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeader.tsx
@@ -16,6 +16,7 @@ import { submitRenameColumnHeader } from './columnHeaderUtils';
 import ColumnHeaderDropdown from './ColumnHeaderDropdown';
 import { getWidthArrayAtFullWidthForColumnIndexes } from './widthUtils';
 import { reconIsColumnCreated, reconIsColumnRenamed } from '../taskpanes/AITransformation/aiUtils';
+import { Actions } from '../../utils/actions';
 
 export const HEADER_TEXT_COLOR_DEFAULT = 'var(--mito-text)'
 export const HEADER_BACKGROUND_COLOR_DEFAULT = 'var(--mito-background-highlight)';
@@ -62,6 +63,7 @@ const ColumnHeader = (props: {
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
     mitoAPI: MitoAPI;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
+    actions: Actions;
 }): JSX.Element => {
 
     const [openColumnHeaderDropdown, setOpenColumnHeaderDropdown] = useState(false);
@@ -434,6 +436,7 @@ const ColumnHeader = (props: {
                 setEditorState={props.setEditorState}
                 sheetData={props.sheetData}
                 gridState={props.gridState}
+                actions={props.actions}
             />
         </div>
     )

--- a/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeaderDropdown.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { MitoAPI } from '../../api/api';
-import { ColumnID, EditorState, GridState, SheetData, UIState } from '../../types';
+import { ActionEnum, ColumnID, EditorState, GridState, SheetData, UIState } from '../../types';
 import { isNumberDtype } from '../../utils/dtypes';
 import Dropdown from '../elements/Dropdown';
 import DropdownItem from '../elements/DropdownItem';
@@ -11,6 +11,7 @@ import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane'
 import { TaskpaneType } from '../taskpanes/taskpanes';
 import { getStartingFormula } from './celleditor/cellEditorUtils';
 import { getColumnIndexesInSelections } from './selectionUtils';
+import { Actions } from '../../utils/actions';
 
 /*
     Displays a set of actions one can perform on a column header
@@ -28,6 +29,7 @@ export default function ColumnHeaderDropdown(props: {
     display: boolean;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
     gridState: GridState;
+    actions: Actions;
 }): JSX.Element {
 
     // Log opening this dropdown
@@ -49,6 +51,20 @@ export default function ColumnHeaderDropdown(props: {
             closeDropdown={() => props.setOpenColumnHeaderDropdown(false)}
             width='medium'
         >
+            <DropdownItem
+                title='Insert Column Left'
+                onClick={() => {
+                    props.closeOpenEditingPopups();
+                    void props.actions.buildTimeActions[ActionEnum.Add_Column_Left].actionFunction();
+                }}
+            />
+            <DropdownItem
+                title='Insert Column Right'
+                onClick={() => {
+                    props.closeOpenEditingPopups();
+                    void props.actions.buildTimeActions[ActionEnum.Add_Column_Right].actionFunction();
+                }}
+            />
             <DropdownItem 
                 title='Delete Column'
                 onClick={() => {

--- a/mitosheet/src/mito/components/endo/ColumnHeaders.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeaders.tsx
@@ -10,6 +10,7 @@ import { classNames } from '../../utils/classNames';
 import ColumnHeader from './ColumnHeader';
 import { changeColumnWidthDataArray } from './widthUtils';
 import { TaskpaneType } from '../taskpanes/taskpanes';
+import { Actions } from '../../utils/actions';
 
 
 /* 
@@ -29,6 +30,7 @@ const ColumnHeaders = (props: {
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
     mitoAPI: MitoAPI;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
+    actions: Actions;
 }): JSX.Element => {
         
     // The div that stores all the column headers
@@ -216,6 +218,7 @@ const ColumnHeaders = (props: {
                                     setUIState={props.setUIState}
                                     mitoAPI={props.mitoAPI}
                                     closeOpenEditingPopups={props.closeOpenEditingPopups}
+                                    actions={props.actions}
                                 />
                             )
                         })}

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -19,6 +19,7 @@ import { reconciliateWidthDataArray } from "./widthUtils";
 import FloatingCellEditor from "./celleditor/FloatingCellEditor";
 import { SendFunctionStatus } from "../../api/send";
 import { SearchBar } from "../SearchBar";
+import { Actions } from "../../utils/actions";
 
 // NOTE: these should match the css
 export const DEFAULT_WIDTH = 123;
@@ -90,7 +91,8 @@ function EndoGrid(props: {
     mitoContainerRef: React.RefObject<HTMLDivElement>
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
     sendFunctionStatus: SendFunctionStatus;
-    analysisData: AnalysisData
+    analysisData: AnalysisData;
+    actions: Actions;
 }): JSX.Element {
 
     // The container for the entire EndoGrid
@@ -689,6 +691,7 @@ function EndoGrid(props: {
                             setGridState={setGridState}
                             mitoAPI={mitoAPI}
                             closeOpenEditingPopups={props.closeOpenEditingPopups}
+                            actions={props.actions}
                         />
                         <IndexHeaders
                             sheetData={sheetData}

--- a/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
@@ -109,7 +109,7 @@ export const FormulaTabContents = (
 
     return (<div className='mito-toolbar-bottom'>
         <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Set_Column_Formula]} />
-        <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Add_Column]} />
+        <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Add_Column_Left]} />
 
         <div className="toolbar-vertical-line"/>
 

--- a/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
@@ -182,7 +182,7 @@ export const HomeTabContents = (
         <div className="toolbar-vertical-line"/>
 
         <ToolbarButton
-            action={props.actions.buildTimeActions[ActionEnum.Add_Column]}
+            action={props.actions.buildTimeActions[ActionEnum.Add_Column_Left]}
             highlightToolbarButton={props.highlightAddColButton}
         />
         <ToolbarButton

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -930,7 +930,8 @@ export const enum FeedbackID {
     then by spreadsheet functions
 */
 export enum ActionEnum {
-    Add_Column = 'add column',
+    Add_Column_Right = 'add column to the right',
+    Add_Column_Left = 'add column to the left',
     AntiMerge = 'anti merge',
     Catch_Up = 'catch up',
     Clear = 'clear',

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -156,12 +156,12 @@ export const getActions = (
         followed by all of the spreadsheet formulas. 
     */
     const buildTimeActions: Record<ActionEnum, BuildTimeAction> = {
-        [ActionEnum.Add_Column]: {
+        [ActionEnum.Add_Column_Right]: {
             type: 'build-time',
-            staticType: ActionEnum.Add_Column,
+            staticType: ActionEnum.Add_Column_Right,
             icon: AddColumnIcon,
             toolbarTitle: 'Insert',
-            longTitle: 'Add column',
+            longTitle: 'Insert column to the Right',
             actionFunction: async () => {
                 if (sheetDataArray.length === 0) {
                     return;
@@ -208,6 +208,59 @@ export const getActions = (
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to add columns to. Import data.'},
             searchTerms: ['add column', 'add col', 'new column', 'new col', 'insert column', 'insert col'],
             tooltip: "Add a new formula column to the right of your selection."
+        },
+        [ActionEnum.Add_Column_Left]: {
+            type: 'build-time',
+            staticType: ActionEnum.Add_Column_Left,
+            icon: AddColumnIcon,
+            toolbarTitle: 'Insert',
+            longTitle: 'Insert Column to the Left',
+            actionFunction: async () => {
+                if (sheetDataArray.length === 0) {
+                    return;
+                }
+
+                // We turn off editing mode, if it is on
+                setEditorState(undefined);
+
+                // we close the editing taskpane if its open
+                closeOpenEditingPopups();
+
+                const newColumnHeader = 'new-column-' + getNewColumnHeader()
+                // The new column should be placed 1 position to the right of the last selected column
+                let newColumnHeaderIndex = gridState.selections[gridState.selections.length - 1].startingColumnIndex;
+
+                await mitoAPI.editAddColumn(
+                    sheetIndex,
+                    newColumnHeader,
+                    newColumnHeaderIndex
+                )
+
+                setGridState(prevGridState => {
+                    return {
+                        ...prevGridState,
+                        selections: [{
+                            sheetIndex: sheetIndex,
+                            startingRowIndex: -1,
+                            startingColumnIndex: newColumnHeaderIndex,
+                            endingRowIndex: -1,
+                            endingColumnIndex: newColumnHeaderIndex
+                        }]
+                    }
+                })
+                setEditorState({
+                    rowIndex: 0,
+                    columnIndex: newColumnHeaderIndex,
+                    formula: '=',
+                    arrowKeysScrollInFormula: arrowKeysScrollInFormula,
+                    editorLocation: 'cell',
+                    editingMode: 'entire_column',
+                    sheetIndex: sheetIndex,
+                })
+            },
+            isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to add columns to. Import data.'},
+            searchTerms: ['add column', 'add col', 'new column', 'new col', 'insert column', 'insert col'],
+            tooltip: "Add a new formula column to the left of your selection."
         },
         [ActionEnum.Catch_Up]: {
             type: 'build-time',

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -228,7 +228,7 @@ export const getActions = (
 
                 const newColumnHeader = 'new-column-' + getNewColumnHeader()
                 // The new column should be placed 1 position to the right of the last selected column
-                let newColumnHeaderIndex = gridState.selections[gridState.selections.length - 1].startingColumnIndex;
+                const newColumnHeaderIndex = gridState.selections[gridState.selections.length - 1].startingColumnIndex;
 
                 await mitoAPI.editAddColumn(
                     sheetIndex,


### PR DESCRIPTION
* Adds a new action for inserting a column to the left of the selection
* Updates the toolbar behavior to insert columns to the left
* Adds "Insert column left" and "Insert column right" as the first two buttons in the column header dropdown
<img width="277" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/12a9880f-678e-4dfe-9271-c4530a82efec">
