### PR TITLE
Update behavior of ctrl+click to open context menu

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1038,6 +1038,15 @@ export const Mito = (props: MitoProps): JSX.Element => {
                         })
                         const endoGridContainer = mitoContainerRef.current?.querySelector('.endo-grid-container') as HTMLDivElement | null | undefined;
                         focusGrid(endoGridContainer);
+                    } else if (uiState.currOpenDropdown !== undefined) {
+                        setUIState(prevUIState => {
+                            return {
+                                ...prevUIState,
+                                currOpenDropdown: undefined
+                            }
+                        })
+                        const endoGridContainer = mitoContainerRef.current?.querySelector('.endo-grid-container') as HTMLDivElement | null | undefined;
+                        focusGrid(endoGridContainer);
                     }
                 }
             }}

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -305,7 +305,6 @@ function EndoGrid(props: {
                 return;
             }
             
-
             if (e.metaKey || e.ctrlKey) {
                 /* 
                     These are the cases where we add a new selection. A user can add to their selection by:
@@ -472,6 +471,23 @@ function EndoGrid(props: {
         const newLastSelection = getNewSelectionAfterMouseUp(gridState.selections[gridState.selections.length - 1], rowIndex, columnIndex);
         const newSelections = [...gridState.selections]
         newSelections[newSelections.length - 1] = newLastSelection
+
+        if (e.ctrlKey && rowIndex !== undefined && columnIndex !== undefined) {
+            setGridState((gridState) => {
+                return {
+                    ...gridState,
+                    selections: [{
+                        startingColumnIndex: columnIndex,
+                        endingColumnIndex: columnIndex,
+                        startingRowIndex: rowIndex,
+                        endingRowIndex: rowIndex,
+                        sheetIndex: sheetIndex,
+                    }]
+                }
+            })
+            return;
+        }
+
         // We only update the selection if has changed, so we don't rerender unnecessarily
         if (!equalSelections(newLastSelection, gridState.selections[gridState.selections.length - 1])) {
             setGridState((gridState) => {

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -311,6 +311,9 @@ function EndoGrid(props: {
                     1. Being on Mac, and command+clicking
                     2. Being on Windows, and ctrl+clicking
                 */
+               const operatingSystem = window.navigator.userAgent.toUpperCase().includes('MAC')
+                    ? 'mac'
+                    : 'windows'
 
                 if (e.shiftKey) {
                     // Just add the new click locaton to a new selection at the end of the selections list
@@ -329,7 +332,7 @@ function EndoGrid(props: {
                         }
                     })
                 // The next step of conditions handle when meta or ctrl key is pressed and shift is not
-                } else if (e.metaKey) {
+                } else if ((operatingSystem === 'mac' && e.metaKey) || (operatingSystem === 'windows' && e.ctrlKey)) {
                     if (rowIndex === -1) {
                         // If column is in selection, then remove it
                         // By passing -1 as the row index, getIsCellSelected checks if the entire column is selected

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -472,6 +472,8 @@ function EndoGrid(props: {
         const newSelections = [...gridState.selections]
         newSelections[newSelections.length - 1] = newLastSelection
 
+        // If this is a ctrl + click, then we want to make the selection just this cell / column / row.
+        // The component itself will handle opening the context menu through the onContextMenu handler.
         if (e.ctrlKey && rowIndex !== undefined && columnIndex !== undefined) {
             setGridState((gridState) => {
                 return {

--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -329,7 +329,7 @@ function EndoGrid(props: {
                         }
                     })
                 // The next step of conditions handle when meta or ctrl key is pressed and shift is not
-                } else {
+                } else if (e.metaKey) {
                     if (rowIndex === -1) {
                         // If column is in selection, then remove it
                         // By passing -1 as the row index, getIsCellSelected checks if the entire column is selected
@@ -475,6 +475,12 @@ function EndoGrid(props: {
         // If this is a ctrl + click, then we want to make the selection just this cell / column / row.
         // The component itself will handle opening the context menu through the onContextMenu handler.
         if (e.ctrlKey && rowIndex !== undefined && columnIndex !== undefined) {
+            // If the user is clicking within a current selection, then we don't change the selection.
+            // This is because we want to allow the user to open the context menu on a selection of cells
+            // without changing the selection.
+            if (getIsCellSelected(gridState.selections, rowIndex, columnIndex)) {
+                return;
+            }
             setGridState((gridState) => {
                 return {
                     ...gridState,

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -345,6 +345,23 @@ export const getActions = (
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
 
+                if (typeof uiState.currOpenDropdown === 'object') {
+                    const rowIndex = uiState.currOpenDropdown.rowIndex;
+                    const columnIndex = uiState.currOpenDropdown.columnIndex;
+                    setGridState(prevGridState => {
+                        return {
+                            ...prevGridState,
+                            selections: [{
+                                sheetIndex: sheetIndex,
+                                startingRowIndex: rowIndex,
+                                startingColumnIndex: columnIndex,
+                                endingRowIndex: rowIndex,
+                                endingColumnIndex: columnIndex
+                            }]
+                        }
+                    })
+                }
+
                 setUIState(prevUIState => {
                     return {
                         ...prevUIState,
@@ -1885,6 +1902,23 @@ export const getActions = (
             actionFunction: () => {
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
+
+                if (typeof uiState.currOpenDropdown === 'object') {
+                    const rowIndex = uiState.currOpenDropdown.rowIndex;
+                    const columnIndex = uiState.currOpenDropdown.columnIndex;
+                    setGridState(prevGridState => {
+                        return {
+                            ...prevGridState,
+                            selections: [{
+                                sheetIndex: sheetIndex,
+                                startingRowIndex: rowIndex,
+                                startingColumnIndex: columnIndex,
+                                endingRowIndex: rowIndex,
+                                endingColumnIndex: columnIndex
+                            }]
+                        }
+                    })
+                }
 
                 setUIState(prevUIState => {
                     return {

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -1497,7 +1497,12 @@ export const getActions = (
             iconContextMenu: EditIcon,
             longTitle: 'Rename column',
             actionFunction: () => {
-                const columnHeader = getCellDataFromCellIndexes(sheetData, -1, startingColumnIndex).columnHeader;
+                let columnIndex = startingColumnIndex;
+                // If this is being triggered by a context menu, then we need to find the column that was clicked on
+                if (typeof uiState.currOpenDropdown === 'object') {
+                    columnIndex = uiState.currOpenDropdown.columnIndex;
+                }
+                const columnHeader = getCellDataFromCellIndexes(sheetData, -1, columnIndex).columnHeader;
 
                 // Get the pieces of the column header. If the column header is not a MultiIndex header, then
                 // lowerLevelColumnHeaders will be an empty array
@@ -1506,7 +1511,7 @@ export const getActions = (
 
                 setEditorState({
                     rowIndex: -1,
-                    columnIndex: startingColumnIndex,
+                    columnIndex: columnIndex,
                     formula: getDisplayColumnHeader(finalColumnHeader),
                     editorLocation: 'cell',
                     editingMode: 'specific_index_labels',

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -193,7 +193,8 @@ export const getActions = (
 
                 const newColumnHeader = 'new-column-' + getNewColumnHeader()
                 // The new column should be placed 1 position to the right of the last selected column
-                const newColumnHeaderIndex = gridState.selections[gridState.selections.length - 1].endingColumnIndex + 1;
+                const selection = gridState.selections[gridState.selections.length - 1];
+                const newColumnHeaderIndex = Math.max(selection.startingColumnIndex, selection.endingColumnIndex) + 1;
 
                 await mitoAPI.editAddColumn(
                     sheetIndex,
@@ -238,8 +239,9 @@ export const getActions = (
                 closeOpenEditingPopups();
 
                 const newColumnHeader = 'new-column-' + getNewColumnHeader()
-                // The new column should be placed 1 position to the right of the last selected column
-                const newColumnHeaderIndex = gridState.selections[gridState.selections.length - 1].startingColumnIndex;
+                // The new column should be placed 1 position to the left of the first selected column
+                const selection = gridState.selections[gridState.selections.length - 1];
+                const newColumnHeaderIndex = Math.min(selection.startingColumnIndex, selection.endingColumnIndex);
 
                 await mitoAPI.editAddColumn(
                     sheetIndex,


### PR DESCRIPTION
Fixes #1060.

* Updates the behavior when the user does a ctrl+click to select the cell /header / row that was clicked on, and opens the context menu.
* Adds handling for closing dropdowns when the user presses "escape"