### PR TITLE
Prevent overwriting code when the user has made changes to the generated code cell

### DIFF
--- a/mitosheet/src/jupyter/code.tsx
+++ b/mitosheet/src/jupyter/code.tsx
@@ -1,6 +1,8 @@
 // Utilities for working with the generated code
 
 import { PublicInterfaceVersion } from "../mito";
+import { getCellText } from "./lab/extensionUtils";
+import { ICellModel } from '@jupyterlab/cells';
 
 const IMPORT_STATEMENTS = [
     'from mitosheet.public.v1 import *',
@@ -138,6 +140,22 @@ export function containsMitosheetCallWithAnyAnalysisToReplay(codeText: string): 
 */
 export function containsGeneratedCodeOfAnalysis(codeText: string, analysisName: string): boolean {
     return isMitoAnalysisCode(codeText) && codeText.includes(analysisName);
+}
+
+/**
+ * This function is used to identify if the user has changed the contents of the code
+ * cell that Mito is using to store the generated code. We need to know this to avoid
+ * overwriting the user's code with the generated code.
+ * @param oldCode - The last analysisData code that was written to the cell
+ * @param codeCell - The cell that contains the code
+ * @returns boolean indicating if the code cell has been changed
+ */
+export function hasCodeCellValueChanged(oldCode: string[], codeCell?: ICellModel): boolean {
+    // We're removing the first line of the old code and the cell code because
+    // the cell code contains the analysis id and the old code does not
+    const oldCodeWithoutFirstLine = oldCode?.slice(1).join('\n');
+    const cellCodeWithoutFirstLine = getCellText(codeCell)?.split('\n').slice(1).join('\n');
+    return oldCodeWithoutFirstLine !== cellCodeWithoutFirstLine;
 }
 
 // Removes all whitespace from a string, except for whitespace in quoted strings.

--- a/mitosheet/src/jupyter/code.tsx
+++ b/mitosheet/src/jupyter/code.tsx
@@ -150,7 +150,7 @@ export function containsGeneratedCodeOfAnalysis(codeText: string, analysisName: 
  * @param codeCell - The cell that contains the code
  * @returns boolean indicating if the code cell has been changed
  */
-export function hasCodeCellValueChanged(oldCode: string[], codeCell?: ICellModel): boolean {
+export function hasCodeCellBeenEditedByUser(oldCode: string[], codeCell?: ICellModel): boolean {
     // We're removing the first line of the old code and the cell code because
     // the cell code contains the analysis id and the old code does not
     const oldCodeWithoutFirstLine = oldCode?.slice(1).join('\n');

--- a/mitosheet/src/jupyter/jupyterUtils.tsx
+++ b/mitosheet/src/jupyter/jupyterUtils.tsx
@@ -52,7 +52,7 @@ export const overwriteAnalysisToReplayToMitosheetCall = (oldAnalysisName: string
 }
 
 
-export const writeGeneratedCodeToCell = (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]): void => {
+export const writeGeneratedCodeToCell = (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode: string[]): void => {
     if (isInJupyterLab()) {
         window.commands?.execute('mitosheet:write-generated-code-cell', {
             analysisName: analysisName,

--- a/mitosheet/src/jupyter/jupyterUtils.tsx
+++ b/mitosheet/src/jupyter/jupyterUtils.tsx
@@ -62,7 +62,7 @@ export const writeGeneratedCodeToCell = (analysisName: string, code: string[], t
             oldCode: oldCode
         });
     } else if (isInJupyterNotebook()) {
-        notebookWriteGeneratedCodeToCell(analysisName, code, telemetryEnabled, publicInterfaceVersion);
+        notebookWriteGeneratedCodeToCell(analysisName, code, telemetryEnabled, publicInterfaceVersion, oldCode);
     } else {
         console.error("Not detected as in Jupyter Notebook or JupyterLab")
     }

--- a/mitosheet/src/jupyter/jupyterUtils.tsx
+++ b/mitosheet/src/jupyter/jupyterUtils.tsx
@@ -52,13 +52,14 @@ export const overwriteAnalysisToReplayToMitosheetCall = (oldAnalysisName: string
 }
 
 
-export const writeGeneratedCodeToCell = (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion): void => {
+export const writeGeneratedCodeToCell = (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]): void => {
     if (isInJupyterLab()) {
         window.commands?.execute('mitosheet:write-generated-code-cell', {
             analysisName: analysisName,
             code: code,
             telemetryEnabled: telemetryEnabled,
-            publicInterfaceVersion: publicInterfaceVersion
+            publicInterfaceVersion: publicInterfaceVersion,
+            oldCode: oldCode
         });
     } else if (isInJupyterNotebook()) {
         notebookWriteGeneratedCodeToCell(analysisName, code, telemetryEnabled, publicInterfaceVersion);

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -1,6 +1,6 @@
 import { PublicInterfaceVersion } from "../../mito";
 import { MitoAPI } from "../../mito/api/api";
-import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, containsMitosheetCallWithSpecificAnalysisToReplay, getArgsFromMitosheetCallCode, getCodeString, hasCodeCellValueChanged, isMitosheetCallCode, removeWhitespaceInPythonCode } from "../code";
+import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, containsMitosheetCallWithSpecificAnalysisToReplay, getArgsFromMitosheetCallCode, getCodeString, hasCodeCellBeenEditedByUser, isMitosheetCallCode, removeWhitespaceInPythonCode } from "../code";
 
 type CellType = any;
 
@@ -230,7 +230,7 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
     const codeCell = getCellAtIndex(mitosheetCallIndex + 1);
 
     if (isEmptyCell(codeCell) || containsGeneratedCodeOfAnalysis(getCellText(codeCell), analysisName)) {
-        if (!isEmptyCell(codeCell) && hasCodeCellValueChanged(oldCode, codeCell)) {
+        if (!isEmptyCell(codeCell) && hasCodeCellBeenEditedByUser(oldCode, codeCell)) {
             return;
         }
         writeToCell(codeCell, code)

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -1,6 +1,6 @@
 import { PublicInterfaceVersion } from "../../mito";
 import { MitoAPI } from "../../mito/api/api";
-import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, containsMitosheetCallWithSpecificAnalysisToReplay, getArgsFromMitosheetCallCode, getCodeString, isMitosheetCallCode, removeWhitespaceInPythonCode } from "../code";
+import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, containsMitosheetCallWithSpecificAnalysisToReplay, getArgsFromMitosheetCallCode, getCodeString, hasCodeCellValueChanged, isMitosheetCallCode, removeWhitespaceInPythonCode } from "../code";
 
 type CellType = any;
 
@@ -229,14 +229,8 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
 
     const codeCell = getCellAtIndex(mitosheetCallIndex + 1);
 
-
-    // We're removing the first line of the old code and the cell code because
-    // the cell code contains the analysis id and the old code does not
-    const oldCodeWithoutFirstLine = oldCode?.slice(1).join('\n');
-    const cellCodeWithoutFirstLine = getCellText(codeCell)?.split('\n').slice(1).join('\n');
-
     if (isEmptyCell(codeCell) || containsGeneratedCodeOfAnalysis(getCellText(codeCell), analysisName)) {
-        if (!isEmptyCell(codeCell) && oldCodeWithoutFirstLine !== cellCodeWithoutFirstLine) {
+        if (!isEmptyCell(codeCell) && hasCodeCellValueChanged(oldCode, codeCell)) {
             return;
         }
         writeToCell(codeCell, code)

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -207,7 +207,7 @@ export const notebookOverwriteAnalysisToReplayToMitosheetCall = (oldAnalysisName
     }
 }
 
-export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]): void => {
+export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode: string[]): void => {
     const code = getCodeString(analysisName, codeLines, telemetryEnabled, publicInterfaceVersion);
         
     // Find the cell that made the mitosheet.sheet call, and if it does not exist, give

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -207,7 +207,7 @@ export const notebookOverwriteAnalysisToReplayToMitosheetCall = (oldAnalysisName
     }
 }
 
-export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion): void => {
+export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]): void => {
     const code = getCodeString(analysisName, codeLines, telemetryEnabled, publicInterfaceVersion);
         
     // Find the cell that made the mitosheet.sheet call, and if it does not exist, give
@@ -229,7 +229,16 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
 
     const codeCell = getCellAtIndex(mitosheetCallIndex + 1);
 
+
+    // We're removing the first line of the old code and the cell code because
+    // the cell code contains the analysis id and the old code does not
+    const oldCodeWithoutFirstLine = oldCode?.slice(1).join('\n');
+    const cellCodeWithoutFirstLine = getCellText(codeCell)?.split('\n').slice(1).join('\n');
+
     if (isEmptyCell(codeCell) || containsGeneratedCodeOfAnalysis(getCellText(codeCell), analysisName)) {
+        if (!isEmptyCell(codeCell) && oldCodeWithoutFirstLine !== cellCodeWithoutFirstLine) {
+            return;
+        }
         writeToCell(codeCell, code)
     } else {
         // If we cannot write to the cell below, we have to go back a new cell below, 

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -93,7 +93,7 @@ export type MitoProps = {
     jupyterUtils?: {
         getArgs: (analysisToReplayName: string | undefined) => Promise<string[]>,
         writeAnalysisToReplayToMitosheetCall: (analysisName: string, mitoAPI: MitoAPI) => void
-        writeGeneratedCodeToCell: (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]) => void
+        writeGeneratedCodeToCell: (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode: string[]) => void
         writeCodeSnippetCell: (analysisName: string, code: string) => void
         overwriteAnalysisToReplayToMitosheetCall: (oldAnalysisName: string, newAnalysisName: string, mitoAPI: MitoAPI) => void
     }

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -93,7 +93,7 @@ export type MitoProps = {
     jupyterUtils?: {
         getArgs: (analysisToReplayName: string | undefined) => Promise<string[]>,
         writeAnalysisToReplayToMitosheetCall: (analysisName: string, mitoAPI: MitoAPI) => void
-        writeGeneratedCodeToCell: (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion) => void
+        writeGeneratedCodeToCell: (analysisName: string, code: string[], telemetryEnabled: boolean, publicInterfaceVersion: PublicInterfaceVersion, oldCode?: string[]) => void
         writeCodeSnippetCell: (analysisName: string, code: string) => void
         overwriteAnalysisToReplayToMitosheetCall: (oldAnalysisName: string, newAnalysisName: string, mitoAPI: MitoAPI) => void
     }
@@ -279,6 +279,10 @@ export const Mito = (props: MitoProps): JSX.Element => {
         }
     }, [mitoAPI, sendFunctionStatus])
 
+    // We're storing the last analysisData in a ref so that we can check the
+    // analysisData's code against the code in the cell and make sure we aren't
+    // overwriting any changes the user might have made. 
+    const oldCodeRef = useRef(analysisData.code);
     useEffect(() => {
         /**
          * We only write code after the render count has been incremented once, which
@@ -286,8 +290,10 @@ export const Mito = (props: MitoProps): JSX.Element => {
          */
         if (analysisData.renderCount >= 1) {
             // Finially, we can go and write the code!
-            props.jupyterUtils?.writeGeneratedCodeToCell(analysisData.analysisName, analysisData.code, userProfile.telemetryEnabled, analysisData.publicInterfaceVersion);
+            props.jupyterUtils?.writeGeneratedCodeToCell(analysisData.analysisName, analysisData.code, userProfile.telemetryEnabled, analysisData.publicInterfaceVersion, oldCodeRef?.current);
         }
+        // After using the ref to get the old code, we update it to the newest analysis.
+        oldCodeRef.current = analysisData.code;
         // TODO: we should store some data with analysis data to not make
         // this run too often?
     }, [analysisData])

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -9,7 +9,7 @@ import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application'
 import { ToolbarButton } from '@jupyterlab/apputils';
 import { INotebookTracker, NotebookActions } from '@jupyterlab/notebook';
 import { mitoJLabIcon } from './jupyter/MitoIcon';
-import { containsGeneratedCodeOfAnalysis, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, hasCodeCellValueChanged } from './jupyter/code';
+import { containsGeneratedCodeOfAnalysis, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, hasCodeCellBeenEditedByUser } from './jupyter/code';
 import { LabComm } from './jupyter/comm';
 import {
     getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell
@@ -166,7 +166,7 @@ function activateMitosheetExtension(
 
             if (isEmptyCell(codeCell) || containsGeneratedCodeOfAnalysis(getCellText(codeCell), analysisName)) {
                 // Prevent overwriting the cell if the user has changed the code
-                if (!isEmptyCell(codeCell) && hasCodeCellValueChanged(oldCode, codeCell)) {
+                if (!isEmptyCell(codeCell) && hasCodeCellBeenEditedByUser(oldCode, codeCell)) {
                     return;
                 }
                 writeToCell(codeCell, code)


### PR DESCRIPTION
Updates the execute function of `writeGeneratedCodeToCell` to take `oldCode` as an input and prevent overwriting changes if the code in the cell is different from the Mito generated code. This required adding a `ref` to keep track of the last mito-generated code in the analysis json and updating it after the call to `writeGeneratedCodeToCell`. 