### PR TITLE
Jan 5 dogfood

### DIFF
--- a/mitosheet/css/elements/MultiToggleBox.css
+++ b/mitosheet/css/elements/MultiToggleBox.css
@@ -25,6 +25,7 @@
     padding: 5px;
     align-items: center;
     margin: 5px 0;
+    width: fit-content;
 }
 
 .expandable-caution-text-container {

--- a/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
+++ b/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
@@ -3,24 +3,19 @@ import CautionIcon from "../icons/CautionIcon";
 import XIcon from "../icons/XIcon";
 import TriangleExpandCollapseIcon from "../icons/TriangleExpandCollapseIcon";
 
-export interface WarningState {
-    warningStrings: string[],
-    dismissed: boolean,
-    dismiss: () => void
-}
-
-const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element => {
+const ExpandableWarning = (props: {warnings?: string[]}): JSX.Element => {
     const [isExpanded, setIsExpanded] = React.useState(false);
+    const [dismissed, setDismissed] = React.useState(false);
 
-    if (props.warningState === undefined || props.warningState.warningStrings.length === 0 || props.warningState.dismissed) {
+    if (props.warnings === undefined || props.warnings.length === 0 || dismissed) {
         return <></>;
-    } else if (props.warningState.warningStrings.length === 1) {
+    } else if (props.warnings.length === 1) {
         return (
             <div className='caution-text-container'>
                 <CautionIcon width={'25px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
-                <p className='caution-text'>{props.warningState.warningStrings[0]}</p>
+                <p className='caution-text'>{props.warnings[0]}</p>
                 <XIcon
-                    onClick={props.warningState.dismiss}
+                    onClick={() => setDismissed(true)}
                     strokeColor="var(--mito-status-warning-dark)"
                     rounded
                     width="12px"
@@ -49,10 +44,10 @@ const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element =>
                         <TriangleExpandCollapseIcon
                             action={isExpanded ? 'collapse' : 'expand'}
                         />
-                        {`${props.warningState.warningStrings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
+                        {`${props.warnings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
                     </p>
                     <XIcon
-                        onClick={props.warningState.dismiss}
+                        onClick={() => setDismissed(true)}
                         strokeColor="var(--mito-status-warning-dark)"
                         rounded
                         width="23px"
@@ -62,7 +57,7 @@ const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element =>
                 {
                     isExpanded &&
                     (<ul style={{margin: '4px 0'}}>
-                        {props.warningState.warningStrings.map((warning, index) => {
+                        {props.warnings.map((warning, index) => {
                             return (
                                 <li className='caution-text' key={index}>
                                     {warning}

--- a/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
+++ b/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
@@ -3,19 +3,24 @@ import CautionIcon from "../icons/CautionIcon";
 import XIcon from "../icons/XIcon";
 import TriangleExpandCollapseIcon from "../icons/TriangleExpandCollapseIcon";
 
-const ExpandableWarning = (props: {warnings?: string[]}): JSX.Element => {
-    const [isExpanded, setIsExpanded] = React.useState(false);
-    const [dismissed, setDismissed] = React.useState(false);
+export interface WarningState {
+    warningStrings: string[],
+    dismissed: boolean,
+    dismiss: () => void
+}
 
-    if (props.warnings === undefined || props.warnings.length === 0 || dismissed) {
+const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element => {
+    const [isExpanded, setIsExpanded] = React.useState(false);
+
+    if (props.warningState === undefined || props.warningState.warningStrings.length === 0 || props.warningState.dismissed) {
         return <></>;
-    } else if (props.warnings.length === 1) {
+    } else if (props.warningState.warningStrings.length === 1) {
         return (
             <div className='caution-text-container'>
                 <CautionIcon width={'25px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
-                <p className='caution-text'>{props.warnings[0]}</p>
+                <p className='caution-text'>{props.warningState.warningStrings[0]}</p>
                 <XIcon
-                    onClick={() => setDismissed(true)}
+                    onClick={props.warningState.dismiss}
                     strokeColor="var(--mito-status-warning-dark)"
                     rounded
                     width="12px"
@@ -44,10 +49,10 @@ const ExpandableWarning = (props: {warnings?: string[]}): JSX.Element => {
                         <TriangleExpandCollapseIcon
                             action={isExpanded ? 'collapse' : 'expand'}
                         />
-                        {`${props.warnings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
+                        {`${props.warningState.warningStrings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
                     </p>
                     <XIcon
-                        onClick={() => setDismissed(true)}
+                        onClick={props.warningState.dismiss}
                         strokeColor="var(--mito-status-warning-dark)"
                         rounded
                         width="23px"
@@ -57,7 +62,7 @@ const ExpandableWarning = (props: {warnings?: string[]}): JSX.Element => {
                 {
                     isExpanded &&
                     (<ul style={{margin: '4px 0'}}>
-                        {props.warnings.map((warning, index) => {
+                        {props.warningState.warningStrings.map((warning, index) => {
                             return (
                                 <li className='caution-text' key={index}>
                                     {warning}

--- a/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
+++ b/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
@@ -12,8 +12,6 @@ export interface WarningState {
 const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element => {
     const [isExpanded, setIsExpanded] = React.useState(false);
 
-    console.log(props.warningState);
-    
     if (props.warningState === undefined || props.warningState.warningStrings.length === 0 || props.warningState.dismissed) {
         return <></>;
     } else if (props.warningState.warningStrings.length === 1) {

--- a/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
+++ b/mitosheet/src/mito/components/elements/ExpandableWarning.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import CautionIcon from "../icons/CautionIcon";
+import XIcon from "../icons/XIcon";
+import TriangleExpandCollapseIcon from "../icons/TriangleExpandCollapseIcon";
+
+export interface WarningState {
+    warningStrings: string[],
+    dismissed: boolean,
+    dismiss: () => void
+};
+
+const ExpandableWarning = (props: {warningState?: WarningState}): JSX.Element => {
+    const [isExpanded, setIsExpanded] = React.useState(false);
+
+    console.log(props.warningState);
+    
+    if (props.warningState === undefined || props.warningState.warningStrings.length === 0 || props.warningState.dismissed) {
+        return <></>;
+    } else if (props.warningState.warningStrings.length === 1) {
+        return (
+            <div className='caution-text-container'>
+                <CautionIcon width={'25px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
+                <p className='caution-text'>{props.warningState.warningStrings[0]}</p>
+                <XIcon
+                    onClick={props.warningState.dismiss}
+                    strokeColor="var(--mito-status-warning-dark)"
+                    rounded
+                    width="12px"
+                    style={{ cursor: 'pointer' }}
+                />
+            </div> 
+        )
+    } else {
+        return (
+            <div
+                className="caution-text-container expandable-caution-text-container"
+                style={{
+                    background: 'var(--mito-status-warning)',
+                    border: '1px solid var(--mito-status-warning-dark)'
+                }}
+                onClick={(e) => {
+                    setIsExpanded(!isExpanded);
+                    e.stopPropagation();
+                }}
+            >
+                <div
+                    style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between'}}
+                >
+                    <CautionIcon width={'54px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
+                    <p className='caution-text'>
+                        <TriangleExpandCollapseIcon
+                            action={isExpanded ? 'collapse' : 'expand'}
+                        />
+                        {`${props.warningState.warningStrings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
+                    </p>
+                    <XIcon
+                        onClick={props.warningState.dismiss}
+                        strokeColor="var(--mito-status-warning-dark)"
+                        rounded
+                        width="23px"
+                        style={{ cursor: 'pointer' }}
+                        />
+                </div>
+                {
+                    isExpanded &&
+                    (<ul style={{margin: '4px 0'}}>
+                        {props.warningState.warningStrings.map((warning, index) => {
+                            return (
+                                <li className='caution-text' key={index}>
+                                    {warning}
+                                </li>
+                            )
+                        })}
+                    </ul>)
+                }
+            </div>
+        )
+    }
+}
+
+export default ExpandableWarning;

--- a/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
+++ b/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
@@ -4,7 +4,7 @@ import { ColumnHeader, ColumnID, SheetData } from '../../types';
 import { toggleInArray } from '../../utils/arrays';
 import { getDisplayColumnHeader } from '../../utils/columnHeaders';
 import { getDtypeValue } from '../taskpanes/ControlPanel/FilterAndSortTab/DtypeCard';
-import ExpandableWarning from './ExpandableWarning';
+import ExpandableWarning, { WarningState } from './ExpandableWarning';
 import MultiToggleBox from './MultiToggleBox';
 import MultiToggleItem from './MultiToggleItem';
 import { Height } from './sizes.d';
@@ -17,7 +17,7 @@ interface MultiToggleColumnsProps {
     disabledColumnIDs?: ColumnID[],
     getIsDisabledColumnID?: (columnID: ColumnID, columnHeader: ColumnHeader, columnDtype: string) => boolean;
     getDisplayColumnHeaderOverride?: (columnID: ColumnID, columnHeader: ColumnHeader) => string;
-    warnings?: string[];
+    warningState?: WarningState;
 }
 
 /**
@@ -32,7 +32,11 @@ const MultiToggleColumns = (props: MultiToggleColumnsProps): JSX.Element => {
 
     return (
         <div>
-            <ExpandableWarning warnings={props.warnings} />
+            {
+                <ExpandableWarning
+                    warningState={props.warningState}
+                />
+            }
             <MultiToggleBox
                 searchable
                 onToggleAll={(newSelectedIndexes) => {

--- a/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
+++ b/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
@@ -4,11 +4,10 @@ import { ColumnHeader, ColumnID, SheetData } from '../../types';
 import { toggleInArray } from '../../utils/arrays';
 import { getDisplayColumnHeader } from '../../utils/columnHeaders';
 import { getDtypeValue } from '../taskpanes/ControlPanel/FilterAndSortTab/DtypeCard';
+import ExpandableWarning, { WarningState } from './ExpandableWarning';
 import MultiToggleBox from './MultiToggleBox';
 import MultiToggleItem from './MultiToggleItem';
 import { Height } from './sizes.d';
-import CautionIcon from '../icons/CautionIcon';
-import XIcon from '../icons/XIcon';
 
 interface MultiToggleColumnsProps {
     sheetData: SheetData | undefined;
@@ -18,7 +17,7 @@ interface MultiToggleColumnsProps {
     disabledColumnIDs?: ColumnID[],
     getIsDisabledColumnID?: (columnID: ColumnID, columnHeader: ColumnHeader, columnDtype: string) => boolean;
     getDisplayColumnHeaderOverride?: (columnID: ColumnID, columnHeader: ColumnHeader) => string;
-    warning?: string;
+    warningState?: WarningState;
 }
 
 /**
@@ -28,24 +27,15 @@ interface MultiToggleColumnsProps {
 const MultiToggleColumns = (props: MultiToggleColumnsProps): JSX.Element => {
 
     const columnIDsMap = props.sheetData?.columnIDsMap || {};
-    const [dismissedWarning, setDismissedWarning] = React.useState(false);
     const columnIDsAndDtype: [ColumnID, string][] = Object.entries(props.sheetData?.columnDtypeMap || {});
     const columnIDs: ColumnID[] = columnIDsAndDtype.map(([cid, ]) => {return cid});
 
     return (
         <div>
-            {(props.warning !== undefined && !dismissedWarning) &&
-                <div className='caution-text-container'>
-                    <CautionIcon width={'25px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
-                    <p className='caution-text'>{props.warning}</p>
-                    <XIcon
-                        onClick={() => setDismissedWarning(true)}
-                        strokeColor="var(--mito-status-warning-dark)"
-                        rounded
-                        width='12px'
-                        style={{ cursor: 'pointer' }}
-                    />
-                </div> 
+            {
+                <ExpandableWarning
+                    warningState={props.warningState}
+                />
             }
             <MultiToggleBox
                 searchable

--- a/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
+++ b/mitosheet/src/mito/components/elements/MultiToggleColumns.tsx
@@ -4,7 +4,7 @@ import { ColumnHeader, ColumnID, SheetData } from '../../types';
 import { toggleInArray } from '../../utils/arrays';
 import { getDisplayColumnHeader } from '../../utils/columnHeaders';
 import { getDtypeValue } from '../taskpanes/ControlPanel/FilterAndSortTab/DtypeCard';
-import ExpandableWarning, { WarningState } from './ExpandableWarning';
+import ExpandableWarning from './ExpandableWarning';
 import MultiToggleBox from './MultiToggleBox';
 import MultiToggleItem from './MultiToggleItem';
 import { Height } from './sizes.d';
@@ -17,7 +17,7 @@ interface MultiToggleColumnsProps {
     disabledColumnIDs?: ColumnID[],
     getIsDisabledColumnID?: (columnID: ColumnID, columnHeader: ColumnHeader, columnDtype: string) => boolean;
     getDisplayColumnHeaderOverride?: (columnID: ColumnID, columnHeader: ColumnHeader) => string;
-    warningState?: WarningState;
+    warnings?: string[];
 }
 
 /**
@@ -32,11 +32,7 @@ const MultiToggleColumns = (props: MultiToggleColumnsProps): JSX.Element => {
 
     return (
         <div>
-            {
-                <ExpandableWarning
-                    warningState={props.warningState}
-                />
-            }
+            <ExpandableWarning warnings={props.warnings} />
             <MultiToggleBox
                 searchable
                 onToggleAll={(newSelectedIndexes) => {

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
@@ -10,7 +10,7 @@ import Row from "../../layout/Row";
 import Spacer from "../../layout/Spacer";
 import { MergeParams } from "../../../types";
 import { getFirstSuggestedMergeKeys } from "./mergeUtils";
-import ExpandableWarning from "../../elements/ExpandableWarning";
+import ExpandableWarning, { WarningState } from "../../elements/ExpandableWarning";
 
 
 const MergeKeysSelectionSection = (props: {
@@ -18,7 +18,7 @@ const MergeKeysSelectionSection = (props: {
     setParams: React.Dispatch<React.SetStateAction<MergeParams>>,
     sheetDataArray: SheetData[],
     error: string | undefined;
-    warnings?: string[];
+    warningState: WarningState | undefined;
 }): JSX.Element => {
 
     const sheetDataOne = props.sheetDataArray[props.params.sheet_index_one];
@@ -115,7 +115,9 @@ const MergeKeysSelectionSection = (props: {
                 </p>    
             }
             {
-                <ExpandableWarning warnings={props.warnings} />
+                <ExpandableWarning
+                    warningState={props.warningState}
+                />
             }
             <Spacer px={15}/>
             <TextButton 

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
@@ -10,82 +10,15 @@ import Row from "../../layout/Row";
 import Spacer from "../../layout/Spacer";
 import { MergeParams } from "../../../types";
 import { getFirstSuggestedMergeKeys } from "./mergeUtils";
-import CautionIcon from "../../icons/CautionIcon";
-import TriangleExpandCollapseIcon from "../../icons/TriangleExpandCollapseIcon";
+import ExpandableWarning, { WarningState } from "../../elements/ExpandableWarning";
 
-const ExpandableWarning = (props: {warnings?: string[]}): JSX.Element => {
-    const [isExpanded, setIsExpanded] = React.useState(false);
-    const [dismissed, setDismissed] = React.useState(false);
-    if (props.warnings === undefined || props.warnings.length === 0 || dismissed) {
-        return <></>;
-    } else if (props.warnings.length === 1) {
-        return (
-            <div className='caution-text-container'>
-                <CautionIcon width={'25px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
-                <p className='caution-text'>{props.warnings[0]}</p>
-                <XIcon
-                    onClick={() => setDismissed(true)}
-                    strokeColor="var(--mito-status-warning-dark)"
-                    rounded
-                    width="12px"
-                    style={{ cursor: 'pointer' }}
-                />
-            </div> 
-        )
-    } else {
-        return (
-            <div
-                className="caution-text-container expandable-caution-text-container"
-                style={{
-                    background: 'var(--mito-status-warning)',
-                    border: '1px solid var(--mito-status-warning-dark)'
-                }}
-                onClick={(e) => {
-                    setIsExpanded(!isExpanded);
-                    e.stopPropagation();
-                }}
-            >
-                <div
-                    style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between'}}
-                >
-                    <CautionIcon width={'54px'} height={'30px'} color='var(--mito-status-warning-dark)'/>
-                    <p className='caution-text'>
-                        <TriangleExpandCollapseIcon
-                            action={isExpanded ? 'collapse' : 'expand'}
-                        />
-                        {`${props.warnings.length} merge key pairings were removed because at least one of the merge keys was missing from the source tabs.`}
-                    </p>
-                    <XIcon
-                        onClick={() => setDismissed(true)}
-                        strokeColor="var(--mito-status-warning-dark)"
-                        rounded
-                        width="23px"
-                        style={{ cursor: 'pointer' }}
-                        />
-                </div>
-                {
-                    isExpanded &&
-                    (<ul style={{margin: '4px 0'}}>
-                        {props.warnings.map((warning, index) => {
-                            return (
-                                <li className='caution-text' key={index}>
-                                    {warning}
-                                </li>
-                            )
-                        })}
-                    </ul>)
-                }
-            </div>
-        )
-    }
-}
 
 const MergeKeysSelectionSection = (props: {
     params: MergeParams,
     setParams: React.Dispatch<React.SetStateAction<MergeParams>>,
     sheetDataArray: SheetData[],
     error: string | undefined;
-    warnings: string[] | undefined;
+    warningState: WarningState | undefined;
 }): JSX.Element => {
 
     const sheetDataOne = props.sheetDataArray[props.params.sheet_index_one];
@@ -183,7 +116,7 @@ const MergeKeysSelectionSection = (props: {
             }
             {
                 <ExpandableWarning
-                    warnings={props.warnings}
+                    warningState={props.warningState}
                 />
             }
             <Spacer px={15}/>

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeKeysSelection.tsx
@@ -10,7 +10,7 @@ import Row from "../../layout/Row";
 import Spacer from "../../layout/Spacer";
 import { MergeParams } from "../../../types";
 import { getFirstSuggestedMergeKeys } from "./mergeUtils";
-import ExpandableWarning, { WarningState } from "../../elements/ExpandableWarning";
+import ExpandableWarning from "../../elements/ExpandableWarning";
 
 
 const MergeKeysSelectionSection = (props: {
@@ -18,7 +18,7 @@ const MergeKeysSelectionSection = (props: {
     setParams: React.Dispatch<React.SetStateAction<MergeParams>>,
     sheetDataArray: SheetData[],
     error: string | undefined;
-    warningState: WarningState | undefined;
+    warnings?: string[];
 }): JSX.Element => {
 
     const sheetDataOne = props.sheetDataArray[props.params.sheet_index_one];
@@ -115,9 +115,7 @@ const MergeKeysSelectionSection = (props: {
                 </p>    
             }
             {
-                <ExpandableWarning
-                    warningState={props.warningState}
-                />
+                <ExpandableWarning warnings={props.warnings} />
             }
             <Spacer px={15}/>
             <TextButton 

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
@@ -197,6 +197,13 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
         }
     )
 
+    // We use this to track whether the user has dismissed the warnings
+    // And we track it here, as opposed to in the child components, because
+    // there are some strange re-rendering issues that happen when we try to
+    // track it in the child components. We just need the whole merge taskpane
+    // to re-render when the user dismisses the warnings, so we track it here.
+    const [dismissedWarnings, setDismissedWarnings] = React.useState<[boolean, boolean, boolean]>([false, false, false]);
+
     /*
         If the merge params are undefined, then display this error message.
     */
@@ -282,7 +289,15 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                     setParams={setParams}
                     sheetDataArray={props.sheetDataArray}
                     error={error}
-                    warnings={editMergeWarnings?.mergeKeyWarnings}
+                    warningState={editMergeWarnings?.mergeKeyWarnings !== undefined ? {
+                        warningStrings: editMergeWarnings?.mergeKeyWarnings,
+                        dismissed: dismissedWarnings[0],
+                        dismiss: () => {
+                            setDismissedWarnings(oldDismissedWarnings => {
+                                return [true, oldDismissedWarnings[1], oldDismissedWarnings[2]]
+                            })
+                        }
+                    }: undefined}
                 />
                 <Spacer px={20}/>
                 <p className='text-header-3'>
@@ -301,7 +316,15 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                 }
                             })
                         }}
-                        warning={editMergeWarnings?.selectedColumnsOneWarnings}
+                        warningState={{
+                            warningStrings: editMergeWarnings?.selectedColumnsOneWarnings !== undefined ? [editMergeWarnings?.selectedColumnsOneWarnings] : [],
+                            dismissed: dismissedWarnings[1],
+                            dismiss: () => {
+                                setDismissedWarnings(oldDismissedWarnings => {
+                                    return [oldDismissedWarnings[0], true, oldDismissedWarnings[2]]
+                                })
+                            }
+                        }}
                     />
                 }
                 {params.how === MergeType.UNIQUE_IN_RIGHT &&
@@ -327,7 +350,16 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                     }
                                 })
                             }}
-                            warning={editMergeWarnings?.selectedColumnsTwoWarnings}
+                            warningState={{
+                                warningStrings: editMergeWarnings?.selectedColumnsTwoWarnings !== undefined ? [editMergeWarnings?.selectedColumnsTwoWarnings] : [],
+                                dismissed: dismissedWarnings[2],
+                                dismiss: () => {
+                                    setDismissedWarnings(oldDismissedWarnings => {
+                                        return [oldDismissedWarnings[0], oldDismissedWarnings[1], true]
+                                    })
+                                }
+                            
+                            }}
                         />
                     }
                     {params.how === MergeType.UNIQUE_IN_LEFT &&

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
@@ -197,13 +197,6 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
         }
     )
 
-    // We use this to track whether the user has dismissed the warnings
-    // And we track it here, as opposed to in the child components, because
-    // there are some strange re-rendering issues that happen when we try to
-    // track it in the child components. We just need the whole merge taskpane
-    // to re-render when the user dismisses the warnings, so we track it here.
-    const [dismissedWarnings, setDismissedWarnings] = React.useState<[boolean, boolean, boolean]>([false, false, false]);
-
     /*
         If the merge params are undefined, then display this error message.
     */
@@ -289,15 +282,7 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                     setParams={setParams}
                     sheetDataArray={props.sheetDataArray}
                     error={error}
-                    warningState={editMergeWarnings?.mergeKeyWarnings !== undefined ? {
-                        warningStrings: editMergeWarnings?.mergeKeyWarnings,
-                        dismissed: dismissedWarnings[0],
-                        dismiss: () => {
-                            setDismissedWarnings(oldDismissedWarnings => {
-                                return [true, oldDismissedWarnings[1], oldDismissedWarnings[2]]
-                            })
-                        }
-                    }: undefined}
+                    warnings={editMergeWarnings?.mergeKeyWarnings}
                 />
                 <Spacer px={20}/>
                 <p className='text-header-3'>
@@ -316,15 +301,7 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                 }
                             })
                         }}
-                        warningState={{
-                            warningStrings: editMergeWarnings?.selectedColumnsOneWarnings !== undefined ? [editMergeWarnings?.selectedColumnsOneWarnings] : [],
-                            dismissed: dismissedWarnings[1],
-                            dismiss: () => {
-                                setDismissedWarnings(oldDismissedWarnings => {
-                                    return [oldDismissedWarnings[0], true, oldDismissedWarnings[2]]
-                                })
-                            }
-                        }}
+                        warnings={editMergeWarnings?.selectedColumnsOneWarnings !== undefined ? [editMergeWarnings?.selectedColumnsOneWarnings] : []}
                     />
                 }
                 {params.how === MergeType.UNIQUE_IN_RIGHT &&
@@ -350,16 +327,7 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                     }
                                 })
                             }}
-                            warningState={{
-                                warningStrings: editMergeWarnings?.selectedColumnsTwoWarnings !== undefined ? [editMergeWarnings?.selectedColumnsTwoWarnings] : [],
-                                dismissed: dismissedWarnings[2],
-                                dismiss: () => {
-                                    setDismissedWarnings(oldDismissedWarnings => {
-                                        return [oldDismissedWarnings[0], oldDismissedWarnings[1], true]
-                                    })
-                                }
-                            
-                            }}
+                            warnings={editMergeWarnings?.selectedColumnsTwoWarnings !== undefined ? [editMergeWarnings?.selectedColumnsTwoWarnings] : []}
                         />
                     }
                     {params.how === MergeType.UNIQUE_IN_LEFT &&

--- a/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Merge/MergeTaskpane.tsx
@@ -197,6 +197,13 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
         }
     )
 
+    // We use this to track whether the user has dismissed the warnings
+    // And we track it here, as opposed to in the child components, because
+    // there are some strange re-rendering issues that happen when we try to
+    // track it in the child components. We just need the whole merge taskpane
+    // to re-render when the user dismisses the warnings, so we track it here.
+    const [dismissedWarnings, setDismissedWarnings] = React.useState<[boolean, boolean, boolean]>([false, false, false]);
+
     /*
         If the merge params are undefined, then display this error message.
     */
@@ -282,7 +289,15 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                     setParams={setParams}
                     sheetDataArray={props.sheetDataArray}
                     error={error}
-                    warnings={editMergeWarnings?.mergeKeyWarnings}
+                    warningState={editMergeWarnings?.mergeKeyWarnings !== undefined ? {
+                        warningStrings: editMergeWarnings?.mergeKeyWarnings,
+                        dismissed: dismissedWarnings[0],
+                        dismiss: () => {
+                            setDismissedWarnings(oldDismissedWarnings => {
+                                return [true, oldDismissedWarnings[1], oldDismissedWarnings[2]]
+                            })
+                        }
+                    }: undefined}
                 />
                 <Spacer px={20}/>
                 <p className='text-header-3'>
@@ -301,7 +316,15 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                 }
                             })
                         }}
-                        warnings={editMergeWarnings?.selectedColumnsOneWarnings !== undefined ? [editMergeWarnings?.selectedColumnsOneWarnings] : []}
+                        warningState={{
+                            warningStrings: editMergeWarnings?.selectedColumnsOneWarnings !== undefined ? [editMergeWarnings?.selectedColumnsOneWarnings] : [],
+                            dismissed: dismissedWarnings[1],
+                            dismiss: () => {
+                                setDismissedWarnings(oldDismissedWarnings => {
+                                    return [oldDismissedWarnings[0], true, oldDismissedWarnings[2]]
+                                })
+                            }
+                        }}
                     />
                 }
                 {params.how === MergeType.UNIQUE_IN_RIGHT &&
@@ -327,7 +350,16 @@ const MergeTaskpane = (props: MergeTaskpaneProps): JSX.Element => {
                                     }
                                 })
                             }}
-                            warnings={editMergeWarnings?.selectedColumnsTwoWarnings !== undefined ? [editMergeWarnings?.selectedColumnsTwoWarnings] : []}
+                            warningState={{
+                                warningStrings: editMergeWarnings?.selectedColumnsTwoWarnings !== undefined ? [editMergeWarnings?.selectedColumnsTwoWarnings] : [],
+                                dismissed: dismissedWarnings[2],
+                                dismiss: () => {
+                                    setDismissedWarnings(oldDismissedWarnings => {
+                                        return [oldDismissedWarnings[0], oldDismissedWarnings[1], true]
+                                    })
+                                }
+                            
+                            }}
                         />
                     }
                     {params.how === MergeType.UNIQUE_IN_LEFT &&

--- a/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/ToolbarButton.tsx
@@ -62,7 +62,10 @@ const ToolbarButton = (
     const hasDropdown = props.children !== undefined;
     const orientation = props.orientation ?? 'vertical';
     let tooltip = disabledTooltip ?? props.action.tooltip ?? props.action.titleToolbar;
-    tooltip += ` (${getKeyboardShortcutString(props.action.staticType as ActionEnum)})` ?? '';
+    const keyboardShortcut = getKeyboardShortcutString(props.action.staticType as ActionEnum);
+    if (keyboardShortcut !== undefined) {
+        tooltip += ` (${keyboardShortcut})`;
+    }
     
     return (
         <div 


### PR DESCRIPTION
# Description

- We were previously showing "(undefined)" after tooltips for toolbar buttons, if there were no keyboard shortcuts
- Fixes bug where dismissing errors in merge didn't rerender merge taskpane properly (see video below)

https://github.com/mito-ds/mito/assets/21002431/6d972c52-4bd7-4a50-8578-00a5428e5a22


# Testing

Check toolbar buttons. Check merge errors (all of them)

# Documentation

No.