### PR TITLE
mitosheet: add domain to user defined types, add importer name to data tab

### DIFF
--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -208,9 +208,18 @@
 
 .mito-toolbar-button-label {
   font-size: 11px;
-  height: 13px;
+  
   text-align: center !important;
   min-width: 35px;
+  width: min-content;
+  
+  /* In notebook, the line height is set higher, so we need to set it back to normal */
+  line-height: normal;
+
+  /* Make sure the text doesn't go more than two lines */
+  overflow: hidden;
+  height: auto;
+  max-height: 27px;
 }
 
 .toolbar-vertical-line {
@@ -245,14 +254,6 @@
 /* This removes the underline that's automatically added to links */
 .mito-container a.mito-plan-button {
   text-decoration: none;
-}
-
-.mito-toolbar-button-label {
-  width: min-content;
-  height: auto;
-  
-  /* In notebook, the line height is set higher, so we need to set it back to normal */
-  line-height: normal;
 }
 
 .mito-toolbar-button span {
@@ -370,9 +371,4 @@
 .mito-toolbar-save-indicator path {
   stroke: var(--mito-text-medium)!important;
   stroke-width: 0.75px;
-}
-
-#mito-editor-tab .mito-toolbar-button-label {
-  overflow: hidden;
-  max-height: 27px;
 }

--- a/mitosheet/mitosheet/step_performers/utils/user_defined_function_utils.py
+++ b/mitosheet/mitosheet/step_performers/utils/user_defined_function_utils.py
@@ -144,7 +144,7 @@ def get_param_names_to_types_for_user_defined_functon(f: Callable) -> Dict[str, 
 
     return param_names_to_types
 
-def get_domain_from_user_defined_importer(f: Callable) -> Optional[str]:
+def get_domain_from_user_defined_function(f: Callable) -> Optional[str]:
     """
     Given a user defined importer, return the domain that it's associated with. If it's not associated with a domain, return None.
 
@@ -162,6 +162,23 @@ def get_domain_from_user_defined_importer(f: Callable) -> Optional[str]:
     
     return None
 
+def get_docstring_for_user_defined_function(f: Callable) -> Optional[str]:
+    """
+    Given a user defined importer, return the docstring for it. Will cleanup extra
+    whitespace due to the way that docstrings are formatted in Python.
+
+    Will also get rid of the domain line if it exists.
+    """
+
+    docstring = f.__doc__
+    if docstring is None:
+        return None
+    
+    lines = docstring.split("\n")
+    # Remove the domain line if it exists
+    lines = [line for line in lines if not line.strip().lower().startswith('domain: ')]
+    return ' '.join(lines)
+
 def get_user_defined_importers_for_frontend(state: Optional[State]) -> List[Any]:
     if state is None:
         return []
@@ -169,9 +186,9 @@ def get_user_defined_importers_for_frontend(state: Optional[State]) -> List[Any]
     return [
         {
             'name': f.__name__,
-            'docstring': f.__doc__,
+            'docstring': get_docstring_for_user_defined_function(f),
             'parameters': get_param_names_to_types_for_user_defined_functon(f),
-            'domain': get_domain_from_user_defined_importer(f)
+            'domain': get_domain_from_user_defined_function(f)
         }
         for f in state.user_defined_importers
     ]

--- a/mitosheet/mitosheet/step_performers/utils/user_defined_function_utils.py
+++ b/mitosheet/mitosheet/step_performers/utils/user_defined_function_utils.py
@@ -144,6 +144,24 @@ def get_param_names_to_types_for_user_defined_functon(f: Callable) -> Dict[str, 
 
     return param_names_to_types
 
+def get_domain_from_user_defined_importer(f: Callable) -> Optional[str]:
+    """
+    Given a user defined importer, return the domain that it's associated with. If it's not associated with a domain, return None.
+
+    Currently, we just support starting a doc string line with "Domain: " to specify the domain.
+    TODO: make this more robust in the future
+    """
+    
+    docstring = f.__doc__
+    if docstring is None:
+        return None
+
+    for line in docstring.lower().split('\n'):
+        if line.strip().startswith('domain: '):
+            return line.strip().split('domain: ')[1].strip()
+    
+    return None
+
 def get_user_defined_importers_for_frontend(state: Optional[State]) -> List[Any]:
     if state is None:
         return []
@@ -153,6 +171,7 @@ def get_user_defined_importers_for_frontend(state: Optional[State]) -> List[Any]
             'name': f.__name__,
             'docstring': f.__doc__,
             'parameters': get_param_names_to_types_for_user_defined_functon(f),
+            'domain': get_domain_from_user_defined_importer(f)
         }
         for f in state.user_defined_importers
     ]

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -179,8 +179,6 @@ export const Mito = (props: MitoProps): JSX.Element => {
         void mitoAPI.log('mitosheet_rendered');
     }, [mitoAPI])
 
-    console.log(analysisData.userDefinedImporters)
-
     useEffect(() => {
         /**
          * The mitosheet is rendered first when the mitosheet.sheet() call is made,

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -179,6 +179,8 @@ export const Mito = (props: MitoProps): JSX.Element => {
         void mitoAPI.log('mitosheet_rendered');
     }, [mitoAPI])
 
+    console.log(analysisData.userDefinedImporters)
+
     useEffect(() => {
         /**
          * The mitosheet is rendered first when the mitosheet.sheet() call is made,

--- a/mitosheet/src/mito/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/mito/components/endo/ColumnHeader.tsx
@@ -208,6 +208,7 @@ const ColumnHeader = (props: {
                     return {
                         ...prevUiState,
                         currOpenDropdown: {
+                            type: 'context-menu',
                             rowIndex: -1,
                             columnIndex: props.columnIndex
                         }

--- a/mitosheet/src/mito/components/endo/GridData.tsx
+++ b/mitosheet/src/mito/components/endo/GridData.tsx
@@ -121,6 +121,7 @@ const GridData = (props: {
                                             return {
                                                 ...prevUiState,
                                                 currOpenDropdown: {
+                                                    type: 'context-menu',
                                                     rowIndex: rowIndex,
                                                     columnIndex: columnIndex
                                                 }

--- a/mitosheet/src/mito/components/endo/IndexHeaders.tsx
+++ b/mitosheet/src/mito/components/endo/IndexHeaders.tsx
@@ -69,6 +69,7 @@ const IndexHeaders = (props: {
                                             return {
                                                 ...prevUiState,
                                                 currOpenDropdown: {
+                                                    type: 'context-menu',
                                                     rowIndex: rowIndex,
                                                     columnIndex: -1
                                                 }

--- a/mitosheet/src/mito/components/endo/visibilityUtils.tsx
+++ b/mitosheet/src/mito/components/endo/visibilityUtils.tsx
@@ -99,5 +99,5 @@ export const ensureCellVisible = (containerDiv: HTMLDivElement | null, scrollAnd
 }
 
 export const isCurrOpenDropdownForCell = (uiState: UIState, rowIndex: number, columnIndex: number): boolean =>  {
-    return typeof uiState.currOpenDropdown == 'object' && uiState.currOpenDropdown.rowIndex === rowIndex && uiState.currOpenDropdown.columnIndex === columnIndex;
+    return typeof uiState.currOpenDropdown == 'object' && uiState.currOpenDropdown.type === 'context-menu' && uiState.currOpenDropdown.rowIndex === rowIndex && uiState.currOpenDropdown.columnIndex === columnIndex;
 }

--- a/mitosheet/src/mito/components/taskpanes/UpdateImports/UserDefinedImportScreen.tsx
+++ b/mitosheet/src/mito/components/taskpanes/UpdateImports/UserDefinedImportScreen.tsx
@@ -48,7 +48,7 @@ const UpdateUserDefinedImportScreen = (props: UpdateUserDefinedImportTaskpanePro
             <DefaultTaskpaneHeader 
                 header={header}
                 setUIState={props.setUIState}       
-                backCallback={props.backCallback}    
+                backCallback={props.backCallback}  
             />
             <DefaultTaskpaneBody
                 requiresEnterprise={{

--- a/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedFunctionDocumentationSection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedFunctionDocumentationSection.tsx
@@ -7,22 +7,27 @@ const UserDefinedFunctionDocumentationSection = (props: {
     userDefinedFunction: UserDefinedFunction,
 }): JSX.Element => {
 
-    const hasDocString = props.userDefinedFunction.docstring !== undefined && props.userDefinedFunction.docstring !== null && props.userDefinedFunction.docstring !== '';
-
-    if (!hasDocString) {
-        return <></>;
-    }
-
     return (
         <>
-            <CollapsibleSection title='Documentation'>
-                <p>
-                    {props.userDefinedFunction.docstring}
+            <CollapsibleSection title='Importer Documentation'>
+                <p className="text-subtext-1">
+                    <span className="text-bold">Function Name:</span> {props.userDefinedFunction.name}
                 </p>
+                {props.userDefinedFunction.docstring !== undefined && props.userDefinedFunction.docstring !== null && props.userDefinedFunction.docstring !== '' &&
+                    <>
+                        <Spacer px={5}/>
+                        <p className="text-subtext-1">
+                            <span className="text-bold">Description:</span> {props.userDefinedFunction.docstring}
+                        </p>
+                    </>
+                }
                 {props.userDefinedFunction.domain !== undefined && props.userDefinedFunction.domain !== null &&
-                    <p>
-                        Domain: {props.userDefinedFunction.domain}
-                    </p>
+                    <>
+                        <Spacer px={5}/>
+                        <p className="text-subtext-1">
+                            <span className="text-bold">Domain:</span>  {props.userDefinedFunction.domain}
+                        </p>
+                    </>
                 }
             </CollapsibleSection>
             <Spacer px={10} />

--- a/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedFunctionDocumentationSection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedFunctionDocumentationSection.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { UserDefinedFunction } from "../../../types";
+import CollapsibleSection from "../../layout/CollapsibleSection";
+import Spacer from "../../layout/Spacer";
+
+const UserDefinedFunctionDocumentationSection = (props: {
+    userDefinedFunction: UserDefinedFunction,
+}): JSX.Element => {
+
+    const hasDocString = props.userDefinedFunction.docstring !== undefined && props.userDefinedFunction.docstring !== null && props.userDefinedFunction.docstring !== '';
+
+    if (!hasDocString) {
+        return <></>;
+    }
+
+    return (
+        <>
+            <CollapsibleSection title='Documentation'>
+                <p>
+                    {props.userDefinedFunction.docstring}
+                </p>
+                {props.userDefinedFunction.domain !== undefined && props.userDefinedFunction.domain !== null &&
+                    <p>
+                        Domain: {props.userDefinedFunction.domain}
+                    </p>
+                }
+            </CollapsibleSection>
+            <Spacer px={10} />
+        </>
+    )
+}
+
+export default UserDefinedFunctionDocumentationSection;
+

--- a/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedImportConfig.tsx
+++ b/mitosheet/src/mito/components/taskpanes/UserDefinedImport/UserDefinedImportConfig.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AnalysisData, SheetData, UserDefinedFunction } from "../../../types";
 import { getInitialParamNameToParamValueMap } from '../../../utils/userDefinedFunctionUtils';
+import UserDefinedFunctionDocumentationSection from "./UserDefinedFunctionDocumentationSection";
 import UserDefinedFunctionParamConfigSection from "./UserDefinedFunctionParamConfigSection";
 import { UserDefinedImportParams, getNoImportMessage } from "./UserDefinedImportTaskpane";
 
@@ -31,6 +32,13 @@ const UserDefinedImportImportConfig = (props: {
 
     return (
         <>
+            {userDefinedImporter !== undefined &&
+                <>
+                    <UserDefinedFunctionDocumentationSection
+                        userDefinedFunction={userDefinedImporter}
+                    />
+                </>
+            }
             {params === undefined &&
                 <p>
                     {getNoImportMessage()}

--- a/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
@@ -3,12 +3,124 @@
 
 import React from 'react'
 
-import { ActionEnum, UIState } from '../../types';
+import { ActionEnum, RunTimeAction, UIState } from '../../types';
 import { Actions } from '../../utils/actions';
 import ToolbarButton from './ToolbarButton';
 import Dropdown from '../elements/Dropdown';
 import DropdownItem from '../elements/DropdownItem';
 import ImportIcon from '../icons/ImportIcon';
+import { toTitleCase } from '../../utils/strings';
+
+const getToolbarButtonsForUserDefinedImports = (
+    actions: Actions,
+    uiState: UIState,
+    setUIState: React.Dispatch<React.SetStateAction<UIState>>
+): JSX.Element[] => {
+    // We create a mapping from domain to action
+    const noDomainActions = actions.runtimeImportActionsList.filter(action => (action.domain === undefined || action.domain === null));
+    const domainToAction = new Map<string, RunTimeAction[]>();
+    actions.runtimeImportActionsList.forEach(action => {
+        if (action.domain === undefined || action.domain === null) {
+            return;
+        }
+        const domainActions = domainToAction.get(action.domain);
+        if (domainActions === undefined) {
+            domainToAction.set(action.domain, [action]);
+        } else {
+            domainActions.push(action);
+        }
+    });
+
+    // For all the actions with no domain, or domains with a single action, we just return a button
+    // While we return a dropdown for domains with multiple actions
+    const soloButtons: JSX.Element[] = [];
+    const dropdownButtons: JSX.Element[] = [];
+    noDomainActions.forEach(action => {
+        soloButtons.push(<ToolbarButton
+            action={action}
+            iconOverride={<ImportIcon />}
+            key={action.staticType}
+        />);
+    });
+
+    domainToAction.forEach((domainActions, domain) => {
+        if (domainActions.length === 1) {
+            soloButtons.push(<ToolbarButton
+                action={domainActions[0]}
+                iconOverride={<ImportIcon />}
+                key={domainActions[0].staticType}
+            />);
+            return;
+        }
+
+        // Otherwise, we create a temporary action that opens this dropdown,
+        // as we need it for the toolbar button. That's a bit of a hack, but it's
+        // well contained to just this function
+        const key = `open-domain-dropdown-${domainActions[0].domain}`;
+        const openDomainAction: RunTimeAction = {
+            staticType: key,
+            titleToolbar: toTitleCase(domain),
+            domain: domain,
+            actionFunction: () => {
+                setUIState(prevUIState => {
+                    if (prevUIState.currOpenDropdown === undefined) {
+                        return {
+                            ...prevUIState,
+                            currOpenDropdown: {
+                                type: 'import-domain-dropdown',
+                                domain: domain
+                            }
+                        };
+                    }
+                    return prevUIState;
+                });
+            },
+            type: 'run-time',
+            longTitle: key,
+            searchTerms: [],
+            isDisabled: () => undefined,
+            tooltip: ''
+        };
+
+        dropdownButtons.push(<ToolbarButton
+            action={openDomainAction}
+            iconOverride={<ImportIcon />}
+            key={domainActions[0].staticType}
+        >
+            <Dropdown
+                display={typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'import-domain-dropdown' && uiState.currOpenDropdown.domain === domain}
+                closeDropdown={() => 
+                    setUIState(prevUIState => {
+                        if (typeof prevUIState.currOpenDropdown !== 'object' || prevUIState.currOpenDropdown.type !== 'import-domain-dropdown' || prevUIState.currOpenDropdown.domain !== domain) {
+                            return prevUIState;
+                        }
+
+                        return {
+                            ...prevUIState,
+                            currOpenDropdown: undefined
+                        }
+                    })
+                }
+                searchable
+            >
+                {domainActions.map(action => {
+                    console.log(action)
+                    return (<DropdownItem
+                        title={action.titleToolbar || action.longTitle}
+                        subtext={action.tooltip}
+                        key={action.staticType}
+                        onClick={action.actionFunction}
+                    />)
+                })}
+            </Dropdown>
+        </ToolbarButton>);
+    });
+
+    // Put all solo buttons first, then all dropdown buttons
+    const buttons: JSX.Element[] = [...soloButtons, ...dropdownButtons];
+    return buttons;
+}
+
 
 export const DataTabContents = (
     props: {
@@ -27,15 +139,7 @@ export const DataTabContents = (
         <ToolbarButton
             action={props.actions.buildTimeActions[ActionEnum.SNOWFLAKEIMPORT]}
         />
-        {props.actions.runtimeImportActionsList.map(action => {
-            return (<ToolbarButton
-                action={action}
-                toolbarTitle={action.titleToolbar}
-                iconOverride={<ImportIcon />}
-                key={action.staticType}
-            />)
-        })}
-
+        {getToolbarButtonsForUserDefinedImports(props.actions, props.uiState, props.setUIState)}
         <div className='toolbar-vertical-line' />
         
         <ToolbarButton

--- a/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
@@ -11,6 +11,13 @@ import DropdownItem from '../elements/DropdownItem';
 import ImportIcon from '../icons/ImportIcon';
 import { toTitleCase } from '../../utils/strings';
 
+
+/**
+ * This function returns a list of toolbar buttons for all the user defined imports:
+ * 1. Any action with no domain gets its own button
+ * 2. Any domain with a single action gets its own button
+ * 3. Any domain with multiple actions gets a dropdown
+ */
 const getToolbarButtonsForUserDefinedImports = (
     actions: Actions,
     uiState: UIState,

--- a/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/DataTabContents.tsx
@@ -30,6 +30,7 @@ export const DataTabContents = (
         {props.actions.runtimeImportActionsList.map(action => {
             return (<ToolbarButton
                 action={action}
+                toolbarTitle={action.titleToolbar}
                 iconOverride={<ImportIcon />}
                 key={action.staticType}
             />)

--- a/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
+++ b/mitosheet/src/mito/components/toolbar/HomeTabContents.tsx
@@ -204,7 +204,7 @@ export const HomeTabContents = (
         />
         <ToolbarButton
             action={props.actions.buildTimeActions[ActionEnum.OpenFind]}
-            toolbarTitle='Find & Replace'
+            titleToolbar='Find & Replace'
         />
         <ToolbarButton
             action={props.actions.buildTimeActions[ActionEnum.Change_Dtype]}

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -29,7 +29,7 @@ const ToolbarButton = (
         /**
          * Optional override of the action's title. 
          */
-        toolbarTitle?: string;
+        titleToolbar?: string;
 
         /**
         * @param [highlightToolbarButton] - Used to draw attention to the toolbar item. Defaults to False. 
@@ -94,8 +94,8 @@ const ToolbarButton = (
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}
                         {props.children !== undefined && props.children}
                     </div>
-                    {(props.toolbarTitle ?? props.action.titleToolbar) && <p className='mito-toolbar-button-label'> 
-                        {props.toolbarTitle ?? props.action.titleToolbar}
+                    {(props.titleToolbar ?? props.action.titleToolbar) && <p className='mito-toolbar-button-label'> 
+                        {props.titleToolbar ?? props.action.titleToolbar}
                     </p>}
                 </span>
             </button>

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -733,7 +733,8 @@ export type UserDefinedFunctionParamNameToType = Record<UserDefinedFunctionParam
 export type UserDefinedFunction = {
     name: string,
     docstring: string,
-    parameters: UserDefinedFunctionParamNameToType
+    parameters: UserDefinedFunctionParamNameToType,
+    domain?: string
 }
 
 

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -884,13 +884,22 @@ export interface ExportState { fileName?: string, exportType: 'csv' | 'excel' }
 export interface CSVExportState extends ExportState { exportType: 'csv' }
 export interface ExcelExportState extends ExportState { exportType: 'excel', sheetIndexes: number[] }
 
-export type OpenDropdownType = ToolbarDropdown | ContextMenu;
 
 export interface ContextMenu {
+    type: 'context-menu';
     rowIndex: number;
     columnIndex: number;
 }
 export type ToolbarDropdown = 'import' | 'format' | 'dtype' | 'export' | 'merge' | 'reset-index' | 'formula-math' | 'formula-logic' | 'formula-finance' | 'formula-date' | 'formula-text' | 'formula-reference' | 'formula-custom' | 'formula-more' | undefined;
+
+export interface DataTabImportDomainDropdown {
+    type: 'import-domain-dropdown';
+    domain: string;
+}
+
+
+export type OpenDropdownType = ToolbarDropdown | ContextMenu | DataTabImportDomainDropdown;
+
 
 export enum PopupType {
     EphemeralMessage = 'ephemeral_message',
@@ -1099,7 +1108,6 @@ export interface BaseAction<Type, StaticType> {
     // The tooltip to display in the toolbar or search bar when this is hovered over
     tooltip: string
 
-
     // If this action has a keyboard shortcut, then you can display this by setting these values
     displayKeyboardShortcuts?: {
         mac: string,
@@ -1108,6 +1116,11 @@ export interface BaseAction<Type, StaticType> {
 
     // If this action is only available for pro users
     requiredPlan?: 'pro' | 'enterprise'
+
+    // If this action is in the context of a specific domain, then you can set this
+    // This is useful for user defined functions, importers, or editors, which 
+    // can be then grouped by domain in the UI
+    domain?: string
 }
 export type BuildTimeAction = BaseAction<'build-time', ActionEnum>
 export type RunTimeAction = BaseAction<'run-time', string>

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -2370,7 +2370,7 @@ export const getActions = (
         return {
             type: 'run-time',
             staticType: f.name,
-            toolbarTitle: displayName,
+            titleToolbar: displayName,
             longTitle: displayName,
             actionFunction: () => {
                 // We turn off editing mode, if it is on

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -345,7 +345,7 @@ export const getActions = (
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
 
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     const rowIndex = uiState.currOpenDropdown.rowIndex;
                     const columnIndex = uiState.currOpenDropdown.columnIndex;
                     setGridState(prevGridState => {
@@ -790,7 +790,7 @@ export const getActions = (
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
 
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     const rowIndex = uiState.currOpenDropdown.rowIndex;
                     const columnIndex = uiState.currOpenDropdown.columnIndex;
                     setGridState(prevGridState => {
@@ -1533,7 +1533,7 @@ export const getActions = (
             actionFunction: () => {
                 let columnIndex = startingColumnIndex;
                 // If this is being triggered by a context menu, then we need to find the column that was clicked on
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     columnIndex = uiState.currOpenDropdown.columnIndex;
                 }
                 const columnHeader = getCellDataFromCellIndexes(sheetData, -1, columnIndex).columnHeader;
@@ -1756,7 +1756,7 @@ export const getActions = (
                 }
 
                 let columnIndex = startingColumnIndex;
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     columnIndex = uiState.currOpenDropdown.columnIndex;
                 }
                 const columnIDForSort = getColumnIDByIndex(sheetData, columnIndex);
@@ -1783,7 +1783,7 @@ export const getActions = (
                 }
 
                 let columnIndex = startingColumnIndex;
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     columnIndex = uiState.currOpenDropdown.columnIndex;
                 }
                 const columnIDForSort = getColumnIDByIndex(sheetData, columnIndex);
@@ -1980,7 +1980,7 @@ export const getActions = (
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
 
-                if (typeof uiState.currOpenDropdown === 'object') {
+                if (typeof uiState.currOpenDropdown === 'object' && uiState.currOpenDropdown.type === 'context-menu') {
                     const rowIndex = uiState.currOpenDropdown.rowIndex;
                     const columnIndex = uiState.currOpenDropdown.columnIndex;
                     setGridState(prevGridState => {
@@ -2389,7 +2389,8 @@ export const getActions = (
             },
             isDisabled: () => {return undefined},
             searchTerms: displayName.split(' '),
-            tooltip: f.docstring
+            tooltip: f.docstring,
+            domain: f.domain
         }
     })
 
@@ -2398,7 +2399,7 @@ export const getActions = (
         return {
             type: 'run-time',
             staticType: f.name,
-            toolbarTitle: displayName,
+            titleToolbar: displayName,
             longTitle: displayName,
             actionFunction: () => {
                 // We turn off editing mode, if it is on

--- a/mitosheet/src/mito/utils/strings.tsx
+++ b/mitosheet/src/mito/utils/strings.tsx
@@ -55,3 +55,7 @@ export const convertToStringOrUndefined = (possibleString: string | number | boo
 export function capitalizeFirstLetter(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
+
+export function toTitleCase(s: string): string {
+    return s.split(' ').map(capitalizeFirstLetter).join(' ');
+}


### PR DESCRIPTION
# Description

1. Fixes https://github.com/mito-ds/mito/issues/1078
2. Adds domain for user defined function (not the full version for now, but this is fine)
3. Includes documentation for user defined functions

Tried hard and failed to cut the subtext at two lines, feel free to give it a shot.

# Testing

Use this streamlit app:

```
from mitosheet.streamlit.v1 import spreadsheet
import pandas as pd
import streamlit as st

# Make the page wide
st.set_page_config(layout="wide")

def no_docstring(x: int, y: int, z: int, f: int, long_variable_name: str):
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def importer_test_domain():
    """
    This is the first importer in the domain Retail. It has a long description, and we're going to see what 
    happens when you go on for a while. 

    This has multiple lines, and some of them should probably be elided in some places, otherwise a whole ton 
    of stuff is going to be displayed when it should not be. 
    
    Domain: Retail
    """
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def importer_test_domain_two():
    """
    This is the second importer in domain Retail
    Domain: Retail
    """
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def solo_domain():
    """
    This is a longer description
    Domain: solo
    """
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def no_domain_one():
    """
    Test
    """
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def no_domain_two():
    """
    Test
    """
    return pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})

def editor(df: pd.DataFrame):
    """
    Test
    Domain: test
    """
    return

spreadsheet(importers=[
    no_docstring,
    importer_test_domain, 
    importer_test_domain_two,
    solo_domain,
    no_domain_one,
    no_domain_two
], editors=[editor], import_folder='datasets')
```

And check out the importers tab.

# Documentation

We can write documentation for this sometime.