### PR TITLE
mitosheet: left align dropdown item subtext

### DIFF
--- a/mitosheet/css/elements/DropdownItem.css
+++ b/mitosheet/css/elements/DropdownItem.css
@@ -49,8 +49,8 @@
 }
 
 .mito-dropdown-item-subtext-container {
+    text-align: left;
     margin-top: 4px;
-
     cursor: default;
 }
 


### PR DESCRIPTION
# Description

Fixes text alignment in dropdowns. Multi line dropdown item subtext was appeared centered like this. Now they are left aligned!

<img width="561" alt="Screenshot 2024-02-13 at 3 33 42 PM" src="https://github.com/mito-ds/mito/assets/18709905/702c3cfb-0ae3-456c-9f7b-4a7a2d7ca5ce">

# Testing

Try it out. 

# Documentation

No. 