### PR TITLE
tests: add streamlit tests for most home bar items

### DIFF
--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.8', '3.10']
+        run_count: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
     - name: Cancel Previous Runs

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.8', '3.10']
-        run_count: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
     - name: Cancel Previous Runs
@@ -55,6 +54,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10']
+        run_count: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
     - name: Cancel Previous Runs

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -88,6 +88,13 @@ jobs:
         source venv/bin/activate
         streamlit run streamlit-test.py --server.port 8555 &
         npm run test:streamlit
+    - name: Upload test-results if failure
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: test-results
+        path: test-results
+        retention-days: 14
 
   test-mitosheet-frontend-dash:
     runs-on: ubuntu-20.04

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,34 @@ source venv/bin/activate
 ```
 ## Running tests
 
+### Streamlit Tests
+
+The Streamlit tests contain most tests of basic functionality. 
+
+Run
+```
+streamlit run streamlit-test.py
+```
+
+And then run
+```
+npm run test:streamlit
+```
+
+### Dash Specific Tests
+
+Run
+```
+python dash-test.py
+```
+
+Then, run the tests with
+```
+npm run test:dash
+```
+
+### Jupyter Specific Tests
+
 Run 
 ```
 jupyter lab --config jupyter_server_test_config.py
@@ -18,7 +46,7 @@ jupyter lab --config jupyter_server_test_config.py
 
 And then in a separate terminal run 
 ```
-jlpm playwright test
+npm run test:jupyterlab
 ```
 
 Add a `--headed` flag to see the test run.
@@ -26,3 +54,19 @@ Add a `--headed` flag to see the test run.
 ## Creating tests
 
 See the Galata README.md here: https://github.com/jupyterlab/jupyterlab/tree/master/galata, where it fully documents how to create and record (!) tests.
+
+## Writing Tests
+
+### Writing Tests for Streamlit
+
+Writing tests for Streamlit is actually a breeze, using VSCode's Playwright extension. To create new tests:
+
+1. Install the Playwright extenstion for VSCode
+2. Use the `Record New` test functionality from the Playwright extension to create a basic test
+3. Copy this into the Streamlit test folder. Then, change the setup for the test to use the utilities from the other tests. 
+
+Keep in mind that:
+1. Setup is done in a standard function.
+2. If you click a button that calls the backend (e.g. makes an edit) you need to use `clickButtonAndAwaitResponse`.
+
+Note that you can also edit a test with the `Record at Cursor` functionality.

--- a/tests/data/test.csv
+++ b/tests/data/test.csv
@@ -1,0 +1,2 @@
+Column1, Column2, Column3
+1, 2, 3

--- a/tests/jupyterlab_ui_tests/jupyterlab.mitosheet.spec.ts
+++ b/tests/jupyterlab_ui_tests/jupyterlab.mitosheet.spec.ts
@@ -1,4 +1,4 @@
-import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+import { expect, test } from '@jupyterlab/galata';
 import { clickToolbarButton, createNewNotebook, dfCreationCode, getNumberOfColumns, waitForCodeToBeWritten, waitForIdle } from './utils';
 
 test.describe.configure({ mode: 'parallel' });

