### PR TITLE
mitosheet: add config variable for disabling series limits on graphs

### DIFF
--- a/mitosheet/mitosheet/enterprise/mito_config.py
+++ b/mitosheet/mitosheet/enterprise/mito_config.py
@@ -33,6 +33,7 @@ MITO_CONFIG_LLM_URL = 'MITO_CONFIG_LLM_URL'
 MITO_CONFIG_ANALYTICS_URL = 'MITO_CONFIG_ANALYTICS_URL'
 MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH = 'MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH'
 MITO_CONFIG_CUSTOM_IMPORTERS_PATH = 'MITO_CONFIG_CUSTOM_IMPORTERS_PATH'
+MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS = 'MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS'
 
 # Note: The below keys can change since they are not set by the user.
 MITO_CONFIG_CODE_SNIPPETS = 'MITO_CONFIG_CODE_SNIPPETS'
@@ -80,7 +81,8 @@ def upgrade_mec_1_to_2(mec: Dict[str, Any]) -> Dict[str, Any]:
         MITO_CONFIG_ENTERPRISE: None,
         MITO_CONFIG_ENTERPRISE_TEMP_LICENSE: None,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: None
     }
 
 """
@@ -136,7 +138,8 @@ MEC_VERSION_KEYS = {
         MITO_CONFIG_ENTERPRISE,
         MITO_CONFIG_ENTERPRISE_TEMP_LICENSE,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS
     ]
 }
 
@@ -359,6 +362,13 @@ class MitoConfig:
             self.mec[MITO_CONFIG_ENTERPRISE],
             self.mec[MITO_CONFIG_ENTERPRISE_TEMP_LICENSE]
         )
+    
+    def get_graph_disable_series_limits(self) -> bool:
+        if self.mec is None or self.mec[MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS] is None:
+            return False
+
+        graph_disable_series_limits = is_env_variable_set_to_true(self.mec[MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS])
+        return graph_disable_series_limits
 
     # Add new mito configuration options here ...
 
@@ -378,5 +388,6 @@ class MitoConfig:
             MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: self.get_custom_sheet_functions_path(),
             MITO_CONFIG_CUSTOM_IMPORTERS_PATH: self.get_custom_importers_path(),
             MITO_CONFIG_PRO: self.get_pro(),
+            MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: self.get_graph_disable_series_limits(),
         }
 

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -20,6 +20,7 @@ from mitosheet.enterprise.mito_config import (
     MITO_CONFIG_DISABLE_TOURS,
     MITO_CONFIG_ENTERPRISE,
     MITO_CONFIG_ENTERPRISE_TEMP_LICENSE,
+    MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS,
     MITO_CONFIG_LLM_URL, 
     MITO_CONFIG_SUPPORT_EMAIL, 
     MITO_CONFIG_VERSION, 
@@ -80,7 +81,8 @@ def test_none_works():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }
 
 def test_none_config_version_is_string():
@@ -120,7 +122,8 @@ def test_version_2_works():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }
 
     # Delete the environmnet variables for the next test
@@ -147,7 +150,8 @@ def test_mito_config_update_version_1_to_2():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }    
 
     # Delete the environmnet variables for the next test
@@ -174,7 +178,8 @@ def test_mito_config_enable_snowflake_import():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }    
 
     delete_all_mito_config_environment_variables()
@@ -201,7 +206,8 @@ def test_mito_config_dont_display_snowflake_import():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }    
 
     delete_all_mito_config_environment_variables()
@@ -228,7 +234,8 @@ def test_mito_config_dont_display_ai_transform_and_scheduling():
         MITO_CONFIG_FEATURE_TELEMETRY: True,
         MITO_CONFIG_PRO: False,
         MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH: None,
-        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None
+        MITO_CONFIG_CUSTOM_IMPORTERS_PATH: None,
+        MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS: False,
     }    
 
     delete_all_mito_config_environment_variables()
@@ -301,8 +308,8 @@ def test_mito_config_custom_sheet_functions_path():
 
     mito_config = MitoConfig()
     mito_config = mito_config.get_mito_config()
-    mito_config[MITO_CONFIG_VERSION] == '2'
-    mito_config[MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH] == "./folder/file.py"
+    assert mito_config[MITO_CONFIG_VERSION] == '2'
+    assert mito_config[MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH] == "./folder/file.py"
 
     delete_all_mito_config_environment_variables()
 
@@ -313,7 +320,20 @@ def test_mito_config_custom_importers_path():
 
     mito_config = MitoConfig()
     mito_config = mito_config.get_mito_config()
-    mito_config[MITO_CONFIG_VERSION] == '2'
-    mito_config[MITO_CONFIG_CUSTOM_IMPORTERS_PATH] == "./folder/file.py"
+    assert mito_config[MITO_CONFIG_VERSION] == '2'
+    assert mito_config[MITO_CONFIG_CUSTOM_IMPORTERS_PATH] == "./folder/file.py"
 
     delete_all_mito_config_environment_variables()
+
+def test_mito_config_disable_graph_series_limit():
+
+    os.environ[MITO_CONFIG_VERSION] = "2"
+    os.environ[MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS] = "true"
+
+    mito_config = MitoConfig()
+    mito_config = mito_config.get_mito_config()
+    assert mito_config[MITO_CONFIG_VERSION] == '2'
+    assert mito_config[MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS]
+
+    delete_all_mito_config_environment_variables()
+

--- a/mitosheet/src/mito/components/taskpanes/Graph/AxisSection.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/AxisSection.tsx
@@ -7,7 +7,7 @@ import Row from '../../layout/Row';
 import Col from '../../layout/Col';
 
 import '../../../../../css/taskpanes/Graph/AxisSection.css'
-import { ColumnID, ColumnIDsMap } from '../../../types';
+import { ColumnID, ColumnIDsMap, MitoEnterpriseConfigKey, UserProfile } from '../../../types';
 import DropdownItem from '../../elements/DropdownItem';
 import { columnIDMapToDisplayHeadersMap, getDisplayColumnHeader } from '../../../utils/columnHeaders';
 import SelectAndXIconCard from '../../elements/SelectAndXIconCard';
@@ -31,6 +31,7 @@ const AxisSection = (props: {
     otherAxisSelectedColumnIDs: ColumnID[];
     updateAxisData: (graphAxis: GraphAxisType, index: number, columnID?: ColumnID) => void;
     mitoAPI: MitoAPI;
+    userProfile: UserProfile
 }): JSX.Element => {
 
     // Filter the column headers that the user can select to only the columns that are the correct type for the graph
@@ -61,7 +62,10 @@ const AxisSection = (props: {
     const numOtherAxisSelectedColumns = props.otherAxisSelectedColumnIDs.length
 
     /* 3. If there are already four series being graphed, then don't let the user add another series */
-    const disabledDueToMaxSeriesReachedBool = numSelectedColumns + numOtherAxisSelectedColumns >= 10
+    let disabledDueToMaxSeriesReachedBool = numSelectedColumns + numOtherAxisSelectedColumns >= 10
+    if (props.userProfile.mitoConfig[MitoEnterpriseConfigKey.GRAPH_DISABLE_SERIES_LIMITS]) {
+        disabledDueToMaxSeriesReachedBool = false;
+    }
 
     return (
         <div>

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSetupTab.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSetupTab.tsx
@@ -2,7 +2,7 @@
 
 import React, { Fragment } from 'react';
 import { MitoAPI } from '../../../api/api';
-import { ColumnID, ColumnIDsMap, GraphParamsFrontend, RecursivePartial, SheetData, UIState } from '../../../types';
+import { ColumnID, ColumnIDsMap, GraphParamsFrontend, RecursivePartial, SheetData, UIState, UserProfile } from '../../../types';
 import { getDisplayColumnHeader } from '../../../utils/columnHeaders';
 import { updateObjectWithPartialObject } from '../../../utils/objects';
 import DataframeSelect from '../../elements/DataframeSelect';
@@ -79,6 +79,7 @@ function GraphSetupTab(
         setUIState: React.Dispatch<React.SetStateAction<UIState>>;
         setGraphParams: React.Dispatch<React.SetStateAction<GraphParamsFrontend>>;
         setGraphUpdatedNumber: React.Dispatch<React.SetStateAction<number>>;
+        userProfile: UserProfile
     }): JSX.Element {
 
     const graphSheetIndex = props.graphParams.graphCreation.sheet_index;
@@ -272,6 +273,7 @@ function GraphSetupTab(
                     otherAxisSelectedColumnIDs={props.graphParams.graphCreation.y_axis_column_ids}
                     updateAxisData={updateAxisData}
                     mitoAPI={props.mitoAPI}
+                    userProfile={props.userProfile}
                 />
                 <AxisSection
                     columnIDsMap={columnIDsMap}
@@ -281,6 +283,7 @@ function GraphSetupTab(
                     otherAxisSelectedColumnIDs={props.graphParams.graphCreation.x_axis_column_ids}
                     updateAxisData={updateAxisData}
                     mitoAPI={props.mitoAPI}
+                    userProfile={props.userProfile}
                 />
                 <div>
                     <Row 

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -246,6 +246,7 @@ const GraphSidebar = (props: {
                                 columnDtypesMap={props.sheetDataArray[dataSourceSheetIndex]?.columnDtypeMap || {}}
                                 columnIDsMapArray={props.columnIDsMapArray}
                                 setUIState={props.setUIState}
+                                userProfile={props.userProfile}
                             />
                         }
                         {selectedGraphSidebarTab === GraphSidebarTab.Style &&

--- a/mitosheet/src/mito/types.tsx
+++ b/mitosheet/src/mito/types.tsx
@@ -721,6 +721,7 @@ export enum MitoEnterpriseConfigKey {
     PRO = 'MITO_CONFIG_PRO',
     CUSTOM_SHEET_FUNCTIONS_PATH = 'MITO_CONFIG_CUSTOM_SHEET_FUNCTIONS_PATH',
     CUSTOM_IMPORTERS_PATH = 'MITO_CONFIG_CUSTOM_IMPORTERS_PATH',
+    GRAPH_DISABLE_SERIES_LIMITS = 'MITO_CONFIG_GRAPH_DISABLE_SERIES_LIMITS'
 }
 
 export type PublicInterfaceVersion = 1 | 2 | 3;
@@ -805,6 +806,8 @@ export interface MitoConfig {
     [MitoEnterpriseConfigKey.DISPLAY_SCHEDULING]: boolean,
     [MitoEnterpriseConfigKey.CUSTOM_SHEET_FUNCTIONS_PATH]: string,
     [MitoEnterpriseConfigKey.CUSTOM_IMPORTERS_PATH]: string,
+    [MitoEnterpriseConfigKey.CUSTOM_IMPORTERS_PATH]: string,
+    [MitoEnterpriseConfigKey.GRAPH_DISABLE_SERIES_LIMITS]: boolean,
 }
 
 


### PR DESCRIPTION
# Description

Per user request, make it possible for pro users to disable series limits on graphs.

# Testing

Use the config variable and add more than 10 series to a graph.

# Documentation

Need to add to config docs page.