### PR TITLE
mitosheet: fix bug where use effect on undo and redo were triggered incorrectly

### DIFF
--- a/mitosheet/src/mito/hooks/useEffectOnRedo.tsx
+++ b/mitosheet/src/mito/hooks/useEffectOnRedo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { AnalysisData } from "../types";
 
 /* 
@@ -6,10 +6,9 @@ import { AnalysisData } from "../types";
     successful redo.
 */
 export const useEffectOnRedo = (effect: () => void, analysisData: AnalysisData): void => {   
-    const redoCountRef = useRef(analysisData.redoCount);
+    const [startingRedoCount] = useState(analysisData.redoCount);
     useEffect(() => {
-        if (analysisData.redoCount > redoCountRef.current) {
-            redoCountRef.current = analysisData.redoCount;
+        if (analysisData.redoCount > startingRedoCount) {
             effect();
         }
     }, [analysisData.redoCount])

--- a/mitosheet/src/mito/hooks/useEffectOnRedo.tsx
+++ b/mitosheet/src/mito/hooks/useEffectOnRedo.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { AnalysisData } from "../types";
 
 /* 
@@ -6,8 +6,10 @@ import { AnalysisData } from "../types";
     successful redo.
 */
 export const useEffectOnRedo = (effect: () => void, analysisData: AnalysisData): void => {   
+    const redoCountRef = useRef(analysisData.redoCount);
     useEffect(() => {
-        if (analysisData.redoCount > 0) {
+        if (analysisData.redoCount > redoCountRef.current) {
+            redoCountRef.current = analysisData.redoCount;
             effect();
         }
     }, [analysisData.redoCount])

--- a/mitosheet/src/mito/hooks/useEffectOnUndo.tsx
+++ b/mitosheet/src/mito/hooks/useEffectOnUndo.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { AnalysisData } from "../types";
 
 /* 
@@ -6,10 +6,14 @@ import { AnalysisData } from "../types";
     successful undo.
 */
 export const useEffectOnUndo = (effect: () => void, analysisData: AnalysisData): void => {
-   
+    
+    const undoCountRef = useRef(analysisData.undoCount);
     useEffect(() => {
-        if (analysisData.undoCount > 0) {
+        
+        if (analysisData.undoCount > undoCountRef.current) {
+            undoCountRef.current = analysisData.undoCount;
             effect();
         }        
+        
     }, [analysisData.undoCount])
 }

--- a/mitosheet/src/mito/hooks/useEffectOnUndo.tsx
+++ b/mitosheet/src/mito/hooks/useEffectOnUndo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { AnalysisData } from "../types";
 
 /* 
@@ -7,13 +7,12 @@ import { AnalysisData } from "../types";
 */
 export const useEffectOnUndo = (effect: () => void, analysisData: AnalysisData): void => {
     
-    const undoCountRef = useRef(analysisData.undoCount);
+    const [startingUndoCount] = useState(analysisData.undoCount);
     useEffect(() => {
         
-        if (analysisData.undoCount > undoCountRef.current) {
-            undoCountRef.current = analysisData.undoCount;
+        if (analysisData.undoCount > startingUndoCount) {
             effect();
-        }        
-        
+        }
+
     }, [analysisData.undoCount])
 }


### PR DESCRIPTION
…ncorrectly

# Description

Closes: #1048 

Previously, things would break in Streamlit you:
1. Imported an XLSX file
2. Undid the import
3. Tried to import another XLSX file (without closing the import taskpane)
4. The sheets in the file never show up

The bug fixed here would cause a getParam api call to be sent at the same time as the excel file metadata -- which would cause the excel file metadata to be dropped. 


# Testing

Test the series of steps above.

# Documentation

No.