### PR TITLE
Mitosheet: replay edits on merge

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
@@ -86,7 +86,8 @@ class DataframeRenameCodeChunk(CodeChunk):
             merge_code_chunk.merge_key_column_ids,
             merge_code_chunk.selected_column_ids_one,
             merge_code_chunk.selected_column_ids_two,
-            self.new_dataframe_name
+            self.new_dataframe_name,
+            merge_code_chunk.optional_code_that_successfully_executed
         )
 
     def _combine_left_with_import_code_chunk(

--- a/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
@@ -32,7 +32,8 @@ class MergeCodeChunk(CodeChunk):
         merge_key_column_ids: List[List[ColumnID]], 
         selected_column_ids_one: List[ColumnID], 
         selected_column_ids_two: List[ColumnID], 
-        new_df_name: str
+        new_df_name: str,
+        optional_code_that_successfully_executed: Optional[Tuple[List[str], List[str]]] = None
     ):
         super().__init__(prev_state)
         self.how: str = how 
@@ -42,6 +43,9 @@ class MergeCodeChunk(CodeChunk):
         self.merge_key_column_ids: List[List[ColumnID]] = merge_key_column_ids 
         self.selected_column_ids_one: List[ColumnID] = selected_column_ids_one 
         self.selected_column_ids_two: List[ColumnID] = selected_column_ids_two
+
+        if optional_code_that_successfully_executed is not None:
+            self.optional_code_that_successfully_executed = optional_code_that_successfully_executed
 
         self.df_one_name = self.prev_state.df_names[self.sheet_index_one]
         self.df_two_name = self.prev_state.df_names[self.sheet_index_two]
@@ -72,7 +76,8 @@ class MergeCodeChunk(CodeChunk):
                 merge_code_chunk.merge_key_column_ids, 
                 merge_code_chunk.selected_column_ids_one, 
                 merge_code_chunk.selected_column_ids_two, 
-                merge_code_chunk.new_df_name
+                merge_code_chunk.new_df_name,
+                merge_code_chunk.optional_code_that_successfully_executed
             )
 
         # If one of the merges if creating the code chunk that the new one is overwriting, then we can optimize
@@ -88,7 +93,8 @@ class MergeCodeChunk(CodeChunk):
                 merge_code_chunk.merge_key_column_ids, 
                 merge_code_chunk.selected_column_ids_one, 
                 merge_code_chunk.selected_column_ids_two, 
-                merge_code_chunk.new_df_name
+                merge_code_chunk.new_df_name,
+                merge_code_chunk.optional_code_that_successfully_executed
             )
 
         return None
@@ -117,7 +123,8 @@ class MergeCodeChunk(CodeChunk):
                 self.merge_key_column_ids, 
                 self.selected_column_ids_one, 
                 self.selected_column_ids_two, 
-                self.new_df_name
+                self.new_df_name,
+                self.optional_code_that_successfully_executed
             )
 
         return None

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -69,7 +69,7 @@ class MergeStepPerformer(StepPerformer):
                     'new_df_names': [new_df_name],
                     'overwrite': {
                         'sheet_index_to_overwrite': destination_sheet_index,
-                        'attempt_to_save_filter_metadata': False
+                        'attempt_to_save_filter_metadata': True
                     } if destination_sheet_index is not None else destination_sheet_index
                 },
                 optional_code=params.get('optional_code')

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -11,9 +11,10 @@ from mitosheet.code_chunks.step_performers.merge_code_chunk import \
     MergeCodeChunk
 from mitosheet.errors import make_incompatible_merge_key_error
 from mitosheet.state import DATAFRAME_SOURCE_MERGED, State
+from mitosheet.step_performers.pivot import get_optional_code_to_replay_on_dataframe_creation
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.step_performers.utils.utils import get_param
-from mitosheet.types import ColumnID
+from mitosheet.types import ColumnID, StepType
 from mitosheet.utils import get_first_unused_dataframe_name
 
 LOOKUP = 'lookup'
@@ -32,6 +33,16 @@ class MergeStepPerformer(StepPerformer):
     @classmethod
     def step_type(cls) -> str:
         return 'merge'
