### PR TITLE
Add destination sheet index to merge

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
@@ -80,6 +80,7 @@ class DataframeRenameCodeChunk(CodeChunk):
         return MergeCodeChunk(
             merge_code_chunk.prev_state,
             merge_code_chunk.how,
+            merge_code_chunk.destination_sheet_index,
             merge_code_chunk.sheet_index_one,
             merge_code_chunk.sheet_index_two,
             merge_code_chunk.merge_key_column_ids,

--- a/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
@@ -21,9 +21,21 @@ UNIQUE_IN_RIGHT = 'unique in right'
 class MergeCodeChunk(CodeChunk):
 
 
-    def __init__(self, prev_state: State, how: str, sheet_index_one: int, sheet_index_two: int, merge_key_column_ids: List[List[ColumnID]], selected_column_ids_one: List[ColumnID], selected_column_ids_two: List[ColumnID], new_df_name: str):
+    def __init__(
+        self,
+        prev_state: State,
+        how: str,
+        destination_sheet_index: Optional[int],
+        sheet_index_one: int, 
+        sheet_index_two: int, 
+        merge_key_column_ids: List[List[ColumnID]], 
+        selected_column_ids_one: List[ColumnID], 
+        selected_column_ids_two: List[ColumnID], 
+        new_df_name: str
+    ):
         super().__init__(prev_state)
         self.how: str = how 
+        self.destination_sheet_index = destination_sheet_index
         self.sheet_index_one: int = sheet_index_one 
         self.sheet_index_two: int = sheet_index_two 
         self.merge_key_column_ids: List[List[ColumnID]] = merge_key_column_ids 
@@ -39,6 +51,75 @@ class MergeCodeChunk(CodeChunk):
     
     def get_description_comment(self) -> str:
         return f'Merged {self.df_one_name} and {self.df_two_name} into {self.new_df_name}'
+
+    def _combine_right_with_merge_code_chunk(self, merge_code_chunk: "MergeCodeChunk") -> Optional["CodeChunk"]:
+        """
+        We can combine a merge code chunk with the one before it if the destination
+        sheet index of the other is the created code index of this step.
+        """
+        destination_sheet_index = self.destination_sheet_index
+        other_destination_sheet_index = merge_code_chunk.destination_sheet_index
+
+        # If both of the merges are overwriting the same destination sheet index, and they are both defined
+        if destination_sheet_index is not None and destination_sheet_index == other_destination_sheet_index:
+            return MergeCodeChunk(
+                self.prev_state,
+                merge_code_chunk.how,
+                merge_code_chunk.destination_sheet_index,
+                merge_code_chunk.sheet_index_one, 
+                merge_code_chunk.sheet_index_two, 
+                merge_code_chunk.merge_key_column_ids, 
+                merge_code_chunk.selected_column_ids_one, 
+                merge_code_chunk.selected_column_ids_two, 
+                merge_code_chunk.new_df_name
+            )
+
+        # If one of the merges if creating the code chunk that the new one is overwriting, then we can optimize
+        # this as well
+        created_sheet_index = self.get_created_sheet_indexes()
+        if created_sheet_index is not None and created_sheet_index[0] == other_destination_sheet_index:
+            return MergeCodeChunk(
+                self.prev_state,
+                merge_code_chunk.how,
+                merge_code_chunk.destination_sheet_index,
+                merge_code_chunk.sheet_index_one, 
+                merge_code_chunk.sheet_index_two, 
+                merge_code_chunk.merge_key_column_ids, 
+                merge_code_chunk.selected_column_ids_one, 
+                merge_code_chunk.selected_column_ids_two, 
+                merge_code_chunk.new_df_name
+            )
+
+        return None
+
+    def combine_right(self, other_code_chunk: "CodeChunk") -> Optional["CodeChunk"]:
+        if isinstance(other_code_chunk, MergeCodeChunk):
+            return self._combine_right_with_merge_code_chunk(other_code_chunk)
+        return None
+    
+    def combine_left(self, other_code_chunk: "CodeChunk") -> Optional["CodeChunk"]:
+        # Because overwriting a merge overwrites all the edits on that merge table
+        # we can optimize out any edits that are before the merge 
+        # NOTE: if we start carrying edits on merges forward, we should remove this 
+        # optimization
+
+        destination_sheet_index = self.destination_sheet_index
+        edited_sheet_indexes = other_code_chunk.get_edited_sheet_indexes()
+
+        if edited_sheet_indexes is not None and len(edited_sheet_indexes) == 1 and edited_sheet_indexes[0] == destination_sheet_index:
+            return MergeCodeChunk(
+                other_code_chunk.prev_state,
+                self.how,
+                self.destination_sheet_index,
+                self.sheet_index_one, 
+                self.sheet_index_two, 
+                self.merge_key_column_ids, 
+                self.selected_column_ids_one, 
+                self.selected_column_ids_two, 
+                self.new_df_name
+            )
+
+        return None
 
     def get_code(self) -> Tuple[List[str], List[str]]:
         merge_keys_one: List[ColumnHeader] = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index_one, list(map(lambda x: x[0], self.merge_key_column_ids)))

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/merge.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/merge.py
@@ -136,3 +136,42 @@ def upgrade_merge_3_to_4(step: Dict[str, Any], later_steps: List[Dict[str, Any]]
         "step_type": "merge", 
         "params": params
     }] + later_steps
