### PR TITLE
Dogfooding PR - toolbar tooltips and dash app update

### DIFF
--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -242,6 +242,11 @@
   height: 18px;
 }
 
+/* This removes the underline that's automatically added to links */
+.mito-container a.mito-plan-button {
+  text-decoration: none;
+}
+
 .mito-toolbar-button-label {
   width: min-content;
   height: auto;

--- a/mitosheet/dash_app.py
+++ b/mitosheet/dash_app.py
@@ -1,40 +1,24 @@
-from dash import Dash, callback, Input, Output, html, dash_table
-from mitosheet.mito_dash.v1 import Spreadsheet, mito_callback
+from dash import Dash, Input, Output, html
+from mitosheet.mito_dash.v1 import Spreadsheet, mito_callback, activate_mito
 
 app = Dash(__name__)
+activate_mito(app)
 
-CSV_URL = '/Users/marthacryan/gitrepos/mito/mitosheet/datasets/small-datasets/loans.csv'
+CSV_URL = 'https://raw.githubusercontent.com/plotly/datasets/master/tesla-stock-price.csv'
 
 app.layout = html.Div([
     html.H1("Stock Analysis"),
-    Spreadsheet(import_folder='datasets', id='sheet'),
-    html.Div(id='output'),
-    html.Button('Run', id='rerun-analysis'),
-    html.Div(id='output-run-analysis')
+    Spreadsheet(CSV_URL, id={'type': 'spreadsheet', 'id': 'sheet'}),
+    html.Div(id='output')
 ])
 
 @mito_callback(
     Output('output', 'children'),
-    Input('sheet', 'spreadsheet_result'),
+    Input({'type': 'spreadsheet', 'id': 'sheet'}, 'spreadsheet_result'),
 )
 def update_code(spreadsheet_result):
     return html.Div([
-        html.Code(spreadsheet_result.analysis().fully_parameterized_function),
-    ])
-
-@mito_callback(
-    Output('output-run-analysis', 'children'),
-    Input('rerun-analysis', 'n_clicks'),
-    Input('sheet', 'spreadsheet_result'),
-    prevent_initial_call=True
-)
-def update_output(n_clicks, spreadsheet_result):
-    result = spreadsheet_result.analysis().run()
-    if result is None:
-        return None
-    return html.Div([
-        html.H3('Analysis Result'),
-        dash_table.DataTable(result.to_dict('records'), [{"name": i, "id": i} for i in result.columns])
+        html.Code(spreadsheet_result.code())
     ])
     
 if __name__ == '__main__':

--- a/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
@@ -298,7 +298,7 @@ try:
         
         def get_result(self):
             return SpreadsheetResult(
-                dfs=self.mito_backend.steps_manager.dfs,
+                dfs=self.mito_backend.steps_manager.dfs.copy(),
                 code=self.mito_backend.steps_manager.code(),
                 index_and_selections=self.index_and_selections,
                 fully_parameterized_function=self.mito_backend.fully_parameterized_function,

--- a/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/mito_dash/v1/spreadsheet.py
@@ -298,7 +298,7 @@ try:
         
         def get_result(self):
             return SpreadsheetResult(
-                dfs=self.mito_backend.steps_manager.dfs.copy(),
+                dfs=(df.copy() for df in self.mito_backend.steps_manager.dfs),
                 code=self.mito_backend.steps_manager.code(),
                 index_and_selections=self.index_and_selections,
                 fully_parameterized_function=self.mito_backend.fully_parameterized_function,

--- a/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
@@ -21,6 +21,7 @@ export const FormulaTabContents = (
         editorState: EditorState | undefined;
         setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>;
         analysisData: AnalysisData;
+        mitoContainerRef: React.RefObject<HTMLDivElement>;
     }): JSX.Element => {
 
     /**
@@ -59,7 +60,7 @@ export const FormulaTabContents = (
                                 ...props.editorState,
                                 formula: `=${functionObject.function}(${currentFormula.startsWith('=') ? currentFormula.substring(1) : currentFormula}`,
                             })
-                            document.getElementById('cell-editor-input')?.focus();
+                            void (props.mitoContainerRef.current?.querySelector('#cell-editor-input') as HTMLElement).focus();
                         } else {
                             const rowIndex = props.gridState.selections[0].startingRowIndex;
                             const columnIndex = props.gridState.selections[0].startingColumnIndex;

--- a/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
@@ -59,6 +59,7 @@ export const FormulaTabContents = (
                                 ...props.editorState,
                                 formula: `=${functionObject.function}(${currentFormula.startsWith('=') ? currentFormula.substring(1) : currentFormula}`,
                             })
+                            document.getElementById('cell-editor-input')?.focus();
                         } else {
                             const rowIndex = props.gridState.selections[0].startingRowIndex;
                             const columnIndex = props.gridState.selections[0].startingColumnIndex;

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -637,7 +637,7 @@ export const getActions = (
                 return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to export. Import data.'
             },
             searchTerms: ['export', 'download', 'excel', 'csv'],
-            tooltip: "Export dataframes as a .csv or .xlsx file."
+            tooltip: "Export dataframes as a .csv or .xlsx file. Choose whether or not to include export in the code."
         },
         [ActionEnum.Fill_Na]: {
             type: 'build-time',
@@ -894,8 +894,8 @@ export const getActions = (
             isDisabled: () => {
                 return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no columns to perform math on. Import data.'
             },
-            searchTerms: ['logic', 'functions'],
-            tooltip: "Perform math on the selected columns."
+            searchTerms: ['formulas', 'functions'],
+            tooltip: "Add formulas to the selected columns."
         },
         [ActionEnum.Currency_Format]: {
             type: 'build-time',
@@ -1060,7 +1060,7 @@ export const getActions = (
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['import', 'upload', 'new', 'excel', 'csv', 'add'],
-            tooltip: "Import any .csv or well-formatted .xlsx file as a new sheet."
+            tooltip: "Import a new sheet from .csv or .xlsx files, dataframe objects, or through Snowflake."
         },
         [ActionEnum.Import_Files]: {
             type: 'build-time',


### PR DESCRIPTION
* Updates the toolbar tooltips for:
  * import / export dropdowns
  * "More Functions" dropdown
* Updates the dash app to use the new spreadsheet API
* Removes underlining in the "Help" button at the top of the toolbar in notebook. 
* Fixes a focus issue where the cell editor didn't grab the focus when the user clicks on a formula dropdown item and the cell editor is already open. This was happening because the cell editor automatically grabs focus when it _opens_ but not when you change the formula. 
* Fixes #1024