### PR TITLE
Add ability to make multi-level dropdowns

### DIFF
--- a/mitosheet/src/mito/components/elements/Dropdown.tsx
+++ b/mitosheet/src/mito/components/elements/Dropdown.tsx
@@ -74,7 +74,9 @@ interface DropdownProps {
      */
     width?: Width;
 
-    theme?: MitoTheme
+    theme?: MitoTheme;
+
+    position?: 'horizontal' | 'vertical';
 }
 
 // Where to place the dropdown
@@ -374,33 +376,42 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
             right: undefined,
             left: undefined 
         };
-        if (topInBounds(parentBottom) && leftInBounds(parentLeft, widthPixels)) {
+        if (props.position === 'vertical' || props.position === undefined) {
+            if (topInBounds(parentBottom) && leftInBounds(parentLeft, widthPixels)) {
+                newBoundingRect = {
+                    top: parentBottom,
+                    bottom: undefined,
+                    right: undefined,
+                    left: parentLeft
+                }
+            } else if (topInBounds(parentBottom) && rightInBounds(parentRight, widthPixels)) {
+                newBoundingRect = {
+                    top: parentBottom,
+                    bottom: undefined,
+                    right: window.innerWidth - parentRight,
+                    left:  undefined
+                }
+            } else if (bottomInBounds(parentTop) && leftInBounds(parentLeft, widthPixels)) {
+                newBoundingRect = {
+                    top: undefined,
+                    bottom: window.innerHeight - parentTop,
+                    right: undefined,
+                    left: parentLeft
+                }
+            } else {
+                newBoundingRect = {
+                    top: undefined,
+                    bottom: window.innerHeight - parentTop,
+                    right: window.innerWidth - parentRight,
+                    left:  undefined
+                }
+            }
+        } else { // This is the horizontal case
             newBoundingRect = {
-                top: parentBottom,
+                top: parentTop,
                 bottom: undefined,
                 right: undefined,
-                left: parentLeft
-            }
-        } else if (topInBounds(parentBottom) && rightInBounds(parentRight, widthPixels)) {
-            newBoundingRect = {
-                top: parentBottom,
-                bottom: undefined,
-                right: window.innerWidth - parentRight,
-                left:  undefined
-            }
-        } else if (bottomInBounds(parentTop) && leftInBounds(parentLeft, widthPixels)) {
-            newBoundingRect = {
-                top: undefined,
-                bottom: window.innerHeight - parentTop,
-                right: undefined,
-                left: parentLeft
-            }
-        } else {
-            newBoundingRect = {
-                top: undefined,
-                bottom: window.innerHeight - parentTop,
-                right: window.innerWidth - parentRight,
-                left:  undefined
+                left: parentRight
             }
         }
 

--- a/mitosheet/src/mito/components/elements/DropdownItem.tsx
+++ b/mitosheet/src/mito/components/elements/DropdownItem.tsx
@@ -114,7 +114,12 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
         <div 
             className={classNames('mito-dropdown-item', {[DROPDOWN_IGNORE_CLICK_CLASS]: disabled, [DROPDOWN_SUPRESS_FOCUS_ON_CLOSE]: props.supressFocusSettingOnClose}, props.className)}
             style={(props.canHaveCheckMark && !props.hasCheckMark) ? { paddingLeft: '32px' } : undefined}
-            onClick={!disabled ? props.onClick : undefined} 
+            onClick={(e) => {
+                e.stopPropagation();
+                if (!disabled) {
+                    props.onClick?.()
+                }
+            }} 
             title={props.tooltip}
             onMouseEnter={props.onMouseEnter}
         > 

--- a/mitosheet/src/mito/components/elements/DropdownItem.tsx
+++ b/mitosheet/src/mito/components/elements/DropdownItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import '../../../../css/elements/DropdownItem.css'
 import { classNames } from '../../utils/classNames';
 import { DROPDOWN_IGNORE_CLICK_CLASS, DROPDOWN_SUPRESS_FOCUS_ON_CLOSE } from './Dropdown';
+import RightArrowIcon from '../icons/RightArrowIcon';
 
 interface DropdownItemProps {
     /** 
@@ -73,7 +74,22 @@ interface DropdownItemProps {
         * @param [supressFocusSettingOnClose] - When True, the dropdown does not set the focus on the parent div
         * when this is clicked on. Helpful for items that open inputs
     */
-    supressFocusSettingOnClose?: boolean
+    supressFocusSettingOnClose?: boolean;
+
+    /**
+     * Optional submenu to display when the DropdownItem is hovered over
+     */
+    subMenu?: JSX.Element;
+
+    /**
+     * Optional function to call when the mouse enters the DropdownItem
+     */
+    onMouseEnter?: (e: React.MouseEvent) => void;
+
+    /**
+     * Optional function to call when the mouse leaves the DropdownItem
+     */
+    onMouseLeave?: (e: React.MouseEvent) => void;
 }
 
 /**
@@ -83,13 +99,15 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
 
     const disabled = props.disabled === true  
     const hideSubtext = props.hideSubtext === true
-    const displaySubtextOnHover = props.displaySubtextOnHover === true
+    const displaySubtextOnHover = props.displaySubtextOnHover === true;
     
     return (
         <div 
             className={classNames('mito-dropdown-item', {[DROPDOWN_IGNORE_CLICK_CLASS]: disabled, [DROPDOWN_SUPRESS_FOCUS_ON_CLOSE]: props.supressFocusSettingOnClose}, props.className)}
             onClick={!disabled ? props.onClick : undefined} 
             title={props.tooltip}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
         > 
             <div className={classNames('mito-dropdown-item-icon-and-title-container')}>
                 { props.icon !== undefined &&
@@ -106,6 +124,7 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
                             {props.title}
                         </p>
                     </span>
+                    {props.subMenu && <RightArrowIcon/>}
                     {props.rightText &&
                         <span className={classNames('mito-dropdown-item-right-text', 'text-body-2')}>
                             {props.rightText}
@@ -127,6 +146,7 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
                     {props.subtext}
                 </div>
             }
+            {props.subMenu}
         </div>
     )
 } 

--- a/mitosheet/src/mito/components/elements/DropdownItem.tsx
+++ b/mitosheet/src/mito/components/elements/DropdownItem.tsx
@@ -5,6 +5,7 @@ import '../../../../css/elements/DropdownItem.css'
 import { classNames } from '../../utils/classNames';
 import { DROPDOWN_IGNORE_CLICK_CLASS, DROPDOWN_SUPRESS_FOCUS_ON_CLOSE } from './Dropdown';
 import RightArrowIcon from '../icons/RightArrowIcon';
+import CheckmarkIcon from '../icons/CheckmarkIcon';
 
 interface DropdownItemProps {
     /** 
@@ -86,6 +87,18 @@ interface DropdownItemProps {
      * Used for displaying submenus
      */
     onMouseEnter?: (e: React.MouseEvent) => void;
+
+    /**
+     * Optional boolean to display a checkmark next to the DropdownItem
+     */
+    hasCheckMark?: boolean;
+
+    /**
+     * Optional boolean to indicate if there can be a checkmark next to the DropdownItem.
+     * This is used to set the margin of the DropdownItem to align with the other DropdownItems
+     * that have checkmarks. 
+     */
+    canHaveCheckMark?: boolean;
 }
 
 /**
@@ -100,11 +113,13 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
     return (
         <div 
             className={classNames('mito-dropdown-item', {[DROPDOWN_IGNORE_CLICK_CLASS]: disabled, [DROPDOWN_SUPRESS_FOCUS_ON_CLOSE]: props.supressFocusSettingOnClose}, props.className)}
+            style={(props.canHaveCheckMark && !props.hasCheckMark) ? { paddingLeft: '32px' } : undefined}
             onClick={!disabled ? props.onClick : undefined} 
             title={props.tooltip}
             onMouseEnter={props.onMouseEnter}
         > 
             <div className={classNames('mito-dropdown-item-icon-and-title-container')}>
+                { props.hasCheckMark && <CheckmarkIcon color='var(--mito-text-medium)' width='26' height='13'/> }
                 { props.icon !== undefined &&
                 <div className={classNames('mito-dropdown-item-icon-container')}>
                     {props.icon}

--- a/mitosheet/src/mito/components/elements/DropdownItem.tsx
+++ b/mitosheet/src/mito/components/elements/DropdownItem.tsx
@@ -82,14 +82,10 @@ interface DropdownItemProps {
     subMenu?: JSX.Element;
 
     /**
-     * Optional function to call when the mouse enters the DropdownItem
+     * Optional function to call when the mouse enters the DropdownItem.
+     * Used for displaying submenus
      */
     onMouseEnter?: (e: React.MouseEvent) => void;
