### PR TITLE
Add keyboard shortcut hint to toolbar button tooltip

### DIFF
--- a/mitosheet/src/mito/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/mito/components/endo/EndoGrid.tsx
@@ -20,6 +20,7 @@ import FloatingCellEditor from "./celleditor/FloatingCellEditor";
 import { SendFunctionStatus } from "../../api/send";
 import { SearchBar } from "../SearchBar";
 import { Actions } from "../../utils/actions";
+import { getOperatingSystem } from "../../utils/keyboardShortcuts";
 
 // NOTE: these should match the css
 export const DEFAULT_WIDTH = 123;
@@ -311,9 +312,7 @@ function EndoGrid(props: {
                     1. Being on Mac, and command+clicking
                     2. Being on Windows, and ctrl+clicking
                 */
-                const operatingSystem = window.navigator.userAgent.toUpperCase().includes('MAC')
-                    ? 'mac'
-                    : 'windows'
+                const operatingSystem = getOperatingSystem();
 
                 if (e.shiftKey) {
                     // Just add the new click locaton to a new selection at the end of the selections list

--- a/mitosheet/src/mito/components/endo/utils.tsx
+++ b/mitosheet/src/mito/components/endo/utils.tsx
@@ -1,4 +1,4 @@
-import { Action, ColumnFilters, ColumnFormatType, ColumnHeader, ColumnID, GridState, IndexLabel, SheetData, UIState } from "../../types";
+import { Action, ActionEnum, ColumnFilters, ColumnFormatType, ColumnHeader, ColumnID, GridState, IndexLabel, SheetData, UIState } from "../../types";
 import { isBoolDtype, isDatetimeDtype, isFloatDtype, isIntDtype, isTimedeltaDtype } from "../../utils/dtypes";
 import { getKeyboardShortcutString } from "../../utils/keyboardShortcuts";
 import StepsIcon from "../icons/StepsIcon";
@@ -209,6 +209,6 @@ export const getPropsForContextMenuDropdownItem = (action: Action, closeOpenEdit
         },
         disabled: !!action.isDisabled(),
         icon: action.iconContextMenu ? <action.iconContextMenu /> : action.iconToolbar ? <action.iconToolbar/> : <StepsIcon/>,
-        rightText: getKeyboardShortcutString(action),
+        rightText: getKeyboardShortcutString(action.staticType as ActionEnum),
     }
 }

--- a/mitosheet/src/mito/components/endo/utils.tsx
+++ b/mitosheet/src/mito/components/endo/utils.tsx
@@ -1,5 +1,6 @@
 import { Action, ColumnFilters, ColumnFormatType, ColumnHeader, ColumnID, GridState, IndexLabel, SheetData, UIState } from "../../types";
 import { isBoolDtype, isDatetimeDtype, isFloatDtype, isIntDtype, isTimedeltaDtype } from "../../utils/dtypes";
+import { getKeyboardShortcutString } from "../../utils/keyboardShortcuts";
 import StepsIcon from "../icons/StepsIcon";
 import { getFormulaStringFromFrontendFormula } from "./celleditor/cellEditorUtils";
 import { getWidthData } from "./widthUtils";
@@ -208,6 +209,6 @@ export const getPropsForContextMenuDropdownItem = (action: Action, closeOpenEdit
         },
         disabled: !!action.isDisabled(),
         icon: action.iconContextMenu ? <action.iconContextMenu /> : action.iconToolbar ? <action.iconToolbar/> : <StepsIcon/>,
-        rightText: action.displayKeyboardShortcuts?.mac
+        rightText: getKeyboardShortcutString(action),
     }
 }

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { BuildTimeAction, RunTimeAction } from '../../types';
 import { classNames } from '../../utils/classNames';
 import StepsIcon from '../icons/StepsIcon';
