### PR TITLE
mitosheet: use formula description as tooltip

### DIFF
--- a/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/FormulaTabContents.tsx
@@ -49,6 +49,7 @@ export const FormulaTabContents = (
             return (
                 <DropdownItem
                     title={functionObject.function}
+                    tooltip={functionObject.description}
                     key={functionObject.function}
                     supressFocusSettingOnClose
                     onClick={(e) => {


### PR DESCRIPTION
# Description

Uses the formula description as the tooltip in the toolbar 

<img width="571" alt="Screenshot 2023-12-11 at 6 49 45 PM" src="https://github.com/mito-ds/mito/assets/18709905/e8bd847a-5e01-4e10-be6b-a12349e7f415">

# Testing

1. Test with a regular function
2. Test with a custom function that has documentation
3. Test with a custom function that does not have documentation

This is too detailed of a test for frontend tests right now. 

# Documentation

No. 