### PR TITLE
Fix graph title editor popup bug

### DIFF
--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -59,6 +59,10 @@ export const Popup = (props: {
         input.focus();
     }, [props.position])
 
+    if (!props.mitoContainerRef) {
+        return <></>
+    }
+
     return (
         ReactDOM.createPortal(
             <div
@@ -100,7 +104,7 @@ export const Popup = (props: {
                     }}
                 />
             </div>,
-            props.mitoContainerRef?.current as HTMLDivElement
+            props.mitoContainerRef.current as HTMLDivElement
         )
     )
 }

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -17,6 +17,7 @@ import { updateObjectWithPartialObject } from '../../../utils/objects';
 import { classNames } from '../../../utils/classNames';
 import Input from '../../elements/Input';
 import { getInputWidth } from '../../elements/Input';
+import ReactDOM from 'react-dom';
 
 export const Popup = (props: {
     value: string;
@@ -26,7 +27,7 @@ export const Popup = (props: {
         top?: number;
         bottom?: number;
     };
-    containerRef?: React.RefObject<HTMLDivElement>;
+    mitoContainerRef?: React.RefObject<HTMLDivElement>;
     setValue: (value: string) => void;
     onClose: () => void;
     caretPosition?: 'above' | 'below-left' | 'below-centered';
@@ -59,45 +60,48 @@ export const Popup = (props: {
     }, [props.position])
 
     return (
-        <div
-            className={`graph-element-popup-div ${props.caretPosition === 'above' ? 'graph-element-popup-div-caret-above' : props.caretPosition === 'below-left' ? 'graph-element-popup-div-caret-below-left' : 'graph-element-popup-div-caret-below-centered'}`}
-            style={{
-                position: 'absolute',
-                height: '32px',
-                left: props.position.left,
-                right: props.position.right,
-                top: props.position.top,
-                bottom: props.position.bottom,
-            }}
-        >
-            <div className='graph-element-popup-div-caret'/>
-            <Input
-                className='popup-input'
-                value={temporaryValue}
+        ReactDOM.createPortal(
+            <div
+                className={`graph-element-popup-div ${props.caretPosition === 'above' ? 'graph-element-popup-div-caret-above' : props.caretPosition === 'below-left' ? 'graph-element-popup-div-caret-below-left' : 'graph-element-popup-div-caret-below-centered'}`}
                 style={{
-                    zIndex: 1,
-                    position: 'relative',
-                    width: getInputWidth(temporaryValue, 150),
+                    position: 'absolute',
+                    height: '32px',
+                    left: props.position.left,
+                    right: props.position.right,
+                    top: props.position.top,
+                    bottom: props.position.bottom,
                 }}
-                onKeyDown={(e) => {
-                    /**
-                     * Normally, when the user has a graph element selected, pressing backspace
-                     * should delete the element. However, we don't want to delete the element
-                     * when the user is typing in the popup input.
-                     */
-                    if (e.key === 'Backspace') {
-                        e.stopPropagation();
-                    }
-                    if (e.key === 'Enter') {
-                        props.setValue(temporaryValue);
-                    }
-                }}
-                autoFocus
-                onChange={(e) => {
-                    setTemporaryValue(e.target.value);
-                }}
-            />
-        </div>
+            >
+                <div className='graph-element-popup-div-caret'/>
+                <Input
+                    className='popup-input'
+                    value={temporaryValue}
+                    style={{
+                        zIndex: 1,
+                        position: 'relative',
+                        width: getInputWidth(temporaryValue, 150),
+                    }}
+                    onKeyDown={(e) => {
+                        /**
+                         * Normally, when the user has a graph element selected, pressing backspace
+                         * should delete the element. However, we don't want to delete the element
+                         * when the user is typing in the popup input.
+                         */
+                        if (e.key === 'Backspace') {
+                            e.stopPropagation();
+                        }
+                        if (e.key === 'Enter') {
+                            props.setValue(temporaryValue);
+                        }
+                    }}
+                    autoFocus
+                    onChange={(e) => {
+                        setTemporaryValue(e.target.value);
+                    }}
+                />
+            </div>,
+            props.mitoContainerRef?.current as HTMLDivElement
+        )
     )
 }
 
@@ -204,7 +208,7 @@ const GraphSidebar = (props: {
 
             const graphObjects = getGraphElementObjects(graphOutput);
             graphObjects?.div.on('plotly_afterplot', () => {
-                registerClickEventsForGraphElements(graphOutput, setSelectedGraphElement);
+                registerClickEventsForGraphElements(graphOutput, setSelectedGraphElement, props.mitoContainerRef?.current);
             });
         } catch (e) {
             console.error("Failed to execute graph function", e)
@@ -296,7 +300,7 @@ const GraphSidebar = (props: {
                     caretPosition={selectedGraphElement?.element === 'gtitle' ? 'above' : selectedGraphElement?.element === 'ytitle' ? 'below-left' : 'below-centered'}
                     position={selectedGraphElement?.popupPosition}
                     onClose={() => setSelectedGraphElement(null)}
-                    containerRef={containerRef}
+                    mitoContainerRef={props.mitoContainerRef}
                 />
             </div>
             {currOpenTaskpane.graphSidebarOpen && <div className='graph-sidebar-toolbar-container'>

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -523,10 +523,10 @@ export const getGraphElementObjects = (graphOutput: GraphOutput) => {
     }
 }
 
-export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elementType: 'gtitle' | 'xtitle' | 'ytitle', graphOutput: GraphOutput): GraphElementType => {
+export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elementType: 'gtitle' | 'xtitle' | 'ytitle', graphOutput: GraphOutput, mitoContainer: HTMLElement | null): GraphElementType => {
     const clientRect = graphElement.getBoundingClientRect()
 
-    if (graphOutput === undefined) {
+    if (mitoContainer === null || graphOutput === undefined) {
         return {
             element: elementType,
             popupPosition: {
@@ -536,17 +536,18 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
             defaultValue: ''
         }
     }
-    const parentDiv = document.getElementById(graphOutput.graphHTML.split('id="')[1].split('"')[0]);
-    const parentDivClientRect = parentDiv?.getBoundingClientRect();
-    const parentDivLeft = parentDivClientRect?.left ?? 0;
-    const parentDivTop = parentDivClientRect?.top ?? 0;
-    const parentDivBottom = parentDivClientRect?.bottom ?? 0;
+
+    const graphOutputTop = document.getElementById(graphOutput.graphHTML.split('id="')[1].split('"')[0])?.getBoundingClientRect().top ?? 0;
+    const mitoDivClientRect = mitoContainer?.getBoundingClientRect();
+    const mitoDivLeft = mitoDivClientRect?.left ?? 0;
+    const mitoDivTop = mitoDivClientRect?.top ?? 0;
+    const mitoDivBottom = mitoDivClientRect?.bottom ?? 0;
     if (elementType === 'gtitle') {
         return {
             element: 'gtitle',
             popupPosition: {
-                left: clientRect.left - parentDivLeft,
-                top: clientRect.bottom - parentDivTop + 10
+                left: clientRect.left - mitoDivLeft,
+                top: clientRect.bottom - mitoDivTop + 10
             },
             defaultValue: graphElement.children?.[0]?.innerHTML
         }
@@ -554,24 +555,26 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
         return {
             element: 'xtitle',
             popupPosition: {
-                left: (clientRect.left + clientRect.right) / 2 - parentDivLeft - 70,
-                bottom: (parentDivBottom - clientRect.top) + 10
+                left: (clientRect.left + clientRect.right) / 2 - mitoDivLeft - 70,
+                bottom: (mitoDivBottom - clientRect.top) + 10
             },
             defaultValue: graphElement.children?.[0]?.innerHTML
         }
     } else {
+        const titleDivTop = mitoDivBottom - clientRect.top + 10;
+        const graphDivTop = mitoDivBottom - graphOutputTop;
         return {
             element: 'ytitle',
             popupPosition: {
-                left: clientRect.left - parentDivLeft,
-                bottom: parentDivBottom - clientRect.top + 10
+                left: clientRect.left - mitoDivLeft,
+                bottom: Math.min(titleDivTop, graphDivTop)
             },
             defaultValue: graphElement.children?.[0]?.innerHTML
         }
     }
 }
 
-export const registerClickEventsForGraphElements = (graphOutput: GraphOutput, setSelectedGraphElement: ((element: GraphElementType | null) => void)) => {
+export const registerClickEventsForGraphElements = (graphOutput: GraphOutput, setSelectedGraphElement: ((element: GraphElementType | null) => void), mitoContainer: HTMLElement | null) => {
     const graphElementObjects = getGraphElementObjects(graphOutput);
     if (graphElementObjects === undefined) {
         return;
@@ -607,14 +610,14 @@ export const registerClickEventsForGraphElements = (graphOutput: GraphOutput, se
      * Open popup when double clicked
      */
     gtitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(gtitle, 'gtitle', graphOutput))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(gtitle, 'gtitle', graphOutput, mitoContainer))
     });
 
     xtitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput, mitoContainer))
     });
 
     ytitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput, mitoContainer))
     });
 }

--- a/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
@@ -91,7 +91,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput, props.mitoContainerRef?.current)
                                         },
                                     }
                                 })
@@ -113,7 +113,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput, props.mitoContainerRef?.current)
                                         },
                                     }
                                 })
@@ -158,7 +158,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput, props.mitoContainerRef?.current)
                                         },
                                     }
                                 })


### PR DESCRIPTION
Fixes #1181. 
* Adds `ReactDOM.createPortal` to the popup so that it can be on top of the toolbar. 
* Adds calculation to keep the position of the popup from going to far up if the title is very long. 