+    
+    @classmethod
+    def saturate(cls, prev_state: State, params: Dict[str, Any], previous_steps: List[StepType]) -> Dict[str, Any]:
+
+        # Replay the edits on top of the merged dataframe
+        optional_code, optional_code_chunk_names = get_optional_code_to_replay_on_dataframe_creation(previous_steps, params)
+        params['optional_code'] = optional_code
+        params['optional_code_chunk_names'] = optional_code_chunk_names
+
+        return params
 
     @classmethod
     def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
@@ -60,7 +71,8 @@ class MergeStepPerformer(StepPerformer):
                         'sheet_index_to_overwrite': destination_sheet_index,
                         'attempt_to_save_filter_metadata': False
                     } if destination_sheet_index is not None else destination_sheet_index
-                }
+                },
+                optional_code=params.get('optional_code')
             )
 
         except ValueError:
@@ -106,7 +118,8 @@ class MergeStepPerformer(StepPerformer):
                 get_param(params, 'merge_key_column_ids'),
                 get_param(params, 'selected_column_ids_one'),
                 get_param(params, 'selected_column_ids_two'),
-                get_param(execution_data if execution_data is not None else {}, 'new_df_name') 
+                get_param(execution_data if execution_data is not None else {}, 'new_df_name'),
+                get_param(execution_data if execution_data is not None else {}, 'optional_code_that_successfully_executed')
             )
         ]
     

--- a/mitosheet/mitosheet/telemetry/anonymization_utils.py
+++ b/mitosheet/mitosheet/telemetry/anonymization_utils.py
@@ -11,7 +11,7 @@ this folder for more details on our approach to private telemetry.
 
 from typing import Any, Dict, Optional
 from mitosheet.parser import parse_formula
-from mitosheet.telemetry.private_params_map import LOG_PARAMS_FORMULAS, LOG_PARAMS_LENGTH, LOG_PARAMS_MAP_KEYS_TO_MAKE_PRIVATE, LOG_PARAMS_TO_LINEARIZE, LOG_PARAMS_PUBLIC
+from mitosheet.telemetry.private_params_map import LOG_PARAMS_FORMULAS, LOG_PARAMS_LENGTH_FIRST_ELEMENT, LOG_PARAMS_MAP_KEYS_TO_MAKE_PRIVATE, LOG_PARAMS_TO_LINEARIZE, LOG_PARAMS_PUBLIC
 from mitosheet.types import StepsManagerType
 from mitosheet.user.db import get_user_field
 from mitosheet.user.schemas import UJ_USER_SALT