+import { getOperatingSystem, keyboardShortcuts } from '../../utils/keyboardShortcuts';
 
 /**
  * The ToolbarButton component is used to create each
@@ -60,6 +61,17 @@ const ToolbarButton = (
     const highlightToobarItemClass = props.highlightToolbarButton === true ? 'mito-toolbar-button-draw-attention' : ''
     const hasDropdown = props.children !== undefined;
     const orientation = props.orientation ?? 'vertical';
+    const shortcut = keyboardShortcuts.find(shortcut => {
+        return shortcut.action === props.action.staticType
+    });
+    let tooltip = disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar;
+    if (shortcut !== undefined) {
+        const keyCombo = shortcut[window.navigator.userAgent.toUpperCase().includes('MAC') ? 'macKeyCombo' : 'winKeyCombo']
+        const metaKey = getOperatingSystem() === 'mac' ? '⌘' : 'Meta';
+        const key = keyCombo.keys[0].length === 1 ? keyCombo.keys[0].toUpperCase() : keyCombo.keys[0];
+        const keyComboString = `${keyCombo.ctrlKey ? 'Ctrl+' : ''}${keyCombo.shiftKey ? 'Shift+' : ''}${keyCombo.altKey ? 'Alt+' : ''}${keyCombo.metaKey ? `${metaKey}+` : ''}${key}`
+        tooltip += `(${keyComboString})`
+    }
     
     return (
         <div 
@@ -88,7 +100,7 @@ const ToolbarButton = (
                     
                     If the icons have different heights, the text won't line up. 
                 */}
-                <span title={disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar}>
+                <span title={tooltip}>
                     <div className='mito-toolbar-button-icon-container'>
                         {props.iconOverride ?? (props.action.iconToolbar !== undefined ? <props.action.iconToolbar /> : <StepsIcon />)}
                         {hasDropdown && <div className='mito-toolbar-button-dropdown-icon'>▾</div>}

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mito
 
 import React from 'react';
-import { BuildTimeAction, RunTimeAction } from '../../types';
+import { ActionEnum, BuildTimeAction, RunTimeAction } from '../../types';
 import { classNames } from '../../utils/classNames';
 import StepsIcon from '../icons/StepsIcon';
 import { getKeyboardShortcutString } from '../../utils/keyboardShortcuts';
