### PR TITLE
mitosheet: fix filter then vlookup

### DIFF
--- a/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
@@ -204,7 +204,10 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
         else:
             return matching_row.iloc[0, index-1]
     
+    # If the lookup_value is a series, we use it, otherwise, we create a series with the where index
+
     value = get_series_from_primitive_or_series(lookup_value, where.index)
+
     value.name = 'lookup_value'
     indices_to_return_from_range = get_series_from_primitive_or_series(index, value.index)
 
@@ -234,6 +237,10 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
     # Then merge on the column we're looking up from, and the df we're looking up in.
     merged = pd.merge(value, where_deduplicated, left_on='lookup_value', right_on=where_first_column, how='left')
 
+    # Change the indexes back to the indexes of the lookup value so the results 
+    # can be added back to the calling dataframe.
+    merged.index = value.index
+    
     def get_value_at_index_in_row(row):
         try:
             return row.iloc[indices_to_return_from_range[row.name]]

--- a/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/misc_functions.py
@@ -203,8 +203,6 @@ def VLOOKUP(lookup_value: AnyPrimitiveOrSeriesInputType, where: pd.DataFrame, in
             return None
         else:
             return matching_row.iloc[0, index-1]
-    
-    # If the lookup_value is a series, we use it, otherwise, we create a series with the where index
 
     value = get_series_from_primitive_or_series(lookup_value, where.index)
 


### PR DESCRIPTION
# Description

Fix bug caused by vlookup-ing when lookup values series has different indexes from `where` dataframe. 

# Testing

```
import pandas as pd
df1 = pd.DataFrame({
    'A': [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
    'B': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
})

df2 = pd.DataFrame({
    'A': [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
    'C': [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
})

mitosheet.sheet(df1, df2)
```
- Filter B to just include 0
- Use the formula in df1 VLOOKUP(A1,df2!A:C, 2)


Also, see regression tests. 

# Documentation

No