@@ -118,8 +118,8 @@ def get_final_private_params_for_single_kv(key: str, value: Any, params: Dict[st
 
     if key in LOG_PARAMS_PUBLIC:
         private_params[key] = value
-    if key in LOG_PARAMS_LENGTH:
-        private_params[key] = len(value)
+    elif key in LOG_PARAMS_LENGTH_FIRST_ELEMENT:
+        private_params[key] = len(value[0]) if value else 0
     elif key in LOG_PARAMS_FORMULAS:
         private_params[key] = anonymize_formula(value, params['sheet_index'], steps_manager)
     else:

--- a/mitosheet/mitosheet/telemetry/private_params_map.py
+++ b/mitosheet/mitosheet/telemetry/private_params_map.py
@@ -13,8 +13,8 @@ more details.
 # Params that do not need to be anonyimized
 LOG_PARAMS_PUBLIC = { 'action', 'analysis_name', 'column_header_index', 'cell_editor_location', 'checklist_id', 'completed_items', 'drop', 'tour_names', 'total_number_of_tour_steps', 'created_non_empty_dataframe', 'destination_sheet_index', 'df_index_type', 'email', 'export_type', 'error', 'error_message', 'error_name', 'error_stack', 'feedback_id', 'field', 'filter_location', 'flatten_column_headers', 'format_type', 'fullscreen', 'function_name', 'graph_id', 'graph_type', 'has_headers', 'has_non_empty_filter', 'height', 'how', 'ignore_index', 'join', 'jupyterlab_theme', 'keep', 'level', 'log_event', 'message', 'move_to_deprecated_id_algorithm', 'new_column_index', 'new_dtype', 'new_graph_id', 'new_signup_step', 'new_version', 'num_args', 'num_df_args', 'num_str_args', 'num_usages', 'number_rendered_sheets', 'old_dtype', 'old_graph_id', 'old_signup_step', 'old_version', 'operator', 'paper_bgcolor', 'param_filtered', 'path_parts_length', 'plot_bgcolor', 'pro_button_location', 'questions_and_answers', 'safety_filter_turned_on_by_user', 'search_string', 'selected_element', 'sheet_index', 'sheet_index_one', 'sheet_index_two', 'sheet_indexes', 'showlegend', 'skiprows', 'sort', 'sort_direction', 'step_id_to_match', 'step_idx', 'step_type', 'steps_manager_analysis_name', 'title_font_color', 'user_agent', 'user_serch_term', 'view_df', 'visible', 'width', 'row_index', 'type', 'value', 'open_due_to_replay_error', 'num_invalid_imports', 'num_total_imports', 'optional_code_chunk_names', 'code_snippet_name', 'get_code_snippet_error_reason', 'completion', 'edited_completion', 'prompt', 'prompt_version', 'user_input', 'feedback', 'created_dataframe_names', 'deleted_dataframe_names', 'last_line_value', 'aiPrivacyPolicyNotAccepted', 'apiKeyNotDefined', 'feature'}
 
-# Params that we want to log the length of only
-LOG_PARAMS_LENGTH = {'optional_code'}
+# Params that we want to log the length of the first element
+LOG_PARAMS_LENGTH_FIRST_ELEMENT = {'optional_code'}
 
 # Parameters that are formulas, and so need to be anonyimized in a special way
 LOG_PARAMS_FORMULAS = {'new_formula', 'old_formula'}
@@ -36,4 +36,4 @@ assert len(LOG_PARAMS_PUBLIC.intersection(LOG_PARAMS_FORMULAS)) == 0
 LOG_EXECUTION_DATA_PUBLIC = {'was_series', 'num_cols_deleted', 'column_header_index', 'pandas_processing_time', 'file_delimeters', 'destination_sheet_index', 'file_encodings', 'num_cols_formatted', 'result'}
 
 # Keys from execution data that are lists, and we just want to know the length of
-LOG_EXECUTION_DATA_LENGTH = {'optional_code_that_successfully_executed'}
+LOG_EXECUTION_DATA_LENGTH_FIRST_ELEMENT = {'optional_code_that_successfully_executed'}

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -23,7 +23,7 @@ import requests
 from unittest.mock import patch
 from mitosheet.errors import MitoError, get_recent_traceback_as_list
 from mitosheet.telemetry.anonymization_utils import anonymize_object, get_final_private_params_for_single_kv
-from mitosheet.telemetry.private_params_map import LOG_EXECUTION_DATA_LENGTH, LOG_EXECUTION_DATA_PUBLIC
+from mitosheet.telemetry.private_params_map import LOG_EXECUTION_DATA_LENGTH_FIRST_ELEMENT, LOG_EXECUTION_DATA_PUBLIC
 from mitosheet.types import StepsManagerType
 from mitosheet.user.location import get_location, is_docker, is_jupyterlite
 from mitosheet.user.schemas import UJ_FEEDBACKS, UJ_FEEDBACKS_V2, UJ_INTENDED_BEHAVIOR, UJ_MITOSHEET_TELEMETRY, UJ_USER_EMAIL
@@ -123,9 +123,9 @@ def _get_execution_data_log_params(steps_manager: Optional[StepsManagerType]=Non
             # Only take those items that are marked as public
             if key in LOG_EXECUTION_DATA_PUBLIC:
                 execution_data_params['execution_data_' + key] = value
-            elif key in LOG_EXECUTION_DATA_LENGTH:
+            elif key in LOG_EXECUTION_DATA_LENGTH_FIRST_ELEMENT:
                 # Calculate the length, if we're asked to
-                execution_data_params['execution_data_' + key] = len(value)
+                execution_data_params['execution_data_' + key] = len(value[0]) if value else 0
             # And make the rest private
             else:
                 execution_data_params['execution_data_' + key] = anonymize_object(value)

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -803,6 +803,14 @@ def test_edit_merge_works_with_filters():
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'])
     mito.filter(2, 'A', 'And', FC_NUMBER_EXACTLY, 2)
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+
+    steps_manager = mito.mito_backend.steps_manager
+    final_step = steps_manager.steps_including_skipped[steps_manager.curr_step_idx]
+
+    assert len(final_step.column_filters[2]['A']['filters']) > 0
+    assert len(final_step.column_filters[2]['B_df1']['filters']) == 0
+    assert len(final_step.column_filters[2]['B_df2']['filters']) == 0
+
     mito.filter(2, 'A', 'And', FC_NUMBER_EXACTLY, 3)
 
     assert mito.dfs[2].equals(pd.DataFrame({'A': [3], 'B_df1': [3], 'B_df2': [3]}, index=[1]))

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -9,6 +9,7 @@ Contains tests for merging events.
 from cmath import exp
 from mitosheet.state import NUMBER_FORMAT_CURRENCY, NUMBER_FORMAT_PLAIN_TEXT
 from mitosheet.tests.step_performers.test_set_dataframe_format import SET_DATAFRAME_FORMAT_TESTS, get_dataframe_format
+from mitosheet.types import FC_NUMBER_EXACTLY, FC_STRING_CONTAINS
 import numpy as np
 import pytest
 import pandas as pd
@@ -793,3 +794,15 @@ def test_edit_merge_replays_edits_after_multiple_edits():
     mito.merge_sheets('outer', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
 
     assert mito.dfs[2].equals(pd.DataFrame({'A': [2, 1], 'B_df1': [2.0, None], 'Test': [2, 1], 'B_df2': [2, 1]}))
+
+
+def test_edit_merge_works_with_filters():
+    df1 = pd.DataFrame({'A': [2, 3], 'B': [2, 3]})
+    df2 = pd.DataFrame({'A': [2, 3], 'B': [2, 3]})
+    mito = create_mito_wrapper(df1, df2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'])
+    mito.filter(2, 'A', 'And', FC_NUMBER_EXACTLY, 2)
+    mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
+    mito.filter(2, 'A', 'And', FC_NUMBER_EXACTLY, 3)
+
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [3], 'B_df1': [3], 'B_df2': [3]}, index=[1]))

--- a/mitosheet/mitosheet/tests/step_performers/test_merge.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_merge.py
@@ -414,9 +414,15 @@ def test_merge_edit_optimizes_with_edit_to_merge():
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A'], destination_sheet_index=2)
 
     assert mito.transpiled_code == [
-        'from mitosheet.public.v3 import *', '', 
+        'from mitosheet.public.v3 import *', 
+        '', 
         "df2_tmp = df2.drop(['B'], axis=1)", 
-        "df_merge = df1.merge(df2_tmp, left_on=['A'], right_on=['A'], how='inner', suffixes=['_df1', '_df2'])", ''
+        "df_merge = df1.merge(df2_tmp, left_on=['A'], right_on=['A'], how='inner', suffixes=['_df1', '_df2'])", 
+        '',
+        '# Added column Test',
+        "df_merge['Test'] = 0",
+        ''
+
     ]
 
 def test_merge_edit_optimizes_after_delete_with_edit_to_merge():
@@ -759,7 +765,7 @@ def test_edit_merge_replays_edit_after():
     mito.add_column(2, 'Test')
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
 
-    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'Test': [0], 'B_df2': [2]}))
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'B_df2': [2], 'Test': [0]}))
 
 def test_edit_merge_replays_multiple_edits():
     df1 = pd.DataFrame({'A': [2], 'B': [2]})