+
+
+def upgrade_merge_4_to_5(step: Dict[str, Any], later_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Support for destination_sheet_index to make edits to merges. 
+
+    OLD: {
+        "step_version": 4, 
+        "step_type": "merge", 
+        "params": {
+            sheet_index_one: 0,
+            sheet_index_two: 1,
+            merge_key_column_ids: [[old.merge_key_column_id_one, old.merge_key_column_id_two]],
+            selected_column_ids_one: List[_ids_],
+            selected_column_ids_two: List[_ids_],
+        }
+    }
+
+    NEW: {
+        "step_version": 5, 
+        "step_type": "merge", 
+        "params": {
+            sheet_index_one: 0,
+            sheet_index_two: 1,
+            merge_key_column_ids: [[old.merge_key_column_id_one, old.merge_key_column_id_two]],
+            selected_column_ids_one: List[_ids_],
+            selected_column_ids_two: List[_ids_],
+            destination_sheet_index: 2
+        }
+    }
+    """
+    params = step['params']
+    params['destination_sheet_index'] = None
+
+    return [{
+        "step_version": 5, 
+        "step_type": "merge", 
+        "params": params
+    }] + later_steps

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/merge.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/merge.py
@@ -163,7 +163,7 @@ def upgrade_merge_4_to_5(step: Dict[str, Any], later_steps: List[Dict[str, Any]]
             merge_key_column_ids: [[old.merge_key_column_id_one, old.merge_key_column_id_two]],
             selected_column_ids_one: List[_ids_],
             selected_column_ids_two: List[_ids_],
-            destination_sheet_index: 2
+            destination_sheet_index: None
         }
     }
     """

--- a/mitosheet/mitosheet/saved_analyses/upgrade.py
+++ b/mitosheet/mitosheet/saved_analyses/upgrade.py
@@ -32,7 +32,7 @@ from mitosheet.saved_analyses.step_upgraders.filter import (
 from mitosheet.saved_analyses.step_upgraders.graph import (
     upgrade_graph_1_to_2, upgrade_graph_2_to_3, upgrade_graph_3_to_4)
 from mitosheet.saved_analyses.step_upgraders.merge import (
-    upgrade_merge_1_to_merge_2, upgrade_merge_2_to_3, upgrade_merge_3_to_4)
+    upgrade_merge_1_to_merge_2, upgrade_merge_2_to_3, upgrade_merge_3_to_4, upgrade_merge_4_to_5)
 from mitosheet.saved_analyses.step_upgraders.pivot import (
     upgrade_group_1_to_pivot_2, upgrade_pivot_2_to_pivot_3,
     upgrade_pivot_3_to_4, upgrade_pivot_4_to_5_and_rename,
@@ -96,6 +96,7 @@ STEP_UPGRADES_FUNCTION_MAPPING_NEW_FORMAT = {
         1: upgrade_merge_1_to_merge_2,
         2: upgrade_merge_2_to_3,
         3: upgrade_merge_3_to_4,
+        4: upgrade_merge_4_to_5
     },
     'change_column_dtype': {
         1: upgrade_change_column_dtype_1_to_2,

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -113,6 +113,6 @@ class MergeStepPerformer(StepPerformer):
     @classmethod
     def get_modified_dataframe_indexes(cls, params: Dict[str, Any]) -> Set[int]:
         destination_sheet_index = get_param(params, 'destination_sheet_index')
-        if destination_sheet_index: # If editing an existing sheet, that is what is changed
+        if destination_sheet_index is not None: # If editing an existing sheet, that is what is changed
             return {destination_sheet_index}
         return {-1}

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -29,7 +29,7 @@ class MergeStepPerformer(StepPerformer):
 
     @classmethod
     def step_version(cls) -> int:
-        return 4
+        return 5
 
     @classmethod
     def step_type(cls) -> str:

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -154,7 +154,7 @@ class PivotStepPerformer(StepPerformer):
     @classmethod
     def get_modified_dataframe_indexes(cls, params: Dict[str, Any]) -> Set[int]:
         destination_sheet_index = get_param(params, 'destination_sheet_index')
-        if destination_sheet_index: # If editing an existing sheet, that is what is changed
+        if destination_sheet_index is not None: # If editing an existing sheet, that is what is changed
             return {destination_sheet_index}
         return {-1}
     

--- a/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
+++ b/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
@@ -174,7 +174,7 @@ UPGRADE_TESTS = [
             "public_interface_version": 1,
             "steps_data": [
                 {'params': {"move_to_deprecated_id_algorithm": True}, 'step_type': 'bulk_old_rename', 'step_version': 1}, 
-                {"step_version": 4, "step_type": "merge", 'params': {"how": 'lookup', "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("Name"), get_column_header_id("Name")]], "selected_column_ids_one": get_column_header_ids(["Name", "Number"]), "selected_column_ids_two": get_column_header_ids(["Name", "Sign"])}}, 
+                {"step_version": 5, "step_type": "merge", 'params': {"how": 'lookup', "destination_sheet_index": None, "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("Name"), get_column_header_id("Name")]], "selected_column_ids_one": get_column_header_ids(["Name", "Number"]), "selected_column_ids_two": get_column_header_ids(["Name", "Sign"])}}, 
                 {"step_version": 2, "step_type": "sort", 'params': {"sheet_index": 2, "column_id": get_column_header_id("Number"), "sort_direction": "descending"}}
             ],
             "args": [],
@@ -452,7 +452,7 @@ UPGRADE_TESTS = [
             "public_interface_version": 1,
             "steps_data": [
                 {"step_version": 2, "step_type": "rename_column", "params": {"sheet_index": 0, "column_id": get_column_header_id("old"), "new_column_header": "new"}}, 
-                {"step_version": 4, "step_type": "merge", 'params': {"how": 'lookup', "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("old"), get_column_header_id("new")]], "selected_column_ids_one": [get_column_header_id("old")], "selected_column_ids_two": [get_column_header_id("new")]}},
+                {"step_version": 5, "step_type": "merge", 'params': {"destination_sheet_index": None, "how": 'lookup', "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("old"), get_column_header_id("new")]], "selected_column_ids_one": [get_column_header_id("old")], "selected_column_ids_two": [get_column_header_id("new")]}},
                 {"step_version": 9, "step_type": "pivot", "params": {"flatten_column_headers": True, "public_interface_version": 1, "public_interface_version": 1, "use_deprecated_id_algorithm": True, 'sheet_index': 0, 'pivot_rows_column_ids_with_transforms': [{'column_id': get_column_header_id("old"), 'transformation': 'no-op'}], 'pivot_columns_column_ids_with_transforms': [{'column_id': get_column_header_id("old"), 'transformation': 'no-op'}], 'values_column_ids_map': {get_column_header_id('old'): ['sum']}, 'destination_sheet_index': 1, 'pivot_filters': []}}, BULK_OLD_RENAME_STEP,
                 {"step_version": 9, "step_type": "pivot", "params": {"flatten_column_headers": True, "public_interface_version": 1, "public_interface_version": 1, "use_deprecated_id_algorithm": True, 'sheet_index': 1, 'pivot_rows_column_ids_with_transforms': [{'column_id': get_column_header_id("new"), 'transformation': 'no-op'}], 'pivot_columns_column_ids_with_transforms': [{'column_id': get_column_header_id("new"), 'transformation': 'no-op'}], 'values_column_ids_map': {get_column_header_id('new'): ['sum']}, 'destination_sheet_index': 1, 'pivot_filters': []}}, BULK_OLD_RENAME_STEP,
                 {'step_version': 5, 'step_type': "set_column_formula", 'params': {'sheet_index': 0,'column_id': get_column_header_id('old'), "formula_label": 0, 'public_interface_version': 1, 'index_labels_formula_is_applied_to': {'type': FORMULA_ENTIRE_COLUMN_TYPE}, 'old_formula': '=A', 'new_formula': '=B'}},
@@ -522,7 +522,7 @@ UPGRADE_TESTS = [
             "steps_data": [
                 {"step_version": 2, "step_type": "rename_column", "params": {"sheet_index": 0, "column_id": get_column_header_id("old"), "new_column_header": "new"}}, 
                 {"step_version": 2, "step_type": "rename_column", "params": {"sheet_index": 0, "column_id": get_column_header_id("old"), "new_column_header": "newer"}}, 
-                {"step_version": 4, "step_type": "merge", 'params': {"how": 'lookup', "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("old"), get_column_header_id("newer")]], "selected_column_ids_one": [get_column_header_id("old")], "selected_column_ids_two": [get_column_header_id("newer")]}},
+                {"step_version": 5, "step_type": "merge", 'params': {"destination_sheet_index": None, "how": 'lookup', "sheet_index_one": 0, "sheet_index_two": 1, "merge_key_column_ids": [[get_column_header_id("old"), get_column_header_id("newer")]], "selected_column_ids_one": [get_column_header_id("old")], "selected_column_ids_two": [get_column_header_id("newer")]}},
                 {"step_version": 9, "step_type": "pivot", "params": {"flatten_column_headers": True, "public_interface_version": 1, "public_interface_version": 1, "use_deprecated_id_algorithm": True, 'sheet_index': 0, 'pivot_rows_column_ids_with_transforms': [{'column_id': get_column_header_id("old"), 'transformation': 'no-op'}], 'pivot_columns_column_ids_with_transforms': [{'column_id': get_column_header_id("old"), 'transformation': 'no-op'}], 'values_column_ids_map': {get_column_header_id('old'): ['sum']}, 'destination_sheet_index': 1, 'pivot_filters': []}}, BULK_OLD_RENAME_STEP,
                 {"step_version": 9, "step_type": "pivot", "params": {"flatten_column_headers": True, "public_interface_version": 1, "use_deprecated_id_algorithm": True, 'sheet_index': 1, 'pivot_rows_column_ids_with_transforms': [{'column_id': get_column_header_id("newer"), 'transformation': 'no-op'}], 'pivot_columns_column_ids_with_transforms': [{'column_id': get_column_header_id("newer"), 'transformation': 'no-op'}], 'values_column_ids_map': {get_column_header_id('newer'): ['sum']}, 'destination_sheet_index': 1, 'pivot_filters': []}}, BULK_OLD_RENAME_STEP,
                 {'step_version': 5, 'step_type': "set_column_formula", 'params': {'sheet_index': 0,'column_id': get_column_header_id('old'), "formula_label": 0, 'public_interface_version': 1, 'index_labels_formula_is_applied_to': {'type': FORMULA_ENTIRE_COLUMN_TYPE}, 'old_formula': '=A', 'new_formula': '=B'}},
@@ -600,6 +600,53 @@ UPGRADE_TESTS = [
             "public_interface_version": 1,
             "steps_data": [{"step_version": 2, "step_type": "simple_import", "params": {"file_names": ["tesla stock new.csv"]}}, {"step_version": 3, "step_type": "delete_column", "params": {"sheet_index": 0, "column_ids": ["Open New"]}}, {"step_version": 3, "step_type": "delete_column", "params": {"sheet_index": 0, "column_ids": ["Close"]}}, {"step_version": 2, "step_type": "set_dataframe_format", "params": {"sheet_index": 0, "df_format": {"conditional_formats": [], "columns": {}, "headers": {"color": "#FFFFFF", "backgroundColor": "#549D3A"}, "rows": {"even": {"color": "#494650", "backgroundColor": "#D0E3C9"}, "odd": {"color": "#494650"}}, "border": {}}}}],
             "args": [],
+            "code_options": {
+                'as_function': False,
+                'import_custom_python_code': False,
+                'call_function': True,
+                'function_name': 'function_ysis',
+                'function_params': {}
+            }
+        }
+    ),
+    # Upgrades the merge step performer
+    (
+        {
+            "version": "0.2.4", 
+            "steps_data": [
+                {
+                    "step_version": 4, 
+                    "step_type": "merge", 
+                    "params": {
+                        "how": "lookup",
+                        "sheet_index_one": 0,
+                        "merge_key_column_id_one": 'A',
+                        "selected_column_ids_one": ['B'],
+                        "sheet_index_two": 1,
+                        "merge_key_column_id_two": 'A',
+                        "selected_column_ids_two": ['B'],
+                    }
+                }
+            ]
+        },
+        {
+            "version": __version__, 
+            "steps_data": [{
+                "step_version": 5, 
+                "step_type": "merge", 
+                "params": {
+                    "how": "lookup",
+                    "destination_sheet_index": None,
+                    "sheet_index_one": 0,
+                    "merge_key_column_id_one": 'A',
+                    "selected_column_ids_one": ['B'],
+                    "sheet_index_two": 1,
+                    "merge_key_column_id_two": 'A',
+                    "selected_column_ids_two": ['B'],
+                }
+            }],
+            "args": [],
+            "public_interface_version": 1,
             "code_options": {
                 'as_function': False,
                 'import_custom_python_code': False,

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -332,6 +332,45 @@ def test_simple_merge_edit():
     pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A_df1': [2], 'B': [2], 'A_df2': [2]}))
     assert len(mito.dfs) == 3
 
+def test_merge_two_edits():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    mito.merge_sheets('outer', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A_df1': [2.0, None], 'B': [2, 1], 'A_df2': [2, 1]}))
+    assert len(mito.dfs) == 3
+
+def test_merge_edit_with_deletion():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    mito.delete_columns(2, ['A_df1'])
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'B': [2], 'A_df2': [2]}))
+    assert len(mito.dfs) == 3
+
+def test_merge_edit_with_deletion_overwrite():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.delete_columns(2, ['B_df1'])
+    mito.merge_sheets('inner', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A_df1': [2], 'B': [2], 'A_df2': [2]}))
+    assert len(mito.dfs) == 3
+
+def test_merge_edit_different_selected_columns():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A': [2], 'B': [2]}))
+    assert len(mito.dfs) == 3
+
 OTHER_MERGE_TESTS = [
     (
         'lookup',

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -404,6 +404,18 @@ def test_edit_merge_optimizes_after_delete_with_other_edit():
 
     assert mito.transpiled_code == ["from mitosheet.public.v3 import *", "", "df1.insert(2, 'Test', 0)", ""]
 
+def test_edit_merge_optimizes_after_delete_with_other_edit_after():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+    mito.delete_dataframe(2)
+    mito.add_column(0, 'Test')
+
+    assert mito.transpiled_code == ["from mitosheet.public.v3 import *", "", "df1.insert(2, 'Test', 0)", ""]
+
+
 OTHER_MERGE_TESTS = [
     (
         'lookup',

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -7,6 +7,8 @@
 Contains tests for merging events.
 """
 from cmath import exp
+from mitosheet.state import NUMBER_FORMAT_CURRENCY, NUMBER_FORMAT_PLAIN_TEXT
+from mitosheet.tests.step_performers.test_set_dataframe_format import SET_DATAFRAME_FORMAT_TESTS, get_dataframe_format
 import numpy as np
 import pytest
 import pandas as pd
@@ -350,6 +352,26 @@ def test_merge_edit_with_deletion():
     mito.merge_sheets('inner', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
     mito.delete_columns(2, ['A_df1'])
     pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'B': [2], 'A_df2': [2]}))
+    assert len(mito.dfs) == 3
+
+def test_merge_edit_with_format_filter_rename():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('outer', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    df_format = get_dataframe_format(
+        columns={'A': {'type': NUMBER_FORMAT_PLAIN_TEXT}},
+        headers={'color': '#FFFFFF', 'backgroundColor': '#549D3A'},
+        rowsOdd={'color': '#494650', 'backgroundColor': '#D0E3C9'}, 
+        rowsEven={'color': '#494650', 'backgroundColor': '#FFFFFF'},
+        border={'borderStyle': 'solid', 'borderColor': '#000000'}
+    )
+    mito.set_dataframe_format(2, df_format)
+    print(mito.dfs[2])
+    mito.filter(2, 'A', 'and', 'greater_than_or_equal', 1)
+    mito.rename_column(2, 'B_df1', 'B_df1_renamed')
+    mito.merge_sheets('outer', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A_df1': [2.0, None], 'B': [2, 1], 'A_df2': [2, 1]}))
     assert len(mito.dfs) == 3
 
 def test_merge_edit_with_deletion_overwrite():

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -381,6 +381,29 @@ def test_merge_edit_optimizes_on_delete():
 
     assert len(mito.transpiled_code) == 0
 
+
+def test_merge_edit_optimizes_after_delete_with_edit_to_merge():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.add_column(2, 'Test')
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+    mito.delete_dataframe(2)
+
+    assert len(mito.transpiled_code) == 0
+
+def test_edit_merge_optimizes_after_delete_with_other_edit():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.add_column(0, 'Test')
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+    mito.delete_dataframe(2)
+
+    assert mito.transpiled_code == ["from mitosheet.public.v3 import *", "", "df1.insert(2, 'Test', 0)", ""]
+
 OTHER_MERGE_TESTS = [
     (
         'lookup',

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -371,6 +371,16 @@ def test_merge_edit_different_selected_columns():
     pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A': [2], 'B': [2]}))
     assert len(mito.dfs) == 3
 
+def test_merge_edit_optimizes_on_delete():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+    mito.delete_dataframe(2)
+
+    assert len(mito.transpiled_code) == 0
+
 OTHER_MERGE_TESTS = [
     (
         'lookup',

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -382,6 +382,20 @@ def test_merge_edit_optimizes_on_delete():
     assert len(mito.transpiled_code) == 0
 
 
+def test_merge_edit_optimizes_with_edit_to_merge():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.add_column(2, 'Test')
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
+
+    assert mito.transpiled_code == [
+        'from mitosheet.public.v3 import *', '', 
+        "df2_tmp = df2.drop(['B'], axis=1)", 
+        "df_merge = df1.merge(df2_tmp, left_on=['A'], right_on=['A'], how='inner', suffixes=['_df1', '_df2'])", ''
+    ]
+
 def test_merge_edit_optimizes_after_delete_with_edit_to_merge():
     df1 = pd.DataFrame({'A': [2], 'B': [2]})
     df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -323,6 +323,15 @@ def test_merge_unique(input_dfs, how, sheet_index_one, sheet_index_two, merge_ke
         assert actual.equals(expected)
 
 
+def test_simple_merge_edit():
+    df1 = pd.DataFrame({'A': [2], 'B': [2]})
+    df2 = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'])
+    mito.merge_sheets('inner', 0, 1, [['B', 'B']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    pd.testing.assert_frame_equal(mito.dfs[2], pd.DataFrame({'A_df1': [2], 'B': [2], 'A_df2': [2]}))
+    assert len(mito.dfs) == 3
+
 OTHER_MERGE_TESTS = [
     (
         'lookup',

--- a/mitosheet/mitosheet/tests/test_step_format.py
+++ b/mitosheet/mitosheet/tests/test_step_format.py
@@ -121,7 +121,7 @@ def test_params_static():
 
     check_step(
         MergeStepPerformer,
-        4,
+        5,
         'merge'
     )
 

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -254,7 +254,8 @@ class MitoWidgetTestWrapper:
             sheet_index_two: int, 
             merge_key_columns: List[Tuple[ColumnHeader, ColumnHeader]], 
             selected_columns_one: List[ColumnHeader],
-            selected_columns_two: List[ColumnHeader]
+            selected_columns_two: List[ColumnHeader],
+            destination_sheet_index: Optional[int]=None,
         ) -> bool:
 
         merge_key_column_ids = list(map(lambda x: [
@@ -283,7 +284,8 @@ class MitoWidgetTestWrapper:
                     'sheet_index_two': sheet_index_two,
                     'merge_key_column_ids': merge_key_column_ids,
                     'selected_column_ids_one': selected_column_ids_one,
-                    'selected_column_ids_two': selected_column_ids_two
+                    'selected_column_ids_two': selected_column_ids_two,
+                    'destination_sheet_index': destination_sheet_index
                 }
             }
         )


### PR DESCRIPTION
Adds an optional param `destination_sheet_index` to the merge step performer / merge code chunk to enable editing existing merges. 

### Testing
Adds a test for the basic usage of the edit. 