### PR TITLE
Add context menus for graph titles

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1029,7 +1029,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
             onClick={(e) => {
                 const eventTarget = e.target;
                 if (uiState.currOpenTaskpane.type === TaskpaneType.GRAPH &&
-                    !!uiState.currOpenTaskpane.currentGraphElement?.display &&
+                    (['context-menu', 'popup-title-editor'].includes(uiState.currOpenTaskpane.currentGraphElement?.display ?? '')) &&
                     !(eventTarget instanceof HTMLInputElement && eventTarget.className.includes('popup-input'))) {
                     e.stopPropagation();
                     setUIState(prevUIState => {

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1029,7 +1029,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
             onClick={(e) => {
                 const eventTarget = e.target;
                 if (uiState.currOpenTaskpane.type === TaskpaneType.GRAPH &&
-                    uiState.currOpenTaskpane.currentGraphElement?.display === 'popup-title-editor' &&
+                    !!uiState.currOpenTaskpane.currentGraphElement?.display &&
                     !(eventTarget instanceof HTMLInputElement && eventTarget.className.includes('popup-input'))) {
                     e.stopPropagation();
                     setUIState(prevUIState => {

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1029,7 +1029,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
             onClick={(e) => {
                 const eventTarget = e.target;
                 if (uiState.currOpenTaskpane.type === TaskpaneType.GRAPH &&
-                    uiState.currOpenTaskpane.currentGraphElement?.popupPosition !== undefined &&
+                    uiState.currOpenTaskpane.currentGraphElement?.display === 'editor' &&
                     !(eventTarget instanceof HTMLInputElement && eventTarget.className.includes('popup-input'))) {
                     e.stopPropagation();
                     setUIState(prevUIState => {

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -1029,7 +1029,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
             onClick={(e) => {
                 const eventTarget = e.target;
                 if (uiState.currOpenTaskpane.type === TaskpaneType.GRAPH &&
-                    uiState.currOpenTaskpane.currentGraphElement?.display === 'editor' &&
+                    uiState.currOpenTaskpane.currentGraphElement?.display === 'popup-title-editor' &&
                     !(eventTarget instanceof HTMLInputElement && eventTarget.className.includes('popup-input'))) {
                     e.stopPropagation();
                     setUIState(prevUIState => {

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -106,7 +106,6 @@ const GraphTitleContextMenu = (props: {
 }) => {
     return (
         <div
-            className='graph-element-context-menu'
             style={{
                 position: 'absolute',
                 ...props.selectedGraphElement?.popupPosition

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -30,7 +30,7 @@ export const GraphTitleEditorPopup = (props: {
     /**
      * If position is undefined, we don't display the popup. 
      */
-    if (props.selectedGraphElement?.display !== 'editor') {
+    if (props.selectedGraphElement?.display !== 'popup-title-editor') {
         return <></>
     }
 
@@ -143,7 +143,7 @@ const GraphTitleContextMenu = (props: {
                             if (graphElementObjects === undefined) {
                                 return;
                             }
-                            const elementInfo = getGraphElementInfoFromHTMLElement(graphElementObjects[props.selectedGraphElement.element], props.selectedGraphElement.element, props.graphOutput, 'editor');
+                            const elementInfo = getGraphElementInfoFromHTMLElement(graphElementObjects[props.selectedGraphElement.element], props.selectedGraphElement.element, props.graphOutput, 'popup-title-editor');
                             props.setSelectedGraphElement(elementInfo);
                         }
                     }}

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -134,7 +134,7 @@ const GraphTitleContextMenu = (props: {
                         props.deleteSelectedGraphElement();
                     }}
                     supressFocusSettingOnClose
-                    title='Delete'
+                    title='Delete Title'
                 />
                 <DropdownItem
                     onClick={() => {

--- a/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/GraphSidebar.tsx
@@ -4,7 +4,7 @@ import '../../../../../css/taskpanes/Graph/LoadingSpinner.css';
 import { MitoAPI } from '../../../api/api';
 import { useEffectOnResizeElement } from '../../../hooks/useEffectOnElementResize';
 import useLiveUpdatingParams from '../../../hooks/useLiveUpdatingParams';
-import { AnalysisData, GraphDataArray, GraphParamsBackend, GraphParamsFrontend, OpenGraphType, RecursivePartial, SheetData, StepType, UIState } from '../../../types';
+import { AnalysisData, GraphDataArray, GraphOutput, GraphParamsBackend, GraphParamsFrontend, OpenGraphType, RecursivePartial, SheetData, StepType, UIState } from '../../../types';
 import XIcon from '../../icons/XIcon';
 import Col from '../../layout/Col';
 import Row from '../../layout/Row';
@@ -12,29 +12,25 @@ import DefaultEmptyTaskpane from '../DefaultTaskpane/DefaultEmptyTaskpane';
 import { TaskpaneType } from '../taskpanes';
 import GraphSetupTab from './GraphSetupTab';
 import LoadingSpinner from './LoadingSpinner';
-import { GraphElementType, convertBackendtoFrontendGraphParams, convertFrontendtoBackendGraphParams, getDefaultGraphParams, getGraphElementObjects, getGraphRenderingParams, registerClickEventsForGraphElements } from './graphUtils';
+import { GraphElementType, convertBackendtoFrontendGraphParams, convertFrontendtoBackendGraphParams, getDefaultGraphParams, getGraphElementInfoFromHTMLElement, getGraphElementObjects, getGraphRenderingParams, registerClickEventsForGraphElements } from './graphUtils';
 import { updateObjectWithPartialObject } from '../../../utils/objects';
 import { classNames } from '../../../utils/classNames';
 import Input from '../../elements/Input';
 import { getInputWidth } from '../../elements/Input';
+import Dropdown from '../../elements/Dropdown';
+import DropdownItem from '../../elements/DropdownItem';
 
-export const Popup = (props: {
-    value: string;
-    position?: {
-        left?: number;
-        right?: number;
-        top?: number;
-        bottom?: number;
-    };
+export const GraphTitleEditorPopup = (props: {
     containerRef?: React.RefObject<HTMLDivElement>;
     setValue: (value: string) => void;
-    onClose: () => void;
-    caretPosition?: 'above' | 'below-left' | 'below-centered';
+    selectedGraphElement?: GraphElementType;
+    setSelectedGraphElement: (graphElement?: GraphElementType) => void;
+    graphOutput: GraphOutput;
 }) => {
     /**
      * If position is undefined, we don't display the popup. 
      */
-    if (!props.position) {
+    if (props.selectedGraphElement?.display !== 'editor') {
         return <></>
     }
 
@@ -42,11 +38,11 @@ export const Popup = (props: {
      * We use a temporary value to store the value of the popup input. This is because
      * we don't want to update the graphParams until the user presses enter.
      */
-    const [ temporaryValue, setTemporaryValue ] = React.useState(props.value);
+    const [ temporaryValue, setTemporaryValue ] = React.useState(props.selectedGraphElement?.defaultValue);
     
     React.useEffect(() => {
-        setTemporaryValue(props.value);
-    }, [props.value]);
+        setTemporaryValue(props.selectedGraphElement?.defaultValue);
+    }, [props.selectedGraphElement?.defaultValue]);
 
     /**
      * The popup input is autofocusing, but when the popup is already open and we switch
@@ -55,50 +51,109 @@ export const Popup = (props: {
      */
     React.useEffect(() => {
         const input = document.getElementsByClassName('popup-input')[0] as HTMLInputElement;
-        input.focus();
-    }, [props.position])
+        input?.focus();
+    }, [props.selectedGraphElement?.popupPosition])
+
+    const caretPosition = props.selectedGraphElement?.element === 'gtitle' ? 'above' : props.selectedGraphElement?.element === 'ytitle' ? 'below-left' : 'below-centered'
 
     return (
         <div
-            className={`graph-element-popup-div ${props.caretPosition === 'above' ? 'graph-element-popup-div-caret-above' : props.caretPosition === 'below-left' ? 'graph-element-popup-div-caret-below-left' : 'graph-element-popup-div-caret-below-centered'}`}
+            className={`graph-element-popup-div ${caretPosition === 'above' ? 'graph-element-popup-div-caret-above' : caretPosition === 'below-left' ? 'graph-element-popup-div-caret-below-left' : 'graph-element-popup-div-caret-below-centered'}`}
             style={{
                 position: 'absolute',
                 height: '32px',
-                left: props.position.left,
-                right: props.position.right,
-                top: props.position.top,
-                bottom: props.position.bottom,
+                ...props.selectedGraphElement?.popupPosition
             }}
         >
-            <div className='graph-element-popup-div-caret'/>
-            <Input
-                className='popup-input'
-                value={temporaryValue}
-                style={{
-                    zIndex: 1,
-                    position: 'relative',
-                    width: getInputWidth(temporaryValue, 150),
+            <div>
+                <div className='graph-element-popup-div-caret'/>
+                <Input
+                    className='popup-input'
+                    value={temporaryValue ?? ''}
+                    style={{
+                        zIndex: 1,
+                        position: 'relative',
+                        width: getInputWidth(temporaryValue ?? '', 150),
+                    }}
+                    onKeyDown={(e) => {
+                        /**
+                         * Normally, when the user has a graph element selected, pressing backspace
+                         * should delete the element. However, we don't want to delete the element
+                         * when the user is typing in the popup input.
+                         */
+                        if (e.key === 'Backspace') {
+                            e.stopPropagation();
+                        }
+                        if (e.key === 'Enter') {
+                            props.setValue(temporaryValue ?? '');
+                        }
+                    }}
+                    autoFocus
+                    onChange={(e) => {
+                        setTemporaryValue(e.target.value);
+                    }}
+                />
+            </div>
+    </div>)
+}
+
+const GraphTitleContextMenu = (props: {
+    selectedGraphElement?: GraphElementType;
+    setSelectedGraphElement: (graphElement?: GraphElementType) => void;
+    graphOutput: GraphOutput;
+    setUIState: React.Dispatch<React.SetStateAction<UIState>>;
+    deleteSelectedGraphElement: () => void;
+}) => {
+    return (
+        <div
+            className='graph-element-context-menu'
+            style={{
+                position: 'absolute',
+                ...props.selectedGraphElement?.popupPosition
+            }}
+        >
+            <Dropdown
+                display={props.selectedGraphElement?.display === 'context-menu'}
+                closeDropdown={() => {
+                    props.setUIState(prevUIState => {
+                        if (prevUIState.currOpenTaskpane.type !== TaskpaneType.GRAPH
+                            || prevUIState.currOpenTaskpane.currentGraphElement?.display !== props.selectedGraphElement?.display) {
+                            return prevUIState;
+                        }
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {
+                                ...prevUIState.currOpenTaskpane,
+                                currentGraphElement: undefined,
+                            }
+                        }
+                    })
                 }}
-                onKeyDown={(e) => {
-                    /**
-                     * Normally, when the user has a graph element selected, pressing backspace
-                     * should delete the element. However, we don't want to delete the element
-                     * when the user is typing in the popup input.
-                     */
-                    if (e.key === 'Backspace') {
-                        e.stopPropagation();
-                    }
-                    if (e.key === 'Enter') {
-                        props.setValue(temporaryValue);
-                    }
-                }}
-                autoFocus
-                onChange={(e) => {
-                    setTemporaryValue(e.target.value);
-                }}
-            />
+            >
+                <DropdownItem
+                    onClick={() => {
+                        props.deleteSelectedGraphElement();
+                    }}
+                    supressFocusSettingOnClose
+                    title='Delete'
+                />
+                <DropdownItem
+                    onClick={() => {
+                        if (props.selectedGraphElement !== undefined) {
+                            const graphElementObjects = getGraphElementObjects(props.graphOutput);
+                            if (graphElementObjects === undefined) {
+                                return;
+                            }
+                            const elementInfo = getGraphElementInfoFromHTMLElement(graphElementObjects[props.selectedGraphElement.element], props.selectedGraphElement.element, props.graphOutput, 'editor');
+                            props.setSelectedGraphElement(elementInfo);
+                        }
+                    }}
+                    supressFocusSettingOnClose
+                    title='Edit Title'
+                />
+            </Dropdown>
         </div>
-    )
+    );
 }
 
 /*
@@ -178,13 +233,13 @@ const GraphSidebar = (props: {
     }, [currOpenTaskpane.graphSidebarOpen], props.mitoContainerRef, '#mito-center-content-container')
 
     const selectedGraphElement = props.uiState.currOpenTaskpane.type === TaskpaneType.GRAPH ? props.uiState.currOpenTaskpane.currentGraphElement : undefined;
-    const setSelectedGraphElement = (graphElement: GraphElementType | null) => {
+    const setSelectedGraphElement = (graphElement?: GraphElementType) => {
         props.setUIState(prevUIState => {
             return {
                 ...prevUIState,
                 currOpenTaskpane: {
                     ...prevUIState.currOpenTaskpane,
-                    currentGraphElement: graphElement === null ? undefined : graphElement,
+                    currentGraphElement: graphElement,
                 }
             }
         });
@@ -227,6 +282,18 @@ const GraphSidebar = (props: {
     const selectedGraphElementClass = selectedGraphElement !== undefined ? `${selectedGraphElement.element}-highlighted` : undefined;
     const containerRef = React.useRef<HTMLDivElement>(null);
 
+    const deleteSelectedGraphElement = () => {
+        const newGraphParams: RecursivePartial<GraphParamsFrontend> = {};
+        if (selectedGraphElement?.element === 'gtitle') {
+            newGraphParams.graphStyling = { title: { visible: false } };
+        } else if (selectedGraphElement?.element === 'xtitle') {
+            newGraphParams.graphStyling = { xaxis: { visible: false } };
+        } else if (selectedGraphElement?.element === 'ytitle') {
+            newGraphParams.graphStyling = { yaxis: { visible: false } };
+        }
+        setGraphParams(updateObjectWithPartialObject(graphParams, newGraphParams));
+    }
+
     return (
         <div
             className={classNames('graph-sidebar-div', selectedGraphElementClass)}
@@ -234,18 +301,10 @@ const GraphSidebar = (props: {
             ref={containerRef}
             onKeyDown={(e) => {
                 if (e.key === 'Backspace') {
-                    const newGraphParams: RecursivePartial<GraphParamsFrontend> = {};
-                    if (selectedGraphElement?.element === 'gtitle') {
-                        newGraphParams.graphStyling = { title: { visible: false } };
-                    } else if (selectedGraphElement?.element === 'xtitle') {
-                        newGraphParams.graphStyling = { xaxis: { visible: false } };
-                    } else if (selectedGraphElement?.element === 'ytitle') {
-                        newGraphParams.graphStyling = { yaxis: { visible: false } };
-                    }
-                    setGraphParams(updateObjectWithPartialObject(graphParams, newGraphParams));
+                    deleteSelectedGraphElement();
                 }
-                if ((e.key === 'Escape' || e.key === 'Enter') && (selectedGraphElement !== null)) {
-                    setSelectedGraphElement(null);
+                if ((e.key === 'Escape' || e.key === 'Enter') && (selectedGraphElement !== undefined)) {
+                    setSelectedGraphElement(undefined);
                 }
             }}
         >
@@ -267,8 +326,10 @@ const GraphSidebar = (props: {
                 {graphOutput !== undefined &&
                     <div dangerouslySetInnerHTML={{ __html: graphOutput.graphHTML }} />
                 }
-                <Popup
-                    value={(selectedGraphElement?.element === 'gtitle' ? graphParams?.graphStyling.title.title : selectedGraphElement?.element === 'xtitle' ? graphParams?.graphStyling.xaxis?.title : selectedGraphElement?.element === 'ytitle' ? graphParams?.graphStyling.yaxis?.title : '') ?? selectedGraphElement?.defaultValue ?? ''}
+                <GraphTitleEditorPopup
+                    setSelectedGraphElement={setSelectedGraphElement}
+                    selectedGraphElement={selectedGraphElement}
+                    graphOutput={graphOutput}
                     setValue={(value) => {
                         const update = {
                             graphStyling: {
@@ -293,10 +354,14 @@ const GraphSidebar = (props: {
                             true
                         );
                     }}
-                    caretPosition={selectedGraphElement?.element === 'gtitle' ? 'above' : selectedGraphElement?.element === 'ytitle' ? 'below-left' : 'below-centered'}
-                    position={selectedGraphElement?.popupPosition}
-                    onClose={() => setSelectedGraphElement(null)}
                     containerRef={containerRef}
+                />
+                <GraphTitleContextMenu
+                    setSelectedGraphElement={setSelectedGraphElement}
+                    selectedGraphElement={selectedGraphElement}
+                    graphOutput={graphOutput}
+                    setUIState={props.setUIState}
+                    deleteSelectedGraphElement={deleteSelectedGraphElement}
                 />
             </div>
             {currOpenTaskpane.graphSidebarOpen && <div className='graph-sidebar-toolbar-container'>

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -571,16 +571,18 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
         const titleDivTop = mitoDivBottom - clientRect.top + 10;
         const graphDivTop = mitoDivBottom - graphOutputTop;
         let left = clientRect.left - mitoDivLeft;
+        let bottom = Math.min(titleDivTop, graphDivTop);
         // Special case for ytitle, we don't want the context menu to be on top of the title,
         // so we move it to the right a bit
         if (display === 'context-menu') {
             left += 25;
+            bottom -= 25;
         }
         return {
             element: 'ytitle',
             popupPosition: {
                 left: left,
-                bottom: Math.min(titleDivTop, graphDivTop)
+                bottom: bottom
             },
             defaultValue: graphElement.children?.[0]?.innerHTML,
             display: display

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -569,6 +569,8 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
         return {
             element: 'ytitle',
             popupPosition: {
+                // Special case for ytitle, we don't want the context menu to be on top of the title,
+                // so we move it to the right a bit
                 left: display === 'context-menu' ? clientRect.left - parentDivLeft + 25 : clientRect.left - parentDivLeft,
                 bottom: parentDivBottom - clientRect.top + 10
             },

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -568,7 +568,8 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
             display: display
         }
     } else {
-        const titleDivTop = mitoDivBottom - clientRect.top + 10;
+        const top = display === 'context-menu' ? (clientRect.top + clientRect.bottom) / 2 : clientRect.top;
+        const titleDivTop = mitoDivBottom - top + 10;
         const graphDivTop = mitoDivBottom - graphOutputTop;
         let left = clientRect.left - mitoDivLeft;
         let bottom = Math.min(titleDivTop, graphDivTop);
@@ -576,7 +577,6 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
         // so we move it to the right a bit
         if (display === 'context-menu') {
             left += 25;
-            bottom -= 25;
         }
         return {
             element: 'ytitle',

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -32,8 +32,9 @@ export interface GraphElementType {
         bottom?: number,
     }
 
-    /** Whether to display the popup */
-    display: 'editor' | 'context-menu' | 'none'
+    /** This indicates whether to display the title editor popup, 
+     * the context menu, or just highlight the selected element */
+    display: 'popup-title-editor' | 'context-menu' | 'highlight-selected-element'
 }
 
 /**
@@ -526,7 +527,7 @@ export const getGraphElementObjects = (graphOutput: GraphOutput) => {
     }
 }
 
-export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elementType: 'gtitle' | 'xtitle' | 'ytitle', graphOutput: GraphOutput, display: 'editor' | 'context-menu' | 'none'): GraphElementType => {
+export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elementType: 'gtitle' | 'xtitle' | 'ytitle', graphOutput: GraphOutput, display: 'popup-title-editor' | 'context-menu' | 'highlight-selected-element'): GraphElementType => {
     const clientRect = graphElement.getBoundingClientRect()
 
     if (graphOutput === undefined) {
@@ -536,7 +537,7 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
                 left: 0,
                 top: 0
             },
-            display: 'none',
+            display: 'highlight-selected-element',
             defaultValue: ''
         }
     }
@@ -613,27 +614,27 @@ export const registerClickEventsForGraphElements = (graphOutput: GraphOutput, se
      * Set selected graph element when clicked
      */
     gtitle.addEventListener('click', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'gtitle', graphOutput, 'none'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'gtitle', graphOutput, 'highlight-selected-element'))
     })
     xtitle.addEventListener('click', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput, 'none'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput, 'highlight-selected-element'))
     })
     ytitle.addEventListener('click', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput, 'none'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput, 'highlight-selected-element'))
     })
 
     /**
      * Open popup when double clicked
      */
     gtitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(gtitle, 'gtitle', graphOutput, 'editor'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(gtitle, 'gtitle', graphOutput, 'popup-title-editor'))
     });
 
     xtitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput, 'editor'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(xtitle, 'xtitle', graphOutput, 'popup-title-editor'))
     });
 
     ytitle.addEventListener('dblclick', () => {
-        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput, 'editor'))
+        setSelectedGraphElement(getGraphElementInfoFromHTMLElement(ytitle, 'ytitle', graphOutput, 'popup-title-editor'))
     });
 }

--- a/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/mito/components/taskpanes/Graph/graphUtils.tsx
@@ -572,7 +572,7 @@ export const getGraphElementInfoFromHTMLElement = (graphElement: Element, elemen
         const titleDivTop = mitoDivBottom - top + 10;
         const graphDivTop = mitoDivBottom - graphOutputTop;
         let left = clientRect.left - mitoDivLeft;
-        let bottom = Math.min(titleDivTop, graphDivTop);
+        const bottom = Math.min(titleDivTop, graphDivTop);
         // Special case for ytitle, we don't want the context menu to be on top of the title,
         // so we move it to the right a bit
         if (display === 'context-menu') {

--- a/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
@@ -91,7 +91,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput, 'editor')
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput, 'popup-title-editor')
                                         },
                                     }
                                 })
@@ -113,7 +113,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput, 'editor')
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput, 'popup-title-editor')
                                         },
                                     }
                                 })
@@ -158,7 +158,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput, 'editor')
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput, 'popup-title-editor')
                                         },
                                     }
                                 })