--- a/tests/jupyterlab_ui_tests/mitosheet.spec.ts
+++ b/tests/jupyterlab_ui_tests/mitosheet.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jupyterlab/galata';
-import { clickToolbarButton, createNewMitosheetOnlyTest, createNewNotebook, dfCreationCode, getNumberOfColumns, selectColumn, waitForCodeToBeWritten, waitForIdle } from './utils';
+import { createNewMitosheetOnlyTest, dfCreationCode, getNumberOfColumns } from './utils';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -7,27 +7,5 @@ test.describe('Mitosheet functionality', () => {
   test('pass a dataframe', async ({ page, tmpPath }) => {
     await createNewMitosheetOnlyTest(page, `${dfCreationCode}import mitosheet\nmitosheet.sheet(df)`);
     await getNumberOfColumns(page, 0).then((num) => expect(num).toBe(2));
-  });
-
-  test('import a CSV', async ({ page, tmpPath }) => {    
-    await createNewMitosheetOnlyTest(page, `${dfCreationCode}df.to_csv('df.csv', index=False)\nimport mitosheet\nmitosheet.sheet()`);
-
-    await page.getByRole('button', { name: 'Import Files', disabled: false }).click();
-    await page.locator('.file-browser-element-list > div:nth-child(2)').dblclick();
-
-    await waitForIdle(page);
-    await waitForCodeToBeWritten(page, 1);
-    await getNumberOfColumns(page, 0).then((num) => expect(num).toBe(2));
-
-  });
-
-  test('delete a col', async ({ page, tmpPath }) => {
-    await createNewNotebook(page, `${dfCreationCode}import mitosheet\nmitosheet.sheet(df)`);
-
-    await clickToolbarButton(page, 'Delete');
-
-    await waitForIdle(page);
-    await waitForCodeToBeWritten(page, 1);
-    await getNumberOfColumns(page, 0).then((num) => expect(num).toBe(1));
   });
 });

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,1 +1,12 @@
-module.exports = require('@jupyterlab/galata/lib/playwright-config');
+exports = require('@jupyterlab/galata/lib/playwright-config');
+
+// extend the default configuration, specifically setting
+// use: permissions: ["clipboard-read"]
+
+module.exports = {
+    ...exports,
+    use: {
+        ...exports.use,
+        permissions: ['clipboard-read'],
+    },
+};

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 notebook
 jupyterlab
+mitosheet-helper-enterprise

--- a/tests/streamlit-test.py
+++ b/tests/streamlit-test.py
@@ -1,3 +1,7 @@
 from mitosheet.streamlit.v1 import spreadsheet
+import streamlit as st
 
-spreadsheet()
+st.set_page_config(layout="wide")
+
+
+spreadsheet(import_folder='data')

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -103,9 +103,6 @@ test.describe('Home Tab Buttons', () => {
     await checkOpenTaskpane(mito, 'Conditional Formatting');
 
     await mito.getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
-    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByRole('button', { name: 'Conditional Formatting' }).click();
-    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByTitle('Delete conditional formatting rule').getByRole('img').click();
-    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
     await mito.locator('div').filter({ hasText: /^Is not empty Applied to 0 columns\.$/ }).first().click();
     await mito.getByRole('checkbox').nth(1).check(); // Check the first column
     await mito.getByRole('textbox').nth(2).fill('#b32929'); // Set the color

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -100,6 +100,7 @@ test.describe('Home Tab Buttons', () => {
 
     await mito.getByText('Default').first().click();
     await mito.getByText('Currency').click();
+    await awaitResponse(page);
     await expect(mito.getByText('$1')).toBeVisible();
   });
 

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -1,9 +1,186 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page, FrameLocator } from '@playwright/test';
+
+test.describe.configure({ mode: 'parallel' });
+
+const getMitoFrame = async (page: Page): Promise<FrameLocator> => {
+  await page.goto('http://localhost:8555/');
+  return page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]');
+};
+
+const importCSV = async (page: Page, mito: FrameLocator, filename: string): Promise<void> => {
+  await mito.getByRole('button', { name: '▾ Import' }).click();
+  await mito.getByTitle('Import Files').getByText('Import Files').click();
+  await mito.getByText(filename).dblclick();
+  await expect(mito.getByTitle('Column1')).toBeVisible(); 
+  await awaitResponse(page);
+  // Close the taskpane, by clicking default-taskpane-header-exit-button-div
+  await mito.locator('.default-taskpane-header-exit-button-div').click();
+
+}
+
+const getMitoFrameWithTestCSV = async (page: Page): Promise<FrameLocator> => {
+  const mito = await getMitoFrame(page);
+  await importCSV(page, mito, 'test.csv');
+  return mito;
+}
+
+const awaitResponse = async (page: Page): Promise<void> => {
+  // Wait at least 25 ms for the message to send
+  await page.waitForTimeout(100);
+  // Then, wait for Streamlit to finish processing the message
+  await expect(page.getByText("Running")).toHaveCount(0);
+}
+
+const clickButtonAndAwaitResponse = async (page: Page, mito: FrameLocator, nameOrOptions: string | any): Promise<void> => {
+  const button = mito.getByRole('button', typeof nameOrOptions === 'string' ? { name: nameOrOptions} : nameOrOptions);
+  // Scroll button into view
+  await button.scrollIntoViewIfNeeded();
+  // Click button
+  await button.click();
+  await awaitResponse(page);
+}
+
+const checkOpenTaskpane = async (mito: FrameLocator, taskpaneName: string): Promise<void> => {
+  // Check there is a class default-taskpane-header-div, that contains a nested div with text "taskpaneName"
+  await expect(mito.locator('.default-taskpane-header-div').locator('div').filter({ hasText: new RegExp(taskpaneName) }).first()).toBeVisible();
+}
 
 test('Can render Mito spreadsheet', async ({ page }) => {
-  await page.goto('http://localhost:8555/');
-  const frame = await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]');
-  await frame.getByRole('button', { name: 'Import Files' }).click();
+  const mito = await getMitoFrame(page);
+  await mito.getByRole('button', { name: 'Import Files' }).click();
+  await expect(mito.getByText('test.csv')).toBeVisible();
+});
 
