### PR TITLE
Change insert icon's arrow to point right

### DIFF
--- a/mitosheet/src/mito/components/icons/AddColumnIcon.tsx
+++ b/mitosheet/src/mito/components/icons/AddColumnIcon.tsx
@@ -5,19 +5,19 @@ import React from 'react';
 
 const AddColumnIcon = (): JSX.Element => {
     return (
-        <svg width="19" height="28" viewBox="0 0 19 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="0.678955" y="26.6406" width="23" height="16" transform="rotate(-90 0.678955 26.6406)" fill="var(--mito-background-off)" stroke="var(--mito-text)"/>
-            <rect x="5.67896" y="26.6406" width="23" height="6" transform="rotate(-90 5.67896 26.6406)" fill="var(--mito-background-off)" stroke="#797774"/>
-            <rect x="0.678955" y="26.6406" width="23" height="16" transform="rotate(-90 0.678955 26.6406)" stroke="var(--mito-text)"/>
-            <rect x="5.67896" y="26.6406" width="23" height="6" transform="rotate(-90 5.67896 26.6406)" stroke="var(--mito-text)"/>
-            <rect x="0.678955" y="26.6406" width="23" height="16" transform="rotate(-90 0.678955 26.6406)" stroke="var(--mito-text)"/>
-            <line x1="1.17896" y1="10.6406" x2="16.179" y2="10.6406" stroke="var(--mito-text)"/>
-            <line x1="1.17896" y1="18.6406" x2="16.179" y2="18.6406" stroke="var(--mito-text)"/>
-            <path d="M5.5 25.9297L5.5 0.575022L12 0.635957L12 13.5L12 25.9297L5.5 25.9297Z" fill="var(--mito-highlight-medium)" stroke="var(--mito-highlight)"/>
-            <path d="M5.17896 8.64062L11.5 8.64062" stroke="var(--mito-highlight)"/>
-            <path d="M5.17896 16.6406L12 16.6406" stroke="var(--mito-highlight)"/>
-            <path d="M14.0746 8.1453L9.91482 11.59M9.91482 11.59L13.9462 15.1841M9.91482 11.59L17.4136 11.7268" stroke="var(--mito-background-off)" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round"/>
-            <path d="M14.0746 8.1453L9.91482 11.59M9.91482 11.59L13.9462 15.1841M9.91482 11.59L17.4136 11.7268" stroke="var(--mito-highlight-medium)" strokeMiterlimit="10" strokeLinecap="round"/>
+        <svg width="22" height="28" viewBox="0 0 22 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="5.07471" y="26.6406" width="23" height="16" transform="rotate(-90 5.07471 26.6406)" fill="var(--mito-background)" stroke="var(--mito-text)"/>
+            <rect x="10.0747" y="26.6406" width="23" height="6" transform="rotate(-90 10.0747 26.6406)" fill="var(--mito-background)" stroke="var(--mito-text-medium)"/>
+            <rect x="5.07471" y="26.6406" width="23" height="16" transform="rotate(-90 5.07471 26.6406)" stroke="var(--mito-text)"/>
+            <rect x="10.0747" y="26.6406" width="23" height="6" transform="rotate(-90 10.0747 26.6406)" stroke="var(--mito-text-medium)"/>
+            <rect x="5.07471" y="26.6406" width="23" height="16" transform="rotate(-90 5.07471 26.6406)" stroke="var(--mito-text)"/>
+            <line x1="5.57471" y1="10.6406" x2="20.5747" y2="10.6406" stroke="var(--mito-text-medium)"/>
+            <line x1="5.57471" y1="18.6406" x2="20.5747" y2="18.6406" stroke="var(--mito-text-medium)"/>
+            <path d="M9.89575 25.9297L9.89575 0.575022L16.3958 0.635957L16.3958 13.5L16.3958 25.9297L9.89575 25.9297Z" fill="var(--mito-highlight-medium)" stroke="var(--mito-highlight)"/>
+            <path d="M9.57471 8.64062L15.8958 8.64062" stroke="var(--mito-highlight)"/>
+            <path d="M9.57471 16.6406L16.3958 16.6406" stroke="var(--mito-highlight)"/>
+            <path d="M5.5198 16.0596L9.59908 12.52M9.59908 12.52L5.48594 9.0197M9.59908 12.52L2.09917 12.556" stroke="var(--mito-background)" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round"/>
+            <path d="M5.5198 16.0596L9.59908 12.52M9.59908 12.52L5.48594 9.0197M9.59908 12.52L2.09917 12.556" stroke="var(--mito-highlight-medium)" strokeMiterlimit="10" strokeLinecap="round"/>
         </svg>
     )
 }

--- a/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
@@ -109,7 +109,7 @@ export const FormulaTabContents = (
 
     return (<div className='mito-toolbar-bottom'>
         <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Set_Column_Formula]} />
-        <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Add_Column_Left]} />
+        <ToolbarButton action={props.actions.buildTimeActions[ActionEnum.Add_Column_Right]} />
 
         <div className="toolbar-vertical-line"/>
 

--- a/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
@@ -182,7 +182,7 @@ export const HomeTabContents = (
         <div className="toolbar-vertical-line"/>
 
         <ToolbarButton
-            action={props.actions.buildTimeActions[ActionEnum.Add_Column_Left]}
+            action={props.actions.buildTimeActions[ActionEnum.Add_Column_Right]}
             highlightToolbarButton={props.highlightAddColButton}
         />
         <ToolbarButton


### PR DESCRIPTION
Changes the arrow in the insert icon to point right because it inserts the column to the right of the selected column.
<img width="211" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/5c551de4-198c-4d32-a643-f5ad5dc55497">
