### PR TITLE
Add bulk column header transform to toolbar

### DIFF
--- a/mitosheet/src/mito/components/icons/BulkColumnHeaderTransformIcon.tsx
+++ b/mitosheet/src/mito/components/icons/BulkColumnHeaderTransformIcon.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Mito
+
+import React from 'react';
+
+const BulkHeaderTransformIcon = (): JSX.Element => {
+    return (
+        <svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.7402 1.31906L13.7402 1.07031V5.07031H0.740234L0.7402 1.31906Z" fill="var(--mito-highlight)"/>
+<path d="M0.519531 14.8368V1.14062H14.1964V14.8368H0.519531Z" stroke="var(--mito-text)"/>
+<path d="M5.55127 17.1376V3.44141H19.2282V17.1376H5.55127Z" fill="var(--mito-background-off)"/>
+<path d="M5.83057 3.75781H18.9492V7.58H5.83057V3.75781Z" fill="#96D394"/>
+<path d="M5.55127 17.1376V3.44141H19.2282V17.1376H5.55127Z" stroke="var(--mito-text)"/>
+<path d="M10.2964 7.58203V16.819M14.7623 7.58203V16.819" stroke="var(--mito-text-light)" stroke-width="0.75"/>
+</svg>
+
+    )
+}
+
+export default BulkHeaderTransformIcon;

--- a/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
@@ -65,6 +65,9 @@ export const DataTabContents = (
             action={props.actions.buildTimeActions[ActionEnum.Split_Text_To_Column]}
         />
         <ToolbarButton
+            action={props.actions.buildTimeActions[ActionEnum.COLUMN_HEADERS_TRANSFORM]}
+        />
+        <ToolbarButton
             action={props.actions.buildTimeActions[ActionEnum.Drop_Duplicates]}
         />
         <div>

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -70,6 +70,7 @@ import CodeSnippetIcon from "../components/icons/CodeSnippetIcon";
 import FunctionIcon from "../components/icons/FunctionIcon";
 import ScheduleIcon from "../components/icons/ScheduleIcon";
 import { getCodeString } from "../../jupyter/code";
+import BulkHeaderTransformIcon from "../components/icons/BulkColumnHeaderTransformIcon";
 
 /**
  * This is a wrapper class that holds all frontend actions. This allows us to create and register
@@ -2046,7 +2047,8 @@ export const getActions = (
         [ActionEnum.COLUMN_HEADERS_TRANSFORM]: {
             type: 'build-time',
             staticType: ActionEnum.COLUMN_HEADERS_TRANSFORM,
-            toolbarTitle: 'Bulk column header transform',
+            icon: BulkHeaderTransformIcon,
+            toolbarTitle: 'Rename Columns',
             longTitle: 'Bulk column headers transform',
             actionFunction: () => {
                 // We turn off editing mode, if it is on


### PR DESCRIPTION
Adds a toolbar button for the existing bulk column header transform behavior. Adds into the data tab:
![image](https://github.com/mito-ds/mito/assets/6673460/647ac8fb-5da1-410a-b6bf-72dfa422cce7)