-  await expect(frame.getByText('To use the file browser, configure the folder you want to allow users to import ')).toBeVisible();
+
+test.describe('Home Tab Buttons', () => {
+  test('Import CSV File (Double Click)', async ({ page }) => {
+    const mito = await getMitoFrame(page);
+    await mito.getByRole('button', { name: 'Import Files' }).click();
+    await mito.getByText('test.csv').dblclick();
+    await expect(mito.getByTitle('Column1')).toBeVisible();
+  });
+
+  test.skip('Copy Button', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await mito.getByTitle('Column1').click();
+    await clickButtonAndAwaitResponse(page, mito, 'Copy')
+
+    // TODO: figure out how to check the clipboard properly...
+  });
+
+  test('Formatting Butons', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, 'Format all of the selected columns as currency. This only changes the display of the data, and does not effect the underlying dataframe.')
+    await expect(mito.getByText('$1')).toBeVisible();
+    await clickButtonAndAwaitResponse(page, mito, 'Format all of the selected columns as percentage. This only changes the display of the data, and does not effect the underlying dataframe.')
+    await expect(mito.getByText('100%')).toBeVisible();
+    await clickButtonAndAwaitResponse(page, mito, 'Increase the number of decimal places that are displayed in the selected number columns.')
+    await expect(mito.getByText('100.0%')).toBeVisible();
+    await clickButtonAndAwaitResponse(page, mito, 'Decrease the number of decimal places that are displayed in the selected number columns.')
+    await expect(mito.getByText('100%')).toBeVisible();
+    await mito.getByText('100%').click();
+  });
+
+  test('Conditional Formatting', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, 'Conditional Formatting')
+
+    await checkOpenTaskpane(mito, 'Conditional Formatting');
+  });
+
+  test('Color Dataframe', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Format', exact: true })
+
+    await checkOpenTaskpane(mito, 'Color Dataframe');
+  });
+
+  test('Delete Column', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await mito.getByTitle('Column1').click();
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Delete' })
+
+    await expect(mito.getByText('Column1')).not.toBeVisible();
+  });
+
+  test('Insert Column', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await mito.getByTitle('Column1').click();
+    await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
+    await awaitResponse(page);
+
+    // Expect there to be 4 column headers
+    await expect(mito.locator('.endo-column-header-container')).toHaveCount(4);
+  });
+
+  test('Open Filter', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Filter' })
+
+    await checkOpenTaskpane(mito, 'Column1');
+  });
+
+  test('Open Find & Replace', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Find & Replace' })
+
+    await expect(mito.getByPlaceholder('Find...')).toBeVisible()
+  });
+
+  test('Change Dtype Dropdown', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    await clickButtonAndAwaitResponse(page, mito, { name: '▾ Dtype' })
+    await mito.getByText('float').click();
+    
+    await expect(mito.getByText('1.00')).toBeVisible();
+  });
+  
+  test('Open Pivot Table', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Pivot' })
+    
+    await checkOpenTaskpane(mito, 'Create Pivot Table test_pivot');
+    
+    await expect(mito.getByText('No data in dataframe.')).toBeVisible();
+  });
+  
+  test('Open Merge (horizontal)', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    await importCSV(page, mito, 'test.csv');
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: '▾ Merge' })
+    await mito.getByText('Merge (horizontal)').click();
+
+    await expect(mito.getByText('Merge Dataframes')).toBeVisible();
+  });
+
+  test('Open Concat (vertical)', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    await importCSV(page, mito, 'test.csv');
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: '▾ Merge' })
+    await mito.getByText('Concat (vertical)').click();
+
+    await expect(mito.getByText('Concatenate Sheet')).toBeVisible();
+  });
+  
+  test('Anti Merge (unique)', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    await importCSV(page, mito, 'test.csv');
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: '▾ Merge' })
+    await mito.getByText('Anti Merge (unique)').click();
+
+    await expect(mito.getByText('Merge Dataframes')).toBeVisible();
+    await expect(mito.getByText('unique in left')).toBeVisible();
+  });
 });

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -103,6 +103,9 @@ test.describe('Home Tab Buttons', () => {
     await checkOpenTaskpane(mito, 'Conditional Formatting');
 
     await mito.getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
+    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByRole('button', { name: 'Conditional Formatting' }).click();
+    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByTitle('Delete conditional formatting rule').getByRole('img').click();
+    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
     await mito.locator('div').filter({ hasText: /^Is not empty Applied to 0 columns\.$/ }).first().click();
     await mito.getByRole('checkbox').nth(1).check(); // Check the first column
     await mito.getByRole('textbox').nth(2).fill('#b32929'); // Set the color
@@ -122,11 +125,11 @@ test.describe('Home Tab Buttons', () => {
 
     await checkOpenTaskpane(mito, 'Color Dataframe');
 
-    await mito.locator('div:nth-child(3) > svg').click();
+    await mito.getByText('Column Headers').click();
+    await mito.getByRole('textbox').first().fill('#3850b7');
 
-    // Check that the .mito-grid-row has a background of 
-    // background-color: rgb(208, 227, 201)
-    await expect(mito.locator('.mito-grid-row').first()).toHaveAttribute('style', /background-color: rgb\(208, 227, 201\)/);
+    // Expect the first column header to have a background color of background-color: rgb(56, 80, 183)
+    await expect(mito.locator('.endo-column-header-container').first()).toHaveAttribute('style', /background-color: rgb\(56, 80, 183\)/);
   });
 
   test('Delete Column', async ({ page }) => {

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -59,6 +59,7 @@ test('Can render Mito spreadsheet', async ({ page }) => {
 
 
 test.describe('Home Tab Buttons', () => {
+
   test('Import CSV File (Double Click)', async ({ page }) => {
     const mito = await getMitoFrame(page);
     await mito.getByRole('button', { name: 'Import Files' }).click();
@@ -81,7 +82,7 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.locator('.endo-column-header-final-container').first()).toHaveAttribute('style', /border-top: 1px dashed black;/);
   });
 
-  test('Formatting Butons', async ({ page }) => {
+  test('Formatting Buttons', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await clickButtonAndAwaitResponse(page, mito, 'Format all of the selected columns as currency. This only changes the display of the data, and does not effect the underlying dataframe.')
@@ -92,7 +93,14 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.getByText('100.0%')).toBeVisible();
     await clickButtonAndAwaitResponse(page, mito, 'Decrease the number of decimal places that are displayed in the selected number columns.')
     await expect(mito.getByText('100%')).toBeVisible();
-    await mito.getByText('100%').click();
+  });
+
+  test('Formatting Select', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    await mito.getByText('Default').first().click();
+    await mito.getByText('Currency').click();
+    await expect(mito.getByText('$1')).toBeVisible();
   });
 
   test.skip('Conditional Formatting', async ({ page }) => {
@@ -113,20 +121,7 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^1$/ }).first()).toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);
     // Check that the .mito-grid-cell containing 2 does not 
     // background-color: rgba(179, 41, 41, 0.4)
-    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^2$/ }).first()).not.toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);
-  
-    await mito.getByRole('button', { name: 'Import Files' }).click();
-    await mito.getByText('test.csv').click();
-    await mito.getByText('test.csv', { exact: true }).click();
-    await mito.locator('div').filter({ hasText: /^test\.csv$/ }).nth(1).click();
-    await mito.getByRole('button', { name: 'Import test.csv' }).click();
-    await mito.getByRole('button', { name: 'Import test.csv' }).click();
-    await mito.locator('#mito-center-content-container line').nth(1).click();
-    await mito.getByText('Column3').click();
-    await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
-    await mito.locator('#cell-editor-input').fill('=123');
-    await mito.locator('#cell-editor-input').press('Enter');
-  
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^2$/ }).first()).not.toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);  
   });
 
   test.skip('Color Dataframe', async ({ page }) => {
@@ -161,6 +156,15 @@ test.describe('Home Tab Buttons', () => {
 
     // Expect there to be 4 column headers
     await expect(mito.locator('.endo-column-header-container')).toHaveCount(4);
+
+    // Check that the column with .endo-column-header-container-selected 
+    // starts with new-column
+    await expect(mito.locator('.endo-column-header-container-selected').first()).toHaveText(/^new-column/);
+
+    // Check that the new column is after Column1
+    await expect(mito.locator('.endo-column-header-container').first()).toHaveText(/^Column1/);
+    await expect(mito.locator('.endo-column-header-container').nth(1)).toHaveText(/^new-column/);
+
   });
 
   test('Filter', async ({ page }) => {
@@ -176,6 +180,7 @@ test.describe('Home Tab Buttons', () => {
     await mito.getByRole('textbox').click();
     await mito.getByRole('textbox').fill('4');
     await mito.getByText('No rows in dataframe.').click();
+    await expect(mito.getByText('Removed an additional 1 rows')).toBeVisible();
 
     // Add another filter and combine with an OR < 10
     await mito.getByText('+ Add Filter').click();
@@ -188,6 +193,7 @@ test.describe('Home Tab Buttons', () => {
 
     // Check that the .mito-grid-cell containing 1 exists
     await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^1$/ }).first()).toBeVisible();
+    await expect(mito.getByText('Removed an additional 0 rows')).toBeVisible();
   });
 
   test('Find and Replace', async ({ page }) => {
@@ -298,5 +304,11 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.locator('.plotly-graph-div').first()).toBeVisible();
   });
 
+  test('AI Not Exist on Enterprise', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+
+    // Check there is no AI button
+    await expect(mito.getByRole('button', { name: 'AI' })).not.toBeVisible();
+  });
 
 });

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -95,13 +95,14 @@ test.describe('Home Tab Buttons', () => {
     await mito.getByText('100%').click();
   });
 