@@ -770,7 +776,7 @@ def test_edit_merge_replays_multiple_edits():
     mito.set_formula('=A', 2, 'Test')
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
 
-    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'Test': [2], 'B_df2': [2]}))
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'B_df2': [2], 'Test': [2]}))
 
 def test_edit_merge_replays_multiple_edits_stops_on_error():
     df1 = pd.DataFrame({'A': [2], 'B': [2]})
@@ -781,7 +787,7 @@ def test_edit_merge_replays_multiple_edits_stops_on_error():
     mito.set_formula('=B', 2, 'Test')
     mito.merge_sheets('inner', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
 
-    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'Test': [0], 'B_df2': [2]}))
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [2], 'B_df1': [2], 'B_df2': [2], 'Test': [0]}))
 
 def test_edit_merge_replays_edits_after_multiple_edits():
     df1 = pd.DataFrame({'A': [2], 'B': [2]})
@@ -793,7 +799,7 @@ def test_edit_merge_replays_edits_after_multiple_edits():
     mito.set_formula('=A', 2, 'Test')
     mito.merge_sheets('outer', 0, 1, [['A', 'A']], ['A', 'B'], ['A', 'B'], destination_sheet_index=2)
 
-    assert mito.dfs[2].equals(pd.DataFrame({'A': [2, 1], 'B_df1': [2.0, None], 'Test': [2, 1], 'B_df2': [2, 1]}))
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [2, 1], 'B_df1': [2.0, None], 'B_df2': [2, 1], 'Test': [2, 1]}))
 
 
 def test_edit_merge_works_with_filters():