-
-    /**
-     * Optional function to call when the mouse leaves the DropdownItem
-     */
-    onMouseLeave?: (e: React.MouseEvent) => void;
 }
 
 /**
@@ -107,7 +103,6 @@ const DropdownItem = (props: DropdownItemProps): JSX.Element => {
             onClick={!disabled ? props.onClick : undefined} 
             title={props.tooltip}
             onMouseEnter={props.onMouseEnter}
-            onMouseLeave={props.onMouseLeave}
         > 
             <div className={classNames('mito-dropdown-item-icon-and-title-container')}>
                 { props.icon !== undefined &&

--- a/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
+++ b/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
@@ -20,14 +20,11 @@ export default function IndexHeaderContextMenu(props: {
     actions: Actions;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
 }): JSX.Element {
-    const [ currentSubmenu, setCurrentSubmenu ] = React.useState<string | undefined>(undefined);
-
     return (
         <Dropdown
             display={props.display}
             closeDropdown={() => props.setUIState((prevUIState) => {
                 const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
-                setCurrentSubmenu(undefined);
                 return {
                     ...prevUIState,
                     currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
@@ -45,17 +42,6 @@ export default function IndexHeaderContextMenu(props: {
             <DropdownItem
                 {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Delete], props.closeOpenEditingPopups)}
                 title='Delete Row'
-                onMouseEnter={() => setCurrentSubmenu('Delete Row')}
-                subMenu={<Dropdown display={currentSubmenu === 'Delete Row'} position='horizontal' closeDropdown={() => props.setUIState((prevUIState) => {
-                    const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
-                    return {
-                        ...prevUIState,
-                        currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
-                    }
-                })}>
-                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
-                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
-                </Dropdown>}
             />
 
             <DropdownSectionSeperator isDropdownSectionSeperator={true}/>
@@ -64,19 +50,7 @@ export default function IndexHeaderContextMenu(props: {
 
             <DropdownSectionSeperator isDropdownSectionSeperator={true}/>
 
-            <DropdownItem
-                onMouseEnter={() => setCurrentSubmenu('Copy Row')}
-                subMenu={<Dropdown display={currentSubmenu === 'Copy Row'} position='horizontal' closeDropdown={() => props.setUIState((prevUIState) => {
-                    const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
-                    return {
-                        ...prevUIState,
-                        currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
-                    }
-                })}>
-                    <DropdownItem hasCheckMark canHaveCheckMark {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
-                    <DropdownItem canHaveCheckMark {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
-                </Dropdown>}
-                {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_DROP_INDEX], props.closeOpenEditingPopups)}/>
+            <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_DROP_INDEX], props.closeOpenEditingPopups)}/>
             <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_KEEP_INDEX], props.closeOpenEditingPopups)}/>
         </Dropdown>
     )

--- a/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
+++ b/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
@@ -73,8 +73,8 @@ export default function IndexHeaderContextMenu(props: {
                         currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
                     }
                 })}>
-                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
-                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                    <DropdownItem hasCheckMark canHaveCheckMark {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                    <DropdownItem canHaveCheckMark {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
                 </Dropdown>}
                 {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_DROP_INDEX], props.closeOpenEditingPopups)}/>
             <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_KEEP_INDEX], props.closeOpenEditingPopups)}/>

--- a/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
+++ b/mitosheet/src/mito/components/endo/IndexHeaderContextMenu.tsx
@@ -20,11 +20,14 @@ export default function IndexHeaderContextMenu(props: {
     actions: Actions;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
 }): JSX.Element {
+    const [ currentSubmenu, setCurrentSubmenu ] = React.useState<string | undefined>(undefined);
+
     return (
         <Dropdown
             display={props.display}
             closeDropdown={() => props.setUIState((prevUIState) => {
                 const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
+                setCurrentSubmenu(undefined);
                 return {
                     ...prevUIState,
                     currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
@@ -42,6 +45,17 @@ export default function IndexHeaderContextMenu(props: {
             <DropdownItem
                 {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Delete], props.closeOpenEditingPopups)}
                 title='Delete Row'
+                onMouseEnter={() => setCurrentSubmenu('Delete Row')}
+                subMenu={<Dropdown display={currentSubmenu === 'Delete Row'} position='horizontal' closeDropdown={() => props.setUIState((prevUIState) => {
+                    const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
+                    return {
+                        ...prevUIState,
+                        currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
+                    }
+                })}>
+                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                </Dropdown>}
             />
 
             <DropdownSectionSeperator isDropdownSectionSeperator={true}/>
@@ -50,7 +64,19 @@ export default function IndexHeaderContextMenu(props: {
 
             <DropdownSectionSeperator isDropdownSectionSeperator={true}/>
 
-            <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_DROP_INDEX], props.closeOpenEditingPopups)}/>
+            <DropdownItem
+                onMouseEnter={() => setCurrentSubmenu('Copy Row')}
+                subMenu={<Dropdown display={currentSubmenu === 'Copy Row'} position='horizontal' closeDropdown={() => props.setUIState((prevUIState) => {
+                    const isCurrOpenDropdown = isCurrOpenDropdownForCell(prevUIState, props.rowIndex, -1);
+                    return {
+                        ...prevUIState,
+                        currOpenDropdown: isCurrOpenDropdown ? undefined : prevUIState.currOpenDropdown
+                    }
+                })}>
+                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                    <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.Copy], props.closeOpenEditingPopups)}/>
+                </Dropdown>}
+                {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_DROP_INDEX], props.closeOpenEditingPopups)}/>
             <DropdownItem {...getPropsForContextMenuDropdownItem(props.actions.buildTimeActions[ActionEnum.RESET_AND_KEEP_INDEX], props.closeOpenEditingPopups)}/>
         </Dropdown>
     )

--- a/mitosheet/src/mito/components/icons/CheckmarkIcon.tsx
+++ b/mitosheet/src/mito/components/icons/CheckmarkIcon.tsx
@@ -3,10 +3,10 @@
 
 import React from 'react';
 
-const CheckmarkIcon = (): JSX.Element => {
+const CheckmarkIcon = (props: { color?: string; width?: string; height?: string }): JSX.Element => {
     return (
-        <svg width="15" height="12" viewBox="0 1 15 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1.80396 7.58667L5.13903 10.4804C5.3476 10.6613 5.66339 10.6389 5.84436 10.4304L13.2045 1.94761" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+        <svg width={props.width ?? "15"} height={props.height ?? "12"} viewBox="0 1 15 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1.80396 7.58667L5.13903 10.4804C5.3476 10.6613 5.66339 10.6389 5.84436 10.4304L13.2045 1.94761" stroke={props.color ?? "white"} strokeWidth="2" strokeLinecap="round"/>
         </svg>
     )
 }

--- a/mitosheet/src/mito/components/icons/RightArrowIcon.tsx
+++ b/mitosheet/src/mito/components/icons/RightArrowIcon.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 
 const RightArrowIcon = (): JSX.Element => {
     return (
-        <svg width="6" height="12" viewBox="0 0 6 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 10.5L4 5.99576L1 1.5" stroke="white" strokeWidth="2" strokeMiterlimit="10" strokeLinecap="round"/>
+        <svg width="10" height="12" viewBox="0 0 6 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 10.5L4 5.99576L1 1.5" stroke='var(--mito-text-medium)' strokeWidth="1.5" strokeMiterlimit="10" strokeLinecap="round"/>
         </svg>
 
     )


### PR DESCRIPTION
* Adds props to `DropdownItem`: `subMenu?: JSX.Element` and `onMouseEnter`. The creator of the dropdown is expected to keep track of the state for displaying submenus, because we want to make it easy to switch between submenus without bugginess. 
* Adds `position?: 'vertical' | 'horizontal'` prop to `Dropdown` so that the position can be determined correctly for submenus. We want the submenu to always appear directly to the right of the dropdown item, so the handling for `position === 'horizontal'` is just to set the bounding box to be directly to the right of the dropdown item, regardless of the position. 
* Adds a dummy example to `IndexHeaderContextMenu.tsx` for testing purposes. 
* **Note: also adds support for checkmarks in dropdowns.**
  * Adds `hasCheckmark` and `canHaveCheckmark` props to the `DropdownItem` class to ensure proper spacing