-  test('Conditional Formatting', async ({ page }) => {
+  test.skip('Conditional Formatting', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
-
+    
     await clickButtonAndAwaitResponse(page, mito, 'Conditional Formatting')
-
+    
     await checkOpenTaskpane(mito, 'Conditional Formatting');
-
+    
+    // This test is currently broken, for some reason this button won't click
     await mito.getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
     await mito.locator('div').filter({ hasText: /^Is not empty Applied to 0 columns\.$/ }).first().click();
     await mito.getByRole('checkbox').nth(1).check(); // Check the first column

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -114,9 +114,22 @@ test.describe('Home Tab Buttons', () => {
     // Check that the .mito-grid-cell containing 2 does not 
     // background-color: rgba(179, 41, 41, 0.4)
     await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^2$/ }).first()).not.toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);
+  
+    await mito.getByRole('button', { name: 'Import Files' }).click();
+    await mito.getByText('test.csv').click();
+    await mito.getByText('test.csv', { exact: true }).click();
+    await mito.locator('div').filter({ hasText: /^test\.csv$/ }).nth(1).click();
+    await mito.getByRole('button', { name: 'Import test.csv' }).click();
+    await mito.getByRole('button', { name: 'Import test.csv' }).click();
+    await mito.locator('#mito-center-content-container line').nth(1).click();
+    await mito.getByText('Column3').click();
+    await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
+    await mito.locator('#cell-editor-input').fill('=123');
+    await mito.locator('#cell-editor-input').press('Enter');
+  
   });
 
