### PR TITLE
mitosheet: fix pd. usage in lambda functions in ai generated code

### DIFF
--- a/mitosheet/mitosheet/ai/recon.py
+++ b/mitosheet/mitosheet/ai/recon.py
@@ -81,12 +81,20 @@ def exec_for_recon(code: str, original_df_map: Dict[str, pd.DataFrame]) -> Dataf
     for df_name in potentially_modified_df_names:
         locals()[df_name] = df_map[df_name]
 
+    # If there are lambda expressions in the code, then we need to also 
+    # inject the pandas and numpy modules in as globals -- as for some
+    # reason the code inside of a lambda doesn't have access to them
+    globals = {}
+    if 'lambda' in code:
+        globals['pd'] = pd
+        globals['np'] = np
+
     # Capture the output as well
     output_string_io = StringIO()
 
     try:
         with redirect_stdout(output_string_io):
-            exec(code, {}, locals())
+            exec(code, globals, locals())
     except Exception as e:
         raise make_exec_error(e)
         

--- a/mitosheet/mitosheet/tests/step_performers/test_ai_transformation.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_ai_transformation.py
@@ -7,6 +7,7 @@
 Contains tests for AI Transformation
 """
 
+import datetime
 import pandas as pd
 import pytest
 from mitosheet.tests.test_utils import create_mito_wrapper
@@ -157,6 +158,21 @@ df1.rename(columns={'A': 'B', 'B': 'B'}, inplace=True)
 """,
         [
             pd.DataFrame({'A': [1, 2, 3], 'B': [1.0, 2.0, 3.0]})
+        ]
+    ),
+    # Split a date and time into two components
+    (
+        [
+            pd.DataFrame({'Date': pd.to_datetime(['1997-07-16T19:20'])})
+        ],
+        """
+import pandas as pd
+
+
+df1[['Date', 'Time']] = df1['Date'].apply(lambda x: pd.Series([x.date(), x.time()]))
+""",
+        [
+            pd.DataFrame({'Date': [datetime.date(1997, 7, 16)], 'Time': [datetime.time(19, 20)]})
         ]
     ),
 ]


### PR DESCRIPTION
# Description

If pandas was accessed in a lambda function, global scope was not captured correctly in our usage of exec. This resulted in code that was correct like:
```
import pandas as pd
df1 = pd.DataFrame({'Date': pd.to_datetime(['1997-07-16T19:20'])})
df1[['Date', 'Time']] = df1['Date'].apply(lambda x: pd.Series([x.date(), x.time()]))
```

Erroring because pandas was not defined (thought it clearly was).

# Testing

See new test to catch this in the future.

# Documentation

No.