--- a/tests/streamlit_ui_tests/features/merge.spec.ts
+++ b/tests/streamlit_ui_tests/features/merge.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+import { awaitResponse, checkOpenTaskpane, clickButtonAndAwaitResponse, closeTaskpane, getColumnHeaderContainer, getMitoFrameWithTestCSV, importCSV } from '../utils';
+
+
+test.describe('Merge', () => {
+
+    test('Allows Editing', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await importCSV(page, mito, 'test.csv');
+        
+        await clickButtonAndAwaitResponse(page, mito, { name: '▾ Merge' })
+        await mito.getByText('Merge (horizontal)').click();
+        await awaitResponse(page);
+    
+        await expect(mito.getByText('Merge Dataframes')).toBeVisible();
+    
+        // Check that Column1 exists
+        const ch1 = await getColumnHeaderContainer(mito, 'Column1');
+        await expect(ch1).toBeVisible();
+
+        // Close the taskpane
+        await closeTaskpane(mito);
+
+        // Reopen the edit merge
+        await mito.getByText('df_merge').click({button: 'right'});
+        await mito.getByText('Edit Merge').click();
+
+        // Add a merge key
+        await mito.getByRole('button', { name: '+ Add Merge Keys' }).click();
+
+        const newCh1 = await getColumnHeaderContainer(mito, 'Column1');
+        await expect(newCh1).toBeVisible();
+        const newCh2 = await getColumnHeaderContainer(mito, 'Column2');
+        await expect(newCh2).toBeVisible();
+        const Column3_test_1 = await getColumnHeaderContainer(mito, 'Column3_test_1');
+        await expect(Column3_test_1).toBeVisible();
+    });
+
+
+    test('Replays Dependent Edits', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await importCSV(page, mito, 'test.csv');
+        
+        await clickButtonAndAwaitResponse(page, mito, { name: '▾ Merge' })
+        await mito.getByText('Merge (horizontal)').click();
+        await awaitResponse(page);
+    
+        await expect(mito.getByText('Merge Dataframes')).toBeVisible();
+    
+        // Check that Column1 exists
+        const ch1 = await getColumnHeaderContainer(mito, 'Column1');
+        await expect(ch1).toBeVisible();
+
+        // Add a column
+        await mito.locator('[id="mito-toolbar-button-add\\ column\\ to\\ the\\ right"]').getByRole('button', { name: 'Insert' }).click();
+        await awaitResponse(page);
+
+        // Check that the merge table has been updated -- there should be
+        // 5 columns from merge + 1 added
+        await expect(mito.locator('.endo-column-header-container')).toHaveCount(6);
+
+        // Reopen the edit merge
+        await mito.getByText('df_merge').click({button: 'right'});
+        await mito.getByText('Edit Merge').click();
+
+        // Add a merge key
+        await mito.getByRole('button', { name: '+ Add Merge Keys' }).click();
+
+        const newCh1 = await getColumnHeaderContainer(mito, 'Column1');
+        await expect(newCh1).toBeVisible();
+        const newCh2 = await getColumnHeaderContainer(mito, 'Column2');
+        await expect(newCh2).toBeVisible();
+        const Column3_test_1 = await getColumnHeaderContainer(mito, 'Column3_test_1');
+        await expect(Column3_test_1).toBeVisible();
+
+        // Check that there are 5 columns still
+        await expect(mito.locator('.endo-column-header-container')).toHaveCount(4);
+    });
+});


### PR DESCRIPTION
# Description

Replays edits on merge. 

Note that this PR is dramatically improved once we merge the PR https://github.com/mito-ds/mito/pull/1115 -- as the column insertion code at the end of the dataframe gets much more robust in this case. This is particularly useful in the case of merge, where editing is very likely to change the number of columns in the dataframe.

# Testing

See new tests. Maybe write a few. 

# Documentation

No.