--- a/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/GraphTabs/AddChartElementButton.tsx
@@ -91,7 +91,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.xtitle, 'xtitle', props.graphOutput, 'editor')
                                         },
                                     }
                                 })
@@ -113,7 +113,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.ytitle, 'ytitle', props.graphOutput, 'editor')
                                         },
                                     }
                                 })
@@ -158,7 +158,7 @@ export const AddChartElementButton = (
                                         currOpenDropdown: undefined,
                                         currOpenTaskpane: { 
                                             ...prevUIState.currOpenTaskpane, 
-                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput)
+                                            currentGraphElement: getGraphElementInfoFromHTMLElement(graphElementObjects.gtitle, 'gtitle', props.graphOutput, 'editor')
                                         },
                                     }
                                 })

--- a/tests/streamlit_ui_tests/graph.spec.ts
+++ b/tests/streamlit_ui_tests/graph.spec.ts
@@ -245,6 +245,37 @@ test.describe('Graph Functionality', () => {
     await openPopupAndEditTitle(mito, '.g-ytitle', 'Y axis Title');
   });
 
+  test('Update Y axis title with context menu', async ({ page }) => {
+    const mito = await getMitoFrameWithTypeCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+    await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+
+    await mito.locator('.g-ytitle').click({ button: 'right' });
+    await mito.getByRole('button', { name: 'Edit Title' }).click();
+    await awaitResponse(page);
+
+    await expect(mito.locator('.popup-input')).toBeVisible();
+    await mito.locator('.popup-input').fill('Y axis Title');
+    await mito.locator('.popup-input').press('Enter');
+
+    await awaitResponse(page);
+    await expect(mito.locator('.g-ytitle', { hasText: 'Y axis Title' })).toBeVisible();
+  });
+
+  test('Delete y axis title with context menu', async ({ page }) => {
+    const mito = await getMitoFrameWithTypeCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+    await expect(mito.locator('.g-ytitle', { hasText: 'Column1' })).toBeVisible();
+
+    await mito.locator('.g-ytitle').click({ button: 'right' });
+    await mito.getByRole('button', { name: 'Delete' }).click();
+    await awaitResponse(page);
+
+    await expect(mito.locator('.g-ytitle', { hasText: 'Column1' })).not.toBeVisible();
+  });
+
   test('Update Y axis Title with double click after interacting with the legend', async ({ page }) => {
     const mito = await getMitoFrameWithTypeCSV(page);
 

--- a/tests/streamlit_ui_tests/graph.spec.ts
+++ b/tests/streamlit_ui_tests/graph.spec.ts
@@ -13,6 +13,37 @@ const openPopupAndEditTitle = async (mito: any, selector: string, newTitle: stri
     await expect(mito.locator(selector, { hasText: newTitle })).toBeVisible();
 }
 
+const testEditTitleThroughContextMenu = async (page, selector) => {
+  const mito = await getMitoFrameWithTypeCSV(page);
+
+  await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+  await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+
+  await mito.locator(selector).click({ button: 'right' });
+  await mito.getByRole('button', { name: 'Edit Title' }).click();
+  await awaitResponse(page);
+
+  await expect(mito.locator('.popup-input')).toBeVisible();
+  await mito.locator('.popup-input').fill('New Title');
+  await mito.locator('.popup-input').press('Enter');
+
+  await awaitResponse(page);
+  await expect(mito.locator(selector, { hasText: 'New Title' })).toBeVisible();
+};
+
+const testDeleteTitleThroughContextMenu = async (page, selector) => {
+  const mito = await getMitoFrameWithTypeCSV(page);
+
+    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
+    await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+
+    await mito.locator(selector).click({ button: 'right' });
+    await mito.getByRole('button', { name: 'Delete' }).click();
+    await awaitResponse(page);
+
+    await expect(mito.locator(selector)).not.toBeVisible();
+};
+
 test.describe('Graph Functionality', () => {
     test('Graph', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
@@ -245,35 +276,28 @@ test.describe('Graph Functionality', () => {
     await openPopupAndEditTitle(mito, '.g-ytitle', 'Y axis Title');
   });
 
+  test('Update graph title with context menu', async ({ page }) => {
+    await testEditTitleThroughContextMenu(page, '.g-gtitle');
+  });
+
+  test('Update X axis title with context menu', async ({ page }) => {
+    await testEditTitleThroughContextMenu(page, '.g-xtitle');
+  });
+
   test('Update Y axis title with context menu', async ({ page }) => {
-    const mito = await getMitoFrameWithTypeCSV(page);
+    await testEditTitleThroughContextMenu(page, '.g-ytitle');
+  });
 
-    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
-    await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+  test('Delete graph title with context menu', async ({ page }) => {
+    await testDeleteTitleThroughContextMenu(page, '.g-gtitle');
+  });
 
-    await mito.locator('.g-ytitle').click({ button: 'right' });
-    await mito.getByRole('button', { name: 'Edit Title' }).click();
-    await awaitResponse(page);
-
-    await expect(mito.locator('.popup-input')).toBeVisible();
-    await mito.locator('.popup-input').fill('Y axis Title');
-    await mito.locator('.popup-input').press('Enter');
-
-    await awaitResponse(page);
-    await expect(mito.locator('.g-ytitle', { hasText: 'Y axis Title' })).toBeVisible();
+  test('Delete x axis title with context menu', async ({ page }) => {
+    await testDeleteTitleThroughContextMenu(page, '.g-xtitle');
   });
 
   test('Delete y axis title with context menu', async ({ page }) => {
-    const mito = await getMitoFrameWithTypeCSV(page);
-
-    await clickButtonAndAwaitResponse(page, mito, { name: 'Graph' })
-    await expect(mito.locator('.g-ytitle', { hasText: 'Column1' })).toBeVisible();
-
-    await mito.locator('.g-ytitle').click({ button: 'right' });
-    await mito.getByRole('button', { name: 'Delete' }).click();
-    await awaitResponse(page);
-
-    await expect(mito.locator('.g-ytitle', { hasText: 'Column1' })).not.toBeVisible();
+    await testDeleteTitleThroughContextMenu(page, '.g-ytitle');
   });
 
   test('Update Y axis Title with double click after interacting with the legend', async ({ page }) => {

--- a/tests/streamlit_ui_tests/graph.spec.ts
+++ b/tests/streamlit_ui_tests/graph.spec.ts
@@ -38,7 +38,7 @@ const testDeleteTitleThroughContextMenu = async (page, selector) => {
     await expect(mito.getByText('Column1 bar chart')).toBeVisible();
 
     await mito.locator(selector).click({ button: 'right' });
-    await mito.getByRole('button', { name: 'Delete' }).click();
+    await mito.getByRole('button', { name: 'Delete Title' }).click();
     await awaitResponse(page);
 
     await expect(mito.locator(selector)).not.toBeVisible();


### PR DESCRIPTION
Adds context menus to the graph, x, and y axis titles:
![title editors](https://github.com/mito-ds/mito/assets/6673460/0fa01603-f0be-4185-97c2-8d72a2c44a18)
