### PR TITLE
Create graph from selection in dataframe

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -84,6 +84,7 @@ import { isInDashboard } from './utils/location';
 import { shallowEqualToDepth } from './utils/objects';
 import GithubScheduleTaskpane from './components/taskpanes/GithubSchedule/GithubScheduleTaskpane';
 import { handleKeyboardShortcuts } from './utils/keyboardShortcuts';
+import { getSelectedColumnIDsWithEntireSelectedColumn } from './components/endo/selectionUtils';
 
 export type MitoProps = {
     getSendFunction: () => Promise<SendFunction | SendFunctionError>
@@ -635,6 +636,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     graphDataDict={analysisData.graphDataDict}
                     analysisData={analysisData}
                     mitoContainerRef={mitoContainerRef}
+                    selectedColumnsIds={getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])}
                 />
             )
             case TaskpaneType.IMPORT_FILES: return (

--- a/mitosheet/src/mito/components/endo/selectionUtils.tsx
+++ b/mitosheet/src/mito/components/endo/selectionUtils.tsx
@@ -781,7 +781,7 @@ export const isSelectionEntireSelectedColumn = (selection: MitoSelection): boole
     return (selection.startingRowIndex === -1 && selection.endingRowIndex === -1);
 }
 
-export const getSelectedColumnIDsWithEntireSelectedColumn = (selections: MitoSelection[], sheetData: SheetData | undefined ): ColumnID[] => {
+export const getSelectedColumnIDsWithEntireSelectedColumn = (selections: MitoSelection[], sheetData: SheetData | undefined, inSameOrderAsDataframe?: boolean ): ColumnID[] => {
     if (sheetData === undefined) {
         return []
     }
@@ -794,6 +794,9 @@ export const getSelectedColumnIDsWithEntireSelectedColumn = (selections: MitoSel
     })
     // Deduplicate the list
     columnIndexes = [...new Set(columnIndexes)];
+    if (inSameOrderAsDataframe) {
+        columnIndexes = columnIndexes.sort();
+    }
 
     return columnIndexes
         .filter(colIdx => sheetData.data.length > colIdx)

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { MitoAPI,  getRandomId } from '../../../api/api';
 import { useDebouncedEffect } from '../../../hooks/useDebouncedEffect';
 import { useEffectOnUpdateEvent } from '../../../hooks/useEffectOnUpdateEvent';
-import { AnalysisData, ColumnIDsMap, GraphDataDict, GraphID, GraphSidebarTab, SheetData, UIState } from '../../../types';
+import { AnalysisData, ColumnID, ColumnIDsMap, GraphDataDict, GraphID, GraphSidebarTab, SheetData, UIState } from '../../../types';
 import DefaultEmptyTaskpane from '../DefaultTaskpane/DefaultEmptyTaskpane';
 import { TaskpaneType } from '../taskpanes';
 import GraphSidebarTabs from './GraphSidebarTabs';
@@ -40,7 +40,8 @@ const GraphSidebar = (props: {
     graphDataDict: GraphDataDict
     analysisData: AnalysisData
     mitoContainerRef: React.RefObject<HTMLDivElement>,
-    graphSidebarTab?: GraphSidebarTab
+    graphSidebarTab?: GraphSidebarTab,
+    selectedColumnsIds?: ColumnID[]
 }): JSX.Element => {
 
     /*
@@ -62,7 +63,7 @@ const GraphSidebar = (props: {
 
     // We keep track of the graph data separately from the backend state so that 
     // the UI updates immediately, even though the backend takes a while to process.
-    const [graphParams, setGraphParams] = useState(() => getGraphParams(props.graphDataDict, graphID, props.uiState.selectedSheetIndex, props.sheetDataArray))
+    const [graphParams, setGraphParams] = useState(() => getGraphParams(props.graphDataDict, graphID, props.uiState.selectedSheetIndex, props.sheetDataArray, props.selectedColumnsIds))
 
     const dataSourceSheetIndex = graphParams.graphCreation.sheet_index
     const graphOutput = props.graphDataDict[graphID]?.graphOutput

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphStyleTab.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphStyleTab.tsx
@@ -224,7 +224,7 @@ function GraphStyleTab(props: {
                         </p>
                     </Col>
                     <Select 
-                        value={graphStylingParams.legend.orientation === 'v' ? 'vertical' : 'horiztonal'} 
+                        value={graphStylingParams.legend.orientation === 'v' ? 'vertical' : 'horizontal'} 
                         width='medium'
                         onChange={(newOrientation: string) => {
                             return updateGraphParam({graphStyling: {legend: {orientation: newOrientation as 'v' | 'h'}}});
@@ -304,7 +304,7 @@ function GraphStyleTab(props: {
                         }}     
                     />
                 </Row>
-                <Row justify='space-between' align='center' title='Turn on/off horiztonal grid lines'>
+                <Row justify='space-between' align='center' title='Turn on/off horizontal grid lines'>
                     <Col>
                         <p>
                             Show horizontal grid
@@ -347,8 +347,8 @@ function GraphStyleTab(props: {
                         width='small'
                         placeholder='1'
                         onChange={(e) => {
-                            const newHoriztonalGridWidth = e.target.value === '' ? undefined : e.target.value;
-                            return updateGraphParam({graphStyling: {yaxis: {gridwidth: newHoriztonalGridWidth}}});
+                            const newHorizontalGridWidth = e.target.value === '' ? undefined : e.target.value;
+                            return updateGraphParam({graphStyling: {yaxis: {gridwidth: newHorizontalGridWidth}}});
                         }}     
                     />
                 </Row>

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -16,6 +16,10 @@ const DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT = '#FFFFFF'
 const DO_NOT_CHANGE_PLOT_BGCOLOR_DEFAULT = '#E6EBF5'
 const DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT = '#2F3E5D'
 
+/**
+ * Returns the default axis column ids for a given graph type and selected column ids.
+ * Used to set the default axis column ids based on the current selection when creating a new graph.
+ */
 const getAxisColumnIDs = (sheetData: SheetData, graphType?: GraphType, selectedColumnIds?: ColumnID[]): {
     x_axis_column_ids: ColumnID[],
     y_axis_column_ids: ColumnID[]
@@ -26,25 +30,19 @@ const getAxisColumnIDs = (sheetData: SheetData, graphType?: GraphType, selectedC
             y_axis_column_ids: []
         }
     }
+    if (selectedColumnIds.length === 1) {
+        return {
+            x_axis_column_ids: [],
+            y_axis_column_ids: selectedColumnIds
+        }
+    }
     if (graphType === GraphType.SCATTER) {
-        if (selectedColumnIds.length === 1) {
-            return {
-                x_axis_column_ids: [],
-                y_axis_column_ids: selectedColumnIds
-            }
-        } else {
-            return {
-                x_axis_column_ids: [selectedColumnIds[0]],
-                y_axis_column_ids: selectedColumnIds.slice(1)
-            }
+        return {
+            x_axis_column_ids: [selectedColumnIds[0]],
+            y_axis_column_ids: selectedColumnIds.slice(1)
         }
     } else {
-        if (selectedColumnIds.length === 1) {
-            return {
-                x_axis_column_ids: [],
-                y_axis_column_ids: selectedColumnIds
-            }
-        } else if (!isNumberDtype(sheetData.columnDtypeMap[selectedColumnIds[0]])) {
+        if (!isNumberDtype(sheetData.columnDtypeMap[selectedColumnIds[0]])) {
             return {
                 x_axis_column_ids: [selectedColumnIds[0]],
                 y_axis_column_ids: selectedColumnIds.slice(1)

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -20,7 +20,7 @@ const getAxisColumnIDs = (sheetData: SheetData, graphType?: GraphType, selectedC
     x_axis_column_ids: ColumnID[],
     y_axis_column_ids: ColumnID[]
 } => {
-    if (selectedColumnIds === undefined) {
+    if (selectedColumnIds === undefined || selectedColumnIds.length === 0) {
         return {
             x_axis_column_ids: [],
             y_axis_column_ids: []

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -16,9 +16,41 @@ const DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT = '#FFFFFF'
 const DO_NOT_CHANGE_PLOT_BGCOLOR_DEFAULT = '#E6EBF5'
 const DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT = '#2F3E5D'
 
+const getAxisColumnIDs = (graphType?: GraphType, selectedColumnIds?: ColumnID[]): {
+    x_axis_column_ids: ColumnID[],
+    y_axis_column_ids: ColumnID[]
+} => {
+    if (selectedColumnIds === undefined) {
+        return {
+            x_axis_column_ids: [],
+            y_axis_column_ids: []
+        }
+    }
+    if (graphType === GraphType.SCATTER) {
+        if (selectedColumnIds.length === 1) {
+            return {
+                x_axis_column_ids: [],
+                y_axis_column_ids: selectedColumnIds
+            }
+        } else {
+            return {
+                x_axis_column_ids: [selectedColumnIds[0]],
+                y_axis_column_ids: selectedColumnIds.slice(1)
+            }
+        }
+    } else {
+        return {
+            x_axis_column_ids: [],
+            y_axis_column_ids: selectedColumnIds
+        }
+    }
+}
+
+
 // unless a graph type is provided
-export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: number, graphType?: GraphType): GraphParamsFrontend => {
+export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: number, graphType?: GraphType, selectedColumnIds?: ColumnID[]): GraphParamsFrontend => {
     graphType = graphType || GraphType.BAR
+    const axis_column_ids = getAxisColumnIDs(graphType, selectedColumnIds)
     return {
         graphPreprocessing: {
             safety_filter_turned_on_by_user: true
@@ -26,15 +58,13 @@ export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: n
         graphCreation: {
             graph_type: graphType,
             sheet_index: sheetIndex,
-            x_axis_column_ids: [],
-            y_axis_column_ids: [],
             color: undefined,
             facet_col_column_id: undefined,
             facet_row_column_id: undefined,
             facet_col_wrap: undefined,
             facet_col_spacing: undefined,
             facet_row_spacing: undefined,
-
+            ...axis_column_ids,
             // Params that are only available to some graph types
             points: GRAPHS_THAT_HAVE_POINTS.includes(graphType) ? 'outliers' : undefined,
             line_shape: GRAPHS_THAT_HAVE_LINE_SHAPE.includes(graphType) ? 'linear' : undefined,
@@ -106,6 +136,7 @@ export const getGraphParams = (
     graphID: GraphID,
     selectedSheetIndex: number,
     sheetDataArray: SheetData[],
+    selectedColumnIds?: ColumnID[]
 ): GraphParamsFrontend => {
 
     const graphParamsCopy: GraphParamsFrontend = window.structuredClone(graphDataDict[graphID]?.graphParams); 
@@ -142,7 +173,7 @@ export const getGraphParams = (
     }
 
     // If the graph does not already exist, create a default graph.
-    return getDefaultGraphParams(sheetDataArray, graphDataSourceSheetIndex);
+    return getDefaultGraphParams(sheetDataArray, graphDataSourceSheetIndex, undefined, selectedColumnIds);
 }
 
 // Returns a list of dropdown items. Selecting them sets the color attribute of the graph.
@@ -270,7 +301,8 @@ export const openGraphEditor =
         setUIState: React.Dispatch<React.SetStateAction<UIState>>,
         sheetIndex: number,
         mitoAPI: MitoAPI,
-        graphType?: GraphType
+        graphType?: GraphType,
+        selectedColumnIds?: ColumnID[]
     ) => {
     // We turn off editing mode, if it is on
         setEditorState(undefined);
@@ -290,7 +322,7 @@ export const openGraphEditor =
         }
 
         const newGraphID = getRandomId() // Create a new GraphID
-        const graphParams = getDefaultGraphParams(sheetDataArray, sheetIndex, graphType)
+        const graphParams = getDefaultGraphParams(sheetDataArray, sheetIndex, graphType, selectedColumnIds)
 
         await mitoAPI.editGraph(
             newGraphID,

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { ColumnID, ColumnIDsMap, EditorState, GraphDataDict, GraphID, GraphParamsBackend, GraphParamsFrontend, SheetData, UIState } from "../../../types"
 import { intersection } from "../../../utils/arrays"
 import { getDisplayColumnHeader } from "../../../utils/columnHeaders"
-import { isDatetimeDtype } from "../../../utils/dtypes"
+import { isDatetimeDtype, isNumberDtype } from "../../../utils/dtypes"
 import { convertStringToFloatOrUndefined } from "../../../utils/numbers"
 import { convertToStringOrUndefined } from "../../../utils/strings"
 import DropdownItem from "../../elements/DropdownItem"
@@ -16,7 +16,7 @@ const DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT = '#FFFFFF'
 const DO_NOT_CHANGE_PLOT_BGCOLOR_DEFAULT = '#E6EBF5'
 const DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT = '#2F3E5D'
 
-const getAxisColumnIDs = (graphType?: GraphType, selectedColumnIds?: ColumnID[]): {
+const getAxisColumnIDs = (sheetData: SheetData, graphType?: GraphType, selectedColumnIds?: ColumnID[]): {
     x_axis_column_ids: ColumnID[],
     y_axis_column_ids: ColumnID[]
 } => {
@@ -39,9 +39,21 @@ const getAxisColumnIDs = (graphType?: GraphType, selectedColumnIds?: ColumnID[])
             }
         }
     } else {
-        return {
-            x_axis_column_ids: [],
-            y_axis_column_ids: selectedColumnIds
+        if (selectedColumnIds.length === 1) {
+            return {
+                x_axis_column_ids: [],
+                y_axis_column_ids: selectedColumnIds
+            }
+        } else if (!isNumberDtype(sheetData.columnDtypeMap[selectedColumnIds[0]])) {
+            return {
+                x_axis_column_ids: [selectedColumnIds[0]],
+                y_axis_column_ids: selectedColumnIds.slice(1)
+            }
+        } else {
+            return {
+                x_axis_column_ids: [],
+                y_axis_column_ids: selectedColumnIds
+            }
         }
     }
 }
@@ -50,7 +62,7 @@ const getAxisColumnIDs = (graphType?: GraphType, selectedColumnIds?: ColumnID[])
 // unless a graph type is provided
 export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: number, graphType?: GraphType, selectedColumnIds?: ColumnID[]): GraphParamsFrontend => {
     graphType = graphType || GraphType.BAR
-    const axis_column_ids = getAxisColumnIDs(graphType, selectedColumnIds)
+    const axis_column_ids = getAxisColumnIDs(sheetDataArray[sheetIndex], graphType, selectedColumnIds)
     return {
         graphPreprocessing: {
             safety_filter_turned_on_by_user: true

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -1229,7 +1229,7 @@ export const getActions = (
             titleToolbar: 'Graph',
             longTitle: 'Create new graph',
             actionFunction: async () => {
-                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex], true)
                 await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, undefined, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
@@ -1242,7 +1242,7 @@ export const getActions = (
             iconToolbar: GraphIcon,
             longTitle: 'Create new bar chart',
             actionFunction: async () => {
-                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex], true)
                 await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.BAR, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
@@ -1255,7 +1255,7 @@ export const getActions = (
             iconToolbar: LineChartIcon,
             longTitle: 'Create new line graph',
             actionFunction: async () => {
-                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex], true)
                 await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.LINE, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
@@ -1268,7 +1268,7 @@ export const getActions = (
             iconToolbar: ScatterPlotIcon,
             longTitle: 'Create new scatter plot',
             actionFunction: async () => {
-                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex], true)
                 await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.SCATTER, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},

--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -1229,7 +1229,8 @@ export const getActions = (
             titleToolbar: 'Graph',
             longTitle: 'Create new graph',
             actionFunction: async () => {
-                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI);
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, undefined, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
             searchTerms: ['graph', 'chart', 'visualize', 'bar chart', 'box plot', 'scatter plot', 'histogram'],
@@ -1241,7 +1242,8 @@ export const getActions = (
             iconToolbar: GraphIcon,
             longTitle: 'Create new bar chart',
             actionFunction: async () => {
-                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.BAR);
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.BAR, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
             searchTerms: ['graph', 'chart', 'visualize', 'bar chart', 'box plot', 'scatter plot', 'histogram'],
@@ -1253,7 +1255,8 @@ export const getActions = (
             iconToolbar: LineChartIcon,
             longTitle: 'Create new line graph',
             actionFunction: async () => {
-                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.LINE);
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.LINE, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
             searchTerms: ['graph', 'chart', 'visualize', 'bar chart', 'box plot', 'scatter plot', 'histogram'],
@@ -1265,7 +1268,8 @@ export const getActions = (
             iconToolbar: ScatterPlotIcon,
             longTitle: 'Create new scatter plot',
             actionFunction: async () => {
-                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.SCATTER);
+                const selectedColumnIds = getSelectedColumnIDsWithEntireSelectedColumn(gridState.selections, sheetDataArray[uiState.selectedSheetIndex])
+                await openGraphEditor(setEditorState, sheetDataArray, setUIState, sheetIndex, mitoAPI, GraphType.SCATTER, selectedColumnIds);
             },
             isDisabled: () => {return doesAnySheetExist(sheetDataArray) ? defaultActionDisabledMessage : 'There are no dataframes to graph. Import data.'},
             searchTerms: ['graph', 'chart', 'visualize', 'bar chart', 'box plot', 'scatter plot', 'histogram'],

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -401,7 +401,7 @@ test.describe('Insert Tab Buttons', () => {
     await clickButtonAndAwaitResponse(page, mito, { name: 'Create an interactive scatter plot.' });
 
     await expect(mito.getByText('Setup Graph')).toBeVisible();
-    await expect(mito.getByText('Scatter', { exact: true })).toBeVisible();
+    await expect(mito.getByText('scatter', { exact: true })).toBeVisible();
   });
 
   test('Test Graph (line)', async ({ page }) => {

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -389,7 +389,7 @@ test.describe('Insert Tab Buttons', () => {
     await clickButtonAndAwaitResponse(page, mito, { name: 'Create an interactive scatter plot.' });
 
     await expect(mito.getByText('Setup Graph')).toBeVisible();
-    await expect(mito.getByText('Scatter')).toBeVisible();
+    await expect(mito.getByText('Scatter', { exact: true })).toBeVisible();
   });
 
   test('Test Graph (line)', async ({ page }) => {

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -270,6 +270,18 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.locator('p.select-text').getByText('Column2')).toBeVisible();
   })
 
+  test('Graph from selection with columns selected in reverse order', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    
+    await mito.getByTitle('Column2').click();
+    await mito.getByTitle('Column1').click({ modifiers: ['Shift']});
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+
+    await expect(mito.locator('p.select-text').nth(3)).toHaveText('Column1');
+    await expect(mito.locator('p.select-text').nth(4)).toHaveText('Column2');
+  })
+
   test('Scatter plot from selection', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     

--- a/tests/streamlit_ui_tests/streamlit.spec.ts
+++ b/tests/streamlit_ui_tests/streamlit.spec.ts
@@ -258,6 +258,31 @@ test.describe('Home Tab Buttons', () => {
     await expect(mito.locator('.plotly-graph-div').first()).toBeVisible();
   });
 
+  test('Graph from selection', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    
+    await mito.getByTitle('Column1').click();
+    await mito.getByTitle('Column2').click({ modifiers: ['Shift']});
+    
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+
+    await expect(mito.locator('p.select-text').getByText('Column1')).toBeVisible();
+    await expect(mito.locator('p.select-text').getByText('Column2')).toBeVisible();
+  })
+
+  test('Scatter plot from selection', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    
+    await mito.getByTitle('Column1').click();
+    await mito.getByTitle('Column2').click({ modifiers: ['Shift']});
+    
+    await clickTab(page, mito, 'Insert');
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Create an interactive scatter plot.' })
+
+    await expect(mito.locator('p.select-text').getByText('Column1')).toBeVisible();
+    await expect(mito.locator('p.select-text').getByText('Column2')).toBeVisible();
+  })
+
   test('AI Not Exist on Enterprise', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
 


### PR DESCRIPTION
Uses the selected columns to populate the axes in the graph configuration. Only covers the cases for bar charts, scatter plots, and line graphs because they are the only charts that can be created new. 
- Bar charts, line graphs : 
    - If the leftmost column is anything but a number, it is the x axis
    - If the y axes aren’t all the same type,
    - else only populate the y axis
- scatter plot:
    - one column: only populate y axis
    - multiple columns: first column is the x axis, rest of columns are the y axis