-  test('Color Dataframe', async ({ page }) => {
+  test.skip('Color Dataframe', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await clickButtonAndAwaitResponse(page, mito, { name: 'Format', exact: true })

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -142,7 +142,8 @@ test.describe('Home Tab Buttons', () => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await mito.getByTitle('Column1').click();
-    await clickButtonAndAwaitResponse(page, mito, { name: 'Insert' })
+    await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
+    await awaitResponse(page);
 
     // Expect there to be 4 column headers
     await expect(mito.locator('.endo-column-header-container')).toHaveCount(4);
@@ -234,7 +235,7 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.getByText('Column3 count 2')).toBeVisible();
   });
   
-  test.only('Open Merge (horizontal)', async ({ page }) => {
+  test('Open Merge (horizontal)', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     await importCSV(page, mito, 'test.csv');
     
@@ -246,15 +247,6 @@ test.describe('Home Tab Buttons', () => {
     // Check that Column1 exists
     const ch1 = await getColumnHeaderContainer(mito, 'Column1');
     await expect(ch1).toBeVisible();
-    
-    await mito.locator('p').filter({ hasText: 'Column1' }).nth(1).click();
-    await mito.locator('.mito-dropdown-item-icon-and-title-container').nth(1).click();
-    await mito.locator('p').filter({ hasText: 'Column1' }).nth(1).click();
-    await mito.locator('.mito-dropdown-item-icon-and-title-container').nth(1).click();
-
-    // Check that Column2 now exists
-    const ch2 = await getColumnHeaderContainer(mito, 'Column2');
-    await expect(ch2).toBeVisible();
   });
 
   test('Open Concat (vertical)', async ({ page }) => {
@@ -265,6 +257,9 @@ test.describe('Home Tab Buttons', () => {
     await mito.getByText('Concat (vertical)').click();
 
     await expect(mito.getByText('Concatenate Sheet')).toBeVisible();
+
+    // Test that the sheet is empty
+    await expect(mito.getByText('No data in dataframe.')).toBeVisible();
   });
   
   test('Anti Merge (unique)', async ({ page }) => {

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -183,4 +183,17 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.getByText('Merge Dataframes')).toBeVisible();
     await expect(mito.getByText('unique in left')).toBeVisible();
   });
+
+  test('Graph', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+
+    await expect(mito.getByText('Setup Graph')).toBeVisible();
+    await mito.getByTitle('Select columns to graph on the X axis.').getByText('+ Add').click();
+    await mito.locator('.mito-dropdown-item').first().click();
+    await expect(mito.locator('.plotly-graph-div').first()).toBeVisible();
+  });
+
+
 });

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page, FrameLocator } from '@playwright/test';
+import { test, expect, Page, FrameLocator, Locator } from '@playwright/test';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -45,6 +45,12 @@ const checkOpenTaskpane = async (mito: FrameLocator, taskpaneName: string): Prom
   await expect(mito.locator('.default-taskpane-header-div').locator('div').filter({ hasText: new RegExp(taskpaneName) }).first()).toBeVisible();
 }
 
+const getColumnHeaderContainer = async (mito: FrameLocator, columnName: string): Promise<Locator> => {
+  return mito.locator('.endo-column-header-container').locator('div').filter({ hasText: columnName }).first();
+}
+
+
+
 test('Can render Mito spreadsheet', async ({ page }) => {
   const mito = await getMitoFrame(page);
   await mito.getByRole('button', { name: 'Import Files' }).click();
@@ -60,13 +66,19 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.getByTitle('Column1')).toBeVisible();
   });
 
-  test.skip('Copy Button', async ({ page }) => {
+  test('Copy Button', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await mito.getByTitle('Column1').click();
     await clickButtonAndAwaitResponse(page, mito, 'Copy')
 
-    // TODO: figure out how to check the clipboard properly...
+    // TODO: There are some bugs with Playwrite 
+    // https://github.com/microsoft/playwright/issues/18901
+    // That make it hard to check the clipboard contents
+    // But we can check that this has a black border
+    // Check that the endo-column-header-final-container has, among it's style, 
+    // the text 'border-top: 1px dashed black;'
+    await expect(mito.locator('.endo-column-header-final-container').first()).toHaveAttribute('style', /border-top: 1px dashed black;/);
   });
 
   test('Formatting Butons', async ({ page }) => {
@@ -89,6 +101,18 @@ test.describe('Home Tab Buttons', () => {
     await clickButtonAndAwaitResponse(page, mito, 'Conditional Formatting')
 
     await checkOpenTaskpane(mito, 'Conditional Formatting');
+
+    await mito.getByRole('button', { name: 'Add Conditional Formatting Rule' }).click();
+    await mito.locator('div').filter({ hasText: /^Is not empty Applied to 0 columns\.$/ }).first().click();
+    await mito.getByRole('checkbox').nth(1).check(); // Check the first column
+    await mito.getByRole('textbox').nth(2).fill('#b32929'); // Set the color
+
+    // Check that the .mito-grid-cell containing 1 has 
+    // background-color: rgba(179, 41, 41, 0.4)
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^1$/ }).first()).toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);
+    // Check that the .mito-grid-cell containing 2 does not 
+    // background-color: rgba(179, 41, 41, 0.4)
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^2$/ }).first()).not.toHaveAttribute('style', /background-color: rgba\(179, 41, 41, 0.4\)/);
   });
 
   test('Color Dataframe', async ({ page }) => {
@@ -97,6 +121,12 @@ test.describe('Home Tab Buttons', () => {
     await clickButtonAndAwaitResponse(page, mito, { name: 'Format', exact: true })
 
     await checkOpenTaskpane(mito, 'Color Dataframe');
+
+    await mito.locator('div:nth-child(3) > svg').click();
+
+    // Check that the .mito-grid-row has a background of 
+    // background-color: rgb(208, 227, 201)
+    await expect(mito.locator('.mito-grid-row').first()).toHaveAttribute('style', /background-color: rgb\(208, 227, 201\)/);
   });
 
   test('Delete Column', async ({ page }) => {
@@ -112,27 +142,61 @@ test.describe('Home Tab Buttons', () => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await mito.getByTitle('Column1').click();
-    await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
-    await awaitResponse(page);
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Insert' })
 
     // Expect there to be 4 column headers
     await expect(mito.locator('.endo-column-header-container')).toHaveCount(4);
   });
 
-  test('Open Filter', async ({ page }) => {
+  test('Filter', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await clickButtonAndAwaitResponse(page, mito, { name: 'Filter' })
 
     await checkOpenTaskpane(mito, 'Column1');
+
+    // Filter out all rows, with a > 4 filter
+    await mito.getByText('+ Add Filter').click();
+    await mito.locator('div').filter({ hasText: /^Add a Filter$/ }).first().click();
+    await mito.getByRole('textbox').click();
+    await mito.getByRole('textbox').fill('4');
+    await mito.getByText('No rows in dataframe.').click();
+
+    // Add another filter and combine with an OR < 10
+    await mito.getByText('+ Add Filter').click();
+    await mito.locator('div').filter({ hasText: /^Add a Filter$/ }).first().click();
+    await mito.getByText('And').click();
+    await mito.getByText('Or', { exact: true }).click();
+    await mito.getByText('>').nth(1).click();
+    await mito.getByText('<').click();
+    await mito.locator('div').filter({ hasText: /^Or<$/ }).getByRole('textbox').fill('10');
+
+    // Check that the .mito-grid-cell containing 1 exists
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^1$/ }).first()).toBeVisible();
   });
 
-  test('Open Find & Replace', async ({ page }) => {
+  test('Find and Replace', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 
     await clickButtonAndAwaitResponse(page, mito, { name: 'Find & Replace' })
 
     await expect(mito.getByPlaceholder('Find...')).toBeVisible()
+
+    // Check finds 2 in both the cell and the header
+    await mito.getByPlaceholder('Find...').fill('2');
+    await expect(mito.getByText('0 of 2')).toBeVisible();
+
+    // Replace in selected columns shouldn't work, as Column2 isn't selected
+    await mito.locator('#mito-center-content-container').getByRole('button').first().click();
+    await mito.getByPlaceholder('Replace...').fill('4');
+    await mito.getByRole('button', { name: 'Replace in Selected Columns' }).click();
+    await expect(mito.getByText('Column4')).not.toBeVisible();
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^4$/ }).first()).not.toBeVisible();
+
+    // Then, replace all, should work
+    await mito.getByRole('button', { name: 'Replace All' }).click();
+    await expect(mito.getByText('Column4')).toBeVisible();
+    await expect(mito.locator('.mito-grid-cell').filter({ hasText: /^4$/ }).first()).toBeVisible();
   });
 
   test('Change Dtype Dropdown', async ({ page }) => {
@@ -143,17 +207,34 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.getByText('1.00')).toBeVisible();
   });
   
-  test('Open Pivot Table', async ({ page }) => {
+  test('Pivot Table', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     
     await clickButtonAndAwaitResponse(page, mito, { name: 'Pivot' })
     
     await checkOpenTaskpane(mito, 'Create Pivot Table test_pivot');
-    
+
+    // Check new empty tab
+    await page.frameLocator('iframe[title="mitosheet\\.streamlit\\.v1\\.spreadsheet\\.my_component"]').getByText('test_pivot', { exact: true }).click();
+    await expect(mito.getByText('test_pivot', { exact: true })).toBeVisible();
     await expect(mito.getByText('No data in dataframe.')).toBeVisible();
+    
+    // Add a row, column and value
+    await mito.getByText('+ Add').first().click();
+    await mito.getByText('Column1').click();
+    await awaitResponse(page);
+    await mito.getByText('+ Add').nth(1).click();
+    await mito.getByText('Column2').click();
+    await awaitResponse(page);
+    await mito.getByText('+ Add').nth(2).click();
+    await mito.getByText('Column3').click();
+    await awaitResponse(page);
+
+    // Check that the pivot table has been created
+    await expect(mito.getByText('Column3 count 2')).toBeVisible();
   });
   
-  test('Open Merge (horizontal)', async ({ page }) => {
+  test.only('Open Merge (horizontal)', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     await importCSV(page, mito, 'test.csv');
     
@@ -161,6 +242,19 @@ test.describe('Home Tab Buttons', () => {
     await mito.getByText('Merge (horizontal)').click();
 
     await expect(mito.getByText('Merge Dataframes')).toBeVisible();
+
+    // Check that Column1 exists
+    const ch1 = await getColumnHeaderContainer(mito, 'Column1');
+    await expect(ch1).toBeVisible();
+    
+    await mito.locator('p').filter({ hasText: 'Column1' }).nth(1).click();
+    await mito.locator('.mito-dropdown-item-icon-and-title-container').nth(1).click();
+    await mito.locator('p').filter({ hasText: 'Column1' }).nth(1).click();
+    await mito.locator('.mito-dropdown-item-icon-and-title-container').nth(1).click();
+
+    // Check that Column2 now exists
+    const ch2 = await getColumnHeaderContainer(mito, 'Column2');
+    await expect(ch2).toBeVisible();
   });
 
   test('Open Concat (vertical)', async ({ page }) => {


### PR DESCRIPTION
# Description

Adds tests for home-bar items. This is supposed to be testing that all basic functionality works -- and doing so in a way that is robust and easy to maintain.

# Testing

See tests. We want them to pass the following criteria:


1. All tests can run in parallel with no issues (two in parallel) currently.
2. Across 10 test runs (which we add with the following), we pass with *no flakeyness*
    
    ```
    strategy:
          matrix:
            run_count: [1, 2, ..., 10]
    ```
    
3. The tests themselves should run in <1 minute. This includes only the *testing* time -- this is true currently.

# Documentation

No.