@@ -62,7 +62,7 @@ const ToolbarButton = (
     const hasDropdown = props.children !== undefined;
     const orientation = props.orientation ?? 'vertical';
     let tooltip = disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar;
-    tooltip += ` (${getKeyboardShortcutString(props.action)})` ?? '';
+    tooltip += ` (${getKeyboardShortcutString(props.action.staticType as ActionEnum)})` ?? '';
     
     return (
         <div 

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -62,7 +62,7 @@ const ToolbarButton = (
     const hasDropdown = props.children !== undefined;
     const orientation = props.orientation ?? 'vertical';
     let tooltip = disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar;
-    tooltip += getKeyboardShortcutString(props.action) ?? '';
+    tooltip += ` (${getKeyboardShortcutString(props.action)})` ?? '';
     
     return (
         <div 

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { BuildTimeAction, RunTimeAction } from '../../types';
 import { classNames } from '../../utils/classNames';
 import StepsIcon from '../icons/StepsIcon';
-import { getOperatingSystem, keyboardShortcuts } from '../../utils/keyboardShortcuts';
+import { getKeyboardShortcutString } from '../../utils/keyboardShortcuts';
 
 /**
  * The ToolbarButton component is used to create each
@@ -61,17 +61,8 @@ const ToolbarButton = (
     const highlightToobarItemClass = props.highlightToolbarButton === true ? 'mito-toolbar-button-draw-attention' : ''
     const hasDropdown = props.children !== undefined;
     const orientation = props.orientation ?? 'vertical';
-    const shortcut = keyboardShortcuts.find(shortcut => {
-        return shortcut.action === props.action.staticType
-    });
     let tooltip = disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar;
-    if (shortcut !== undefined) {
-        const keyCombo = shortcut[window.navigator.userAgent.toUpperCase().includes('MAC') ? 'macKeyCombo' : 'winKeyCombo']
-        const metaKey = getOperatingSystem() === 'mac' ? '⌘' : 'Meta';
-        const key = keyCombo.keys[0].length === 1 ? keyCombo.keys[0].toUpperCase() : keyCombo.keys[0];
-        const keyComboString = `${keyCombo.ctrlKey ? 'Ctrl+' : ''}${keyCombo.shiftKey ? 'Shift+' : ''}${keyCombo.altKey ? 'Alt+' : ''}${keyCombo.metaKey ? `${metaKey}+` : ''}${key}`
-        tooltip += `(${keyComboString})`
-    }
+    tooltip += getKeyboardShortcutString(props.action) ?? '';
     
     return (
         <div 

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -1104,13 +1104,6 @@ export interface BaseAction<Type, StaticType> {
     // The tooltip to display in the toolbar or search bar when this is hovered over
     tooltip: string
 
-
-    // If this action has a keyboard shortcut, then you can display this by setting these values
-    displayKeyboardShortcuts?: {
-        mac: string,
-        windows: string
-    }
-
     // If this action is only available for pro users
     requiredPlan?: 'pro' | 'enterprise'
 }

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -416,11 +416,7 @@ export const getActions = (
                 return getDataframeIsSelected(uiState, sheetDataArray) ? defaultActionDisabledMessage : "There is no selected data to copy."
             },
             searchTerms: ['copy', 'paste', 'export'],
-            tooltip: "Copy the current selection to the clipboard.",
-            displayKeyboardShortcuts: {
-                mac: 'Cmd+C',
-                windows: 'Ctrl+C'
-            }
+            tooltip: "Copy the current selection to the clipboard."
         },
         [ActionEnum.CopyCode]: {
             type: 'build-time',
@@ -1601,11 +1597,7 @@ export const getActions = (
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['redo', 'undo'],
-            tooltip: "Reapplies the last step that you undid, as long as you haven't made any edits since the undo.",
-            displayKeyboardShortcuts: {
-                mac: 'Cmd+Y',
-                windows: 'Ctrl+Y'
-            }
+            tooltip: "Reapplies the last step that you undid, as long as you haven't made any edits since the undo."
         },
         [ActionEnum.Rename_Column]: {
             type: 'build-time',
@@ -2047,10 +2039,6 @@ export const getActions = (
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no sheets to pivot. Import data.'},
             searchTerms: ['search', 'find', 'filter', 'lookup'],
             tooltip: "Search for a value in your data.",
-            displayKeyboardShortcuts: {
-                mac: 'Cmd+F',
-                windows: 'Ctrl+F'
-            }
         },
         [ActionEnum.OpenFindAndReplace]: {
             type: 'build-time',
@@ -2077,11 +2065,7 @@ export const getActions = (
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no sheets to pivot. Import data.'},
             searchTerms: ['search', 'find', 'filter', 'lookup'],
-            tooltip: "Search for a value in your data and replace with another value.",
-            displayKeyboardShortcuts: {
-                mac: 'Shift+Ctrl+F',
-                windows: 'Ctrl+H'
-            }
+            tooltip: "Search for a value in your data and replace with another value."
         },
         [ActionEnum.Open_Next_Sheet]: {
             type: 'build-time',
@@ -2100,11 +2084,7 @@ export const getActions = (
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['sheet', 'index', 'next', 'forward'],
-            tooltip: "Go to the next sheet.",
-            displayKeyboardShortcuts: {
-                mac: 'Option+Right Arrow',
-                windows: 'Alt+Right Arrow'
-            }
+            tooltip: "Go to the next sheet."
         },
         [ActionEnum.Open_Previous_Sheet]: {
             type: 'build-time',
@@ -2123,11 +2103,7 @@ export const getActions = (
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['sheet', 'index', 'previous', 'last'],
-            tooltip: "Go to the previous sheet.",
-            displayKeyboardShortcuts: {
-                mac: 'Option+Left Arrow',
-                windows: 'Alt+Left Arrow'
-            }
+            tooltip: "Go to the previous sheet."
         },
         [ActionEnum.Undo]: {
             type: 'build-time',
@@ -2145,11 +2121,7 @@ export const getActions = (
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['undo', 'go back', 'redo'],
-            tooltip: 'Undo the most recent edit.',
-            displayKeyboardShortcuts: {
-                mac: 'Cmd+Z',
-                windows: 'Ctrl+Z'
-            }
+            tooltip: 'Undo the most recent edit.'
         },
         [ActionEnum.Unique_Values]: {
             type: 'build-time',

--- a/mitosheet/src/mito/utils/keyboardShortcuts.tsx
+++ b/mitosheet/src/mito/utils/keyboardShortcuts.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionEnum, KeyboardShorcut } from "../types"
+import { ActionEnum, KeyboardShorcut } from "../types"
 import { Actions } from "./actions"
 
 /**
@@ -286,6 +286,8 @@ export const keyboardShortcuts: KeyboardShorcut[] = [
     }
 ]
 
+export const keyboardShortcutsMap = new Map<ActionEnum, KeyboardShorcut>(keyboardShortcuts.map(shortcut => [shortcut.action, shortcut]))
+
 /**
  * Used to determine if the user is on a mac or windows.
  * @returns 'mac' if the user is on a mac, 'windows' otherwise.
@@ -300,11 +302,9 @@ export const getOperatingSystem = () => {
  * @param action - The action to get the keyboard shortcut for.
  * @returns A string describing the keyboard shortcut for the given action.
  */
-export const getKeyboardShortcutString = (action: Action) => {
+export const getKeyboardShortcutString = (action: ActionEnum) => {
     // Find the keyboard shortcut for the given action.
-    const shortcut = keyboardShortcuts.find(shortcut => {
-        return shortcut.action === action.staticType
-    });
+    const shortcut = keyboardShortcutsMap.get(action);
 
     // If there is no keyboard shortcut for the given action, return undefined.
     if (shortcut === undefined) {

--- a/mitosheet/src/mito/utils/keyboardShortcuts.tsx
+++ b/mitosheet/src/mito/utils/keyboardShortcuts.tsx
@@ -1,4 +1,4 @@
-import { ActionEnum, KeyboardShorcut } from "../types"
+import { Action, ActionEnum, KeyboardShorcut } from "../types"
 import { Actions } from "./actions"
 
 /**
@@ -286,10 +286,39 @@ export const keyboardShortcuts: KeyboardShorcut[] = [
     }
 ]
 
+/**
+ * Used to determine if the user is on a mac or windows.
+ * @returns 'mac' if the user is on a mac, 'windows' otherwise.
+ */
 export const getOperatingSystem = () => {
     return window.navigator.userAgent.toUpperCase().includes('MAC')
         ? 'mac'
         : 'windows';
+}
+
+/**
+ * @param action - The action to get the keyboard shortcut for.
+ * @returns A string describing the keyboard shortcut for the given action.
+ */
+export const getKeyboardShortcutString = (action: Action) => {
+    // Find the keyboard shortcut for the given action.
+    const shortcut = keyboardShortcuts.find(shortcut => {
+        return shortcut.action === action.staticType
+    });
+
+    // If there is no keyboard shortcut for the given action, return undefined.
+    if (shortcut === undefined) {
+        return undefined;
+    }
+
+    // Get the key combo for the current operating system.
+    const keyCombo = shortcut[window.navigator.userAgent.toUpperCase().includes('MAC') ? 'macKeyCombo' : 'winKeyCombo']
+
+    // For mac, use the symbol associated with command key. For windows, use the word "Meta".
+    const metaKey = getOperatingSystem() === 'mac' ? '⌘' : 'Meta';
+    const key = keyCombo.keys[0].length === 1 ? keyCombo.keys[0].toUpperCase() : keyCombo.keys[0];
+    const keyComboString = `${keyCombo.ctrlKey ? 'Ctrl+' : ''}${keyCombo.shiftKey ? 'Shift+' : ''}${keyCombo.altKey ? 'Alt+' : ''}${keyCombo.metaKey ? `${metaKey}+` : ''}${key}`
+    return keyComboString;
 }
 
 /**

--- a/mitosheet/src/mito/utils/keyboardShortcuts.tsx
+++ b/mitosheet/src/mito/utils/keyboardShortcuts.tsx
@@ -286,15 +286,19 @@ export const keyboardShortcuts: KeyboardShorcut[] = [
     }
 ]
 
+export const getOperatingSystem = () => {
+    return window.navigator.userAgent.toUpperCase().includes('MAC')
+        ? 'mac'
+        : 'windows';
+}
+
 /**
  * Handles keyboard shortcuts. If a keyboard shortcut is pressed, the corresponding action is executed.
  * @param e The keyboard event.
  * @param actions The actions object.
  */
 export const handleKeyboardShortcuts = (e: React.KeyboardEvent, actions: Actions) => {
-    const operatingSystem = window.navigator.userAgent.toUpperCase().includes('MAC')
-        ? 'mac'
-        : 'windows'
+    const operatingSystem = getOperatingSystem();
 
     const shortcut = keyboardShortcuts.find(shortcut => {
         const keyCombo = operatingSystem === 'mac' ? shortcut.macKeyCombo : shortcut.winKeyCombo

--- a/mitosheet/src/mito/utils/keyboardShortcuts.tsx
+++ b/mitosheet/src/mito/utils/keyboardShortcuts.tsx
@@ -316,7 +316,11 @@ export const getKeyboardShortcutString = (action: Action) => {
 
     // For mac, use the symbol associated with command key. For windows, use the word "Meta".
     const metaKey = getOperatingSystem() === 'mac' ? '⌘' : 'Meta';
+
+    // If a key is a single character, make it uppercase. Otherwise, leave it as is.
     const key = keyCombo.keys[0].length === 1 ? keyCombo.keys[0].toUpperCase() : keyCombo.keys[0];
+
+    // Create a string describing the keyboard shortcut.
     const keyComboString = `${keyCombo.ctrlKey ? 'Ctrl+' : ''}${keyCombo.shiftKey ? 'Shift+' : ''}${keyCombo.altKey ? 'Alt+' : ''}${keyCombo.metaKey ? `${metaKey}+` : ''}${key}`
     return keyComboString;
 }

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -16,7 +16,7 @@ import {
     getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell
 } from './jupyter/lab/extensionUtils';
 import { containsGeneratedCodeOfAnalysis, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine } from './jupyter/code';
-import { keyboardShortcuts } from './mito/utils/keyboardShortcuts';
+import { getOperatingSystem, keyboardShortcuts } from './mito/utils/keyboardShortcuts';
 
 const registerMitosheetToolbarButtonAdder = (tracker: INotebookTracker) => {
 
@@ -315,9 +315,7 @@ function activateMitosheetExtension(
     for (const shortcut of keyboardShortcuts) {
         // Only add the keyboard shortcut if it has a jupyterLabAction defined. 
         if (shortcut.jupyterLabCommand !== undefined) {
-            const operatingSystem = window.navigator.userAgent.toUpperCase().includes('MAC')
-                ? 'mac'
-                : 'windows'
+            const operatingSystem = getOperatingSystem();
             const keyCombo = operatingSystem === 'mac' ? shortcut.macKeyCombo : shortcut.winKeyCombo
 
             app.commands.addKeyBinding({

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -337,7 +337,7 @@ test.describe('Keyboard Shortcuts', () => {
 
   test('Select Row with multiple rows', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
-    await mito.getByTitle('5').click();
+    await mito.getByTitle('5', {exact: true}).click();
     await mito.getByTitle('8').click({ modifiers: ['Shift']});
     await page.keyboard.press('Shift+ ');
     await expect(mito.locator('.index-header-selected')).toHaveCount(2);

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -323,14 +323,14 @@ test.describe('Home Tab Buttons', () => {
 test.describe('Keyboard Shortcuts', () => {
   test('Select Column', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
-    await mito.getByText('5').click();
+    await mito.getByText('5', { exact: true }).click();
     await page.keyboard.press('Control+ ');
     await expect(mito.locator('.endo-column-header-container-selected .endo-column-header-final-text')).toHaveText('Column2');
   })
 
   test('Select Row', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
-    await mito.getByTitle('5').click();
+    await mito.getByTitle('5', { exact: true }).click();
     await page.keyboard.press('Shift+ ');
     await expect(mito.locator('.index-header-selected')).toHaveText('1');
   })


### PR DESCRIPTION
Adds keyboard shortcut in parentheses after the tooltip text for toolbar buttons and context menu items
<img width="364" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/b1853ffc-e059-4feb-95ab-461e12390b7e">
<img width="401" alt="image" src="https://github.com/mito-ds/mito/assets/6673460/053ce600-f2e6-4622-b87a-daf05c760dd4">
