### PR TITLE
trymito: remove rel=noreferrer from links to docs

### DIFF
--- a/trymito.io/components/Footer/Footer.tsx
+++ b/trymito.io/components/Footer/Footer.tsx
@@ -71,7 +71,7 @@ const Footer = (): JSX.Element => {
                         Resources
                     </ol>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
+                        <a href='https://docs.trymito.io' target="_blank" rel="noopener">Docs</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
                         <Link href='/excel-to-python/'>Excel to Python</Link>
@@ -80,16 +80,16 @@ const Footer = (): JSX.Element => {
                         <Link href='/blog'>Blog</Link>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">GitHub</a>
+                        <a href={MITO_GITHUB_LINK} target="_blank" rel="noopener">GitHub</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://discord.gg/XdJSZyejJU' target="_blank" rel="noreferrer">Discord</a>
+                        <a href='https://discord.gg/XdJSZyejJU' target="_blank" rel="noopener">Discord</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://join.slack.com/t/trymito/shared_invite/zt-1h6t163v7-xLPudO7pjQNKccXz7h7GSg' target="_blank" rel="noreferrer">Slack</a>
+                        <a href='https://join.slack.com/t/trymito/shared_invite/zt-1h6t163v7-xLPudO7pjQNKccXz7h7GSg' target="_blank" rel="noopener">Slack</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noreferrer">Install</a>
+                        <a href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noopener">Install</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
                         <Link href='/teams'>Teams</Link>
@@ -100,25 +100,25 @@ const Footer = (): JSX.Element => {
                         Company
                     </ol>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">Jobs</a>
+                        <a href={JOBS_BOARD_LINK} target="_blank" rel="noopener">Jobs</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
                         <Link href='/security'>Security</Link>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://docs.trymito.io/misc/terms-of-service' target="_blank" rel="noreferrer">Terms</a>
+                        <a href='https://docs.trymito.io/misc/terms-of-service' target="_blank" rel="noopener">Terms</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://privacy.trymito.io/privacy-policy' target="_blank" rel="noreferrer">Privacy</a>
+                        <a href='https://privacy.trymito.io/privacy-policy' target="_blank" rel="noopener">Privacy</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://twitter.com/tryMito' target="_blank" rel="noreferrer">Twitter</a>
+                        <a href='https://twitter.com/tryMito' target="_blank" rel="noopener">Twitter</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://www.youtube.com/channel/UCN9o_0m1fwCjigfIpnKr0oA/videos' target="_blank" rel="noreferrer">YouTube</a>
+                        <a href='https://www.youtube.com/channel/UCN9o_0m1fwCjigfIpnKr0oA/videos' target="_blank" rel="noopener">YouTube</a>
                     </li>
                     <li className={classNames(footerStyle.nav_item)}>
-                        <a href='https://join.slack.com/t/trymito/shared_invite/zt-1h6t163v7-xLPudO7pjQNKccXz7h7GSg' target="_blank" rel="noreferrer">Contact</a>
+                        <a href='https://join.slack.com/t/trymito/shared_invite/zt-1h6t163v7-xLPudO7pjQNKccXz7h7GSg' target="_blank" rel="noopener">Contact</a>
                     </li>
                 </div>
             </div>

--- a/trymito.io/components/GithubButton/GithubButton.tsx
+++ b/trymito.io/components/GithubButton/GithubButton.tsx
@@ -12,7 +12,7 @@ const GithubButton = (props: {variant: GithubButtonVariant, text: string}): JSX.
     const href = props.variant === 'Star' ? MITO_GITHUB_LINK : MTIO_GITHUB_DISCUSSION_LINK
 
     return (
-        <a href={href} rel="noreferrer" target="_blank">
+        <a href={href} rel="noopener" target="_blank">
             <button className={stylesGithubButton.github_button}>
                 <Image src={imageSrc} height='20rem' width='20rem' alt='Github button icon' />
                 <p>

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -154,7 +154,7 @@ const Header = (): JSX.Element => {
                 </HeaderDropdown>
 
                 <li className={classNames('highlight-on-hover', headerStyles.nav_item)}>
-                  <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
+                  <a href='https://docs.trymito.io' target="_blank" rel="noopener">Docs</a>
                 </li>
               </ul>
             </nav>
@@ -234,10 +234,10 @@ const Header = (): JSX.Element => {
                   <Link href='/excel-to-python'>Excel to Python Glossary</Link>
                 </li>
                 <li className='highlight-on-hover'>
-                  <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
+                  <a href='https://docs.trymito.io' target="_blank" rel="noopener">Docs</a>
                 </li>
                 <li className='highlight-on-hover'>
-                  <a href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">GitHub</a>
+                  <a href={MITO_GITHUB_LINK} target="_blank" rel="noopener">GitHub</a>
                 </li>
               </ul>
             </nav>

--- a/trymito.io/components/InstallInstructions/InstallInstructions.tsx
+++ b/trymito.io/components/InstallInstructions/InstallInstructions.tsx
@@ -11,7 +11,7 @@ const InstallInstructions = (props: {}): JSX.Element => {
     return (
         <>
             <h2 style={{textAlign: 'center'}}>
-                Install <span className='text-highlight'><a className={pageStyles.link} href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">open-source</a></span> Mito <br/>
+                Install <span className='text-highlight'><a className={pageStyles.link} href={MITO_GITHUB_LINK} target="_blank" rel="noopener">open-source</a></span> Mito <br/>
                 in under a minute
             </h2>
             <div className={installInstructions.install_instructions_container}>

--- a/trymito.io/components/StreamlitAppCard/StreamlitAppCard.tsx
+++ b/trymito.io/components/StreamlitAppCard/StreamlitAppCard.tsx
@@ -26,7 +26,7 @@ const StreamlitAppCard = (props: {
                 height={132}
                 onClick={() => window.open(props.streamlitHref, '_blank')}
             />
-            <a href={props.streamlitHref} target="_blank" rel="noreferrer" className={streamlitAppCardStyles.title_text}>
+            <a href={props.streamlitHref} target="_blank" rel="noopener" className={streamlitAppCardStyles.title_text}>
                 {props.title}
             </a>
             <p className={streamlitAppCardStyles.description}>
@@ -34,7 +34,7 @@ const StreamlitAppCard = (props: {
             </p>
             
             <div className={streamlitAppCardStyles.footer}>
-                <a href={props.gitHubHref} target="_blank" rel="noreferrer" className={streamlitAppCardStyles.view_code}>
+                <a href={props.gitHubHref} target="_blank" rel="noopener" className={streamlitAppCardStyles.view_code}>
                     View Code →
                 </a>
                 <p className={streamlitAppCardStyles.hashtag}>

--- a/trymito.io/pages/data-app.tsx
+++ b/trymito.io/pages/data-app.tsx
@@ -49,7 +49,7 @@ const DataApp: NextPage = () => {
                         <source src={'/data-app/data-verification-app.mp4'} />
                     </video>
                 </div>
-                <a href={DATA_VERIFICATION_STREAMLIT_APP_LINK} target="_blank" rel="noreferrer" className={pageStyles.link_with_p_tag_margins}>
+                <a href={DATA_VERIFICATION_STREAMLIT_APP_LINK} target="_blank" rel="noopener" className={pageStyles.link_with_p_tag_margins}>
                     Try this app now →
                 </a>
             </section>

--- a/trymito.io/pages/excel-to-python.tsx
+++ b/trymito.io/pages/excel-to-python.tsx
@@ -221,7 +221,7 @@ const ExcelToPythonHomePage = (props: {glossaryPageInfo: GlossaryPageInfo[]}) =>
                                             We&apos;ve implemented all of Excel&apos;s most powerful features in Python so you don&apos;t have to look through documentation like this!
                                             Use Excel formulas, create pivot tables, filter your data, build graphs, and more. 
                                         </p>
-                                        <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noreferrer" className={pageStyles.link_with_p_tag_margins}>
+                                        <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noopener" className={pageStyles.link_with_p_tag_margins}>
                                             View all 100+ transformations →
                                         </a>
                                     </div>

--- a/trymito.io/pages/index.tsx
+++ b/trymito.io/pages/index.tsx
@@ -122,7 +122,7 @@ const Home: NextPage = () => {
                   Stop sitting through Python trainings or waiting for IT support. 
                   Take automation into your own hands using the tools you already know.
                 </p>
-                <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noreferrer" className={pageStyles.link_with_p_tag_margins}>
+                <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noopener" className={pageStyles.link_with_p_tag_margins}>
                   View all 100+ transformations →
                 </a>
               </div>
@@ -240,7 +240,7 @@ const Home: NextPage = () => {
             <FAQCard title='Is Mito open source?'>
               <div>
                 <p>
-                  Mito is an open source project, and the codebase is available on <a className={pageStyles.link} href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">Github</a>.
+                  Mito is an open source project, and the codebase is available on <a className={pageStyles.link} href={MITO_GITHUB_LINK} target="_blank" rel="noopener">Github</a>.
                 </p>
                 <p>
                   Outside contributions are welcome and encouraged! 
@@ -250,7 +250,7 @@ const Home: NextPage = () => {
             <FAQCard title='Is Mito free?'>
               <div>
                 <p>
-                  Mito Open Source is free. You can install Mito by following the install instructions <a className={pageStyles.link} href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noreferrer">here</a>.
+                  Mito Open Source is free. You can install Mito by following the install instructions <a className={pageStyles.link} href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noopener">here</a>.
                 </p>
                 <p>
                   For individuals automating spreadsheet processes, we offer a Pro version. Mito Pro includes unlimited AI completions, disabling all telemetry, and additional formatting and transformation options.
@@ -269,7 +269,7 @@ const Home: NextPage = () => {
                   Mito is a Jupyter extension that runs in JupyterLab, Jupyter notebooks, and JupyterHub.
                 </p>
                 <p>
-                  You can install Mito by following the install instructions <a className={pageStyles.link} href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noreferrer">here</a>.
+                  You can install Mito by following the install instructions <a className={pageStyles.link} href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noopener">here</a>.
                 </p>
               </div>
             </FAQCard>

--- a/trymito.io/pages/industries/financial-services.tsx
+++ b/trymito.io/pages/industries/financial-services.tsx
@@ -83,7 +83,7 @@ const Security: NextPage = () => {
                                     Speeding up report generation not only lets analysts work on higher priority work, it also means that reports can be updated frequently so you&apos;re always working with the most up to date data.
                                 </p>
                                 <p>
-                                    See how the Director of Finance at Enigma saved himself 16 hours per month <a className={classNames('margin-0', pageStyles.link)} href="https://trymito.io/blog/enigma-case-study/" rel="noreferrer" target='_blank'>using Mito</a>.
+                                    See how the Director of Finance at Enigma saved himself 16 hours per month <a className={classNames('margin-0', pageStyles.link)} href="https://trymito.io/blog/enigma-case-study/" rel="noopener" target='_blank'>using Mito</a>.
                                 </p>
                             </div>
                             <div className={classNames(pageStyles.subsection_column)}>

--- a/trymito.io/pages/industries/life-sciences.tsx
+++ b/trymito.io/pages/industries/life-sciences.tsx
@@ -13,10 +13,10 @@ import textImageSplitStyles from '../../styles/TextImageSplit.module.css';
 
 // Import Icons & Background Grid
 import { classNames } from '../../utils/classNames';
-import CTAButtons from '../../components/CTAButtons/CTAButtons';
+import Buttons from '../../components/Buttons/Buttons';
 import FAQCard from '../../components/FAQCard/FAQCard';
-import ContactCTACard from '../../components/CTACards/ContactCTACard';
-import { PLAUSIBLE_INSTALL_DOCS_CTA_LOCATION_TITLE_CARD } from '../../utils/plausible';
+import ContactCard from '../../components/Cards/ContactCard';
+import { PLAUSIBLE_INSTALL_DOCS__LOCATION_TITLE_CARD } from '../../utils/plausible';
 
 const LifeSciences: NextPage = () => {
 
@@ -40,7 +40,7 @@ const LifeSciences: NextPage = () => {
               <p className={classNames(titleStyles.subtitle)}>
                 Intuitive Python automation tools that let you focus on the science.
               </p>
-              <CTAButtons variant={'download'} align='left' textButtonClassName={PLAUSIBLE_INSTALL_DOCS_CTA_LOCATION_TITLE_CARD}/>
+              <Buttons variant={'download'} align='left' textButtonClassName={PLAUSIBLE_INSTALL_DOCS__LOCATION_TITLE_CARD}/>
             </div>
             <div className={classNames(spreadsheetAutomationStyles.hero_video_container)}>
               <video autoPlay loop disablePictureInPicture playsInline webkit-playsinline="true" muted>
@@ -83,7 +83,7 @@ const LifeSciences: NextPage = () => {
                   It&apos;s nearly impossible to verify Excel models don&apos;t contain manual mistakes like typos and accidental data manipulation.
                 </p> 
                 <p>
-                  According to an <a href="https://www.nature.com/articles/d41586-021-02211-4" target="_blank" rel="noreferrer" className={pageStyles.link}>article</a> published by Nature, “Despite geneticists being warned about spreadsheet problems, 30% of published papers contain mangled gene names in supplementary data.”
+                  According to an <a href="https://www.nature.com/articles/d41586-021-02211-4" target="_blank" rel="noopener" className={pageStyles.link}>article</a> published by Nature, “Despite geneticists being warned about spreadsheet problems, 30% of published papers contain mangled gene names in supplementary data.”
                 </p>    
               </div>
               <div className={classNames(pageStyles.subsection_column)}>
@@ -136,7 +136,7 @@ const LifeSciences: NextPage = () => {
                   Bioinformatics
                 </h2>
                 <p> 
-                  Use Python libraries specifically designed for bioinformatics research, like <a href="https://biopython.org" target="_blank" rel="noreferrer" className={pageStyles.link}>BioPython</a>, to parse bioinformatics files, perform k Nearest Neighbors classifications, and common operations like translation and transcription. 
+                  Use Python libraries specifically designed for bioinformatics research, like <a href="https://biopython.org" target="_blank" rel="noopener" className={pageStyles.link}>BioPython</a>, to parse bioinformatics files, perform k Nearest Neighbors classifications, and common operations like translation and transcription. 
                 </p>
                 <p>
                   Use Mito to visualize and clean your data without bouncing back and forth between Excel and Python.
@@ -192,7 +192,7 @@ const LifeSciences: NextPage = () => {
           </section>
 
           <section className={pageStyles.background_card}>
-            <ContactCTACard />
+            <ContactCard />
           </section>
         </main>
         <Footer />

--- a/trymito.io/pages/security.tsx
+++ b/trymito.io/pages/security.tsx
@@ -65,7 +65,7 @@ const Security: NextPage = () => {
                 <p>
                   If you want to see the code that&apos;s running on your computer, you can. Mito is dedicated to building in public. 
                 </p>
-                <a className={pageStyles.link_with_p_tag_margins} href={MITO_GITHUB_LINK} rel="noreferrer" target='_blank'>
+                <a className={pageStyles.link_with_p_tag_margins} href={MITO_GITHUB_LINK} rel="noopener" target='_blank'>
                   See our Github →
                 </a>
               </div>
@@ -97,7 +97,7 @@ const Security: NextPage = () => {
                 <p>
                   We don&apos;t want any data you don&apos;t want us to have. CCPA compliance means you stay in control of everything. 
                 </p>
-                <a className={pageStyles.link_with_p_tag_margins} href='https://privacy.trymito.io/privacy-policy' rel="noreferrer" target='_blank'>
+                <a className={pageStyles.link_with_p_tag_margins} href='https://privacy.trymito.io/privacy-policy' rel="noopener" target='_blank'>
                   See our Privacy Policy → 
                 </a>
               </div>
@@ -113,7 +113,7 @@ const Security: NextPage = () => {
                 <p>
                   Once you have Mito installed, you&apos;re in total control of which version you run. Upgrade when you want to.
                 </p>
-                <a className={pageStyles.link_with_p_tag_margins} href='https://docs.trymito.io/misc/release-notes' rel="noreferrer" target='_blank'>
+                <a className={pageStyles.link_with_p_tag_margins} href='https://docs.trymito.io/misc/release-notes' rel="noopener" target='_blank'>
                   See our recent updates → 
                 </a>
               </div>

--- a/trymito.io/pages/spreadsheet-automation.tsx
+++ b/trymito.io/pages/spreadsheet-automation.tsx
@@ -110,7 +110,7 @@ const SpreadsheetAutomation: NextPage = () => {
                   Apply conditional formatting, set table colors, and format numbers using Mito. Don&apos;t waste time trying to understand the xlsxwriter API -- it&apos;s confusing even to engineers!
                 </p>
                 <p>
-                  Learn more about <a href="https://docs.trymito.io/how-to/exporting-to-csv-and-excel/download-as-excel" target="_blank" rel="noreferrer" className={pageStyles.link}>generating presentation-ready Excel files.</a>
+                  Learn more about <a href="https://docs.trymito.io/how-to/exporting-to-csv-and-excel/download-as-excel" target="_blank" rel="noopener" className={pageStyles.link}>generating presentation-ready Excel files.</a>
                 </p>
               </div>
               <div className={classNames(textImageSplitStyles.functionality_media, 'only-on-mobile-block')}>
@@ -128,7 +128,7 @@ const SpreadsheetAutomation: NextPage = () => {
               <p>
                 We&apos;ve implemented all of Excel&apos;s most powerful features in Python so you don&apos;t have to. Keep using the tools you&apos;re most comfortable with, and automatically generate reusable Python code.
               </p>
-              <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noreferrer" className={pageStyles.link_with_p_tag_margins}>
+              <a href="https://docs.trymito.io/how-to/importing-data-to-mito" target="_blank" rel="noopener" className={pageStyles.link_with_p_tag_margins}>
                 View all 100+ transformations →
               </a>
             </div>


### PR DESCRIPTION
# Description

Removes rel=noreferrer from links to docs so we can make it easier for users to navigate to the install instructions when they want to download Mito. 

# Testing

Deploy and make sure this works. 

# Documentation

No. 