### PR TITLE
Add column control panel tests

### DIFF
--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -1,0 +1,128 @@
+import { FrameLocator, Page, expect, test } from '@playwright/test';
+import { awaitResponse, getMitoFrameWithTestCSV } from '../utils';
+
+
+
+const openColumnControlPanel = async (mito: any, columnName: string) => {
+    const columnHeader = await mito.locator('.endo-column-header-final-container', { hasText: columnName });
+    await columnHeader.getByText('int').click();
+    await expect(mito.locator('.spacing-col', { hasText: 'Dtype' })).toBeVisible();
+};
+
+const changeDtype = async (mito: FrameLocator, page: Page, dtype: string) => {
+    await mito.locator('.spacing-row', { hasText: 'Dtype' }).locator('.select-text').click();
+    await mito.locator('.mito-dropdown-item', { hasText: dtype }).click();
+    await awaitResponse(page);
+}
+
+const changeNumType = async (mito: FrameLocator, page: Page, numType: string) => {
+    await mito.locator('.spacing-row', { hasText: 'Num Type' }).locator('.select-text').click();
+    await mito.locator('.mito-dropdown-item', { hasText: numType }).click();
+    await awaitResponse(page);
+}
+
+const checkColumnCellsHaveValues = async (mito: FrameLocator, columnIndex: number, values: any[]) => {
+    const cells = await mito.locator(`.mito-grid-cell[mito-col-index="${columnIndex}"]`).all()
+    await expect(mito.locator('.index-header-container')).toHaveCount(values.length);
+    for (const cellIndex in values) {
+        const cell = cells[cellIndex];
+        await expect(cell).toHaveText(values[cellIndex]);
+    }
+}
+
+const checkColumnControlPanelValuesTab = async (mito: FrameLocator, expectedValues: any[]) => {
+    const values = await mito.locator('.multi-toggle-box').locator('.multi-toggle-box-row').all();
+    for (const valueIndex in values) {
+        const value = values[valueIndex];
+        await expect(value).toHaveText(expectedValues[valueIndex]);
+    }
+};
+
+test.describe('Column Control Panel', () => {
+    test('Changing dtype', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        
+        await openColumnControlPanel(mito, 'Column1');
+        
+        await changeDtype(mito, page, 'bool');
+        await checkColumnCellsHaveValues(mito, 0, ['true', 'true', 'true', 'true']);
+
+        await changeDtype(mito, page, 'str');
+        await checkColumnCellsHaveValues(mito, 0, ['1', '4', '7', '10']);
+    
+        await changeDtype(mito, page, 'float');
+        await checkColumnCellsHaveValues(mito, 0, ['1.00', '4.00', '7.00', '10.00']);
+    
+        await changeDtype(mito, page, 'datetime');
+        await checkColumnCellsHaveValues(mito, 0, ['1970-01-01 00:00:01', '1970-01-01 00:00:04', '1970-01-01 00:00:07', '1970-01-01 00:00:10']);
+    })
+
+    test('Adding filter', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        
+        await openColumnControlPanel(mito, 'Column1');
+        
+        await mito.getByText('Add Filter').click();
+        await mito.getByText('Add a Filter').click();
+        await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('4');
+        await awaitResponse(page);
+
+        await checkColumnCellsHaveValues(mito, 0, ['7', '10']);
+    });
+
+    test('Sorting', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        
+        await openColumnControlPanel(mito, 'Column1');
+    
+        await mito.getByText('Descending').click();
+        await awaitResponse(page);
+
+        await checkColumnCellsHaveValues(mito, 0, ['10', '7', '4', '1']);
+
+        await mito.getByText('Ascending').click();
+        await awaitResponse(page);
+
+        await checkColumnCellsHaveValues(mito, 0, ['1', '4', '7', '10']);
+    });
+
+    test('Change the number type', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await openColumnControlPanel(mito, 'Column1');
+
+        await changeNumType(mito, page, 'Currency');
+        await checkColumnCellsHaveValues(mito, 0, ['$1', '$4', '$7', '$10']);
+
+        await changeNumType(mito, page, 'Accounting');
+        await checkColumnCellsHaveValues(mito, 0, ['$1', '$4', '$7', '$10']);
+
+        await changeNumType(mito, page, 'Percent');
+        await checkColumnCellsHaveValues(mito, 0, ['100%', '400%', '700%', '1,000%']);
+
+        await changeNumType(mito, page, 'Scientific Notation');
+        await checkColumnCellsHaveValues(mito, 0, ['1e+0', '4e+0', '7e+0', '1e+1']);
+    });
+
+    test('Values tab: filtering values by clicking on them', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await openColumnControlPanel(mito, 'Column1');
+
+        await mito.locator('.control-panel-taskpane-tab', { hasText: 'Values'}).click();
+        await checkColumnControlPanelValuesTab(mito, ['1', '4', '7', '10']);
+
+        await mito.locator('.multi-toggle-box-row', { hasText: '4' }).locator('input[type="checkbox"]').click();
+        await awaitResponse(page);
+        await checkColumnCellsHaveValues(mito, 0, ['1', '7', '10']);
+    })
+
+    test('Loads summary stats', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await openColumnControlPanel(mito, 'Column1');
+
+        await mito.locator('.control-panel-taskpane-tab', { hasText: 'Stats'}).click();
+        await expect(mito.locator('.column-describe-table-row', { hasText: 'mean' })).toContainText('5.5')
+        await expect(mito.locator('.column-describe-table-row', { hasText: 'std' })).toContainText('3.87')
+        await expect(mito.locator('.column-describe-table-row', { hasText: 'min' })).toContainText('1.0')
+    })
+    
+});

--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -1,33 +1,22 @@
 import { FrameLocator, Page, expect, test } from '@playwright/test';
-import { awaitResponse, getMitoFrameWithTestCSV } from '../utils';
-
-
+import { awaitResponse, getMitoFrameWithTestCSV, checkColumnCellsHaveExpectedValues } from '../utils';
 
 const openColumnControlPanel = async (mito: any, columnName: string) => {
     const columnHeader = await mito.locator('.endo-column-header-final-container', { hasText: columnName });
-    await columnHeader.getByText('int').click();
+    await columnHeader.getByTitle('Edit filters').click();
     await expect(mito.locator('.spacing-col', { hasText: 'Dtype' })).toBeVisible();
 };
 
-const changeDtype = async (mito: FrameLocator, page: Page, dtype: string) => {
+const changeDtypeInColumnControlPanel = async (mito: FrameLocator, page: Page, dtype: string) => {
     await mito.locator('.spacing-row', { hasText: 'Dtype' }).locator('.select-text').click();
     await mito.locator('.mito-dropdown-item', { hasText: dtype }).click();
     await awaitResponse(page);
 }
 
-const changeNumType = async (mito: FrameLocator, page: Page, numType: string) => {
+const changeNumTypeInColumnControlPanel = async (mito: FrameLocator, page: Page, numType: string) => {
     await mito.locator('.spacing-row', { hasText: 'Num Type' }).locator('.select-text').click();
     await mito.locator('.mito-dropdown-item', { hasText: numType }).click();
     await awaitResponse(page);
-}
-
-const checkColumnCellsHaveExpectedValues = async (mito: FrameLocator, columnIndex: number, values: any[]) => {
-    const cells = await mito.locator(`.mito-grid-cell[mito-col-index="${columnIndex}"]`).all()
-    await expect(mito.locator('.index-header-container')).toHaveCount(values.length);
-    for (const cellIndex in values) {
-        const cell = cells[cellIndex];
-        await expect(cell).toHaveText(values[cellIndex]);
-    }
 }
 
 const checkValuesTabHasExpectedValues = async (mito: FrameLocator, expectedValues: any[]) => {
@@ -44,16 +33,16 @@ test.describe('Column Control Panel', () => {
         
         await openColumnControlPanel(mito, 'Column1');
         
-        await changeDtype(mito, page, 'bool');
+        await changeDtypeInColumnControlPanel(mito, page, 'bool');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['true', 'true', 'true', 'true']);
 
-        await changeDtype(mito, page, 'str');
+        await changeDtypeInColumnControlPanel(mito, page, 'str');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['1', '4', '7', '10']);
     
-        await changeDtype(mito, page, 'float');
+        await changeDtypeInColumnControlPanel(mito, page, 'float');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['1.00', '4.00', '7.00', '10.00']);
     
-        await changeDtype(mito, page, 'datetime');
+        await changeDtypeInColumnControlPanel(mito, page, 'datetime');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['1970-01-01 00:00:01', '1970-01-01 00:00:04', '1970-01-01 00:00:07', '1970-01-01 00:00:10']);
     })
 
@@ -90,16 +79,16 @@ test.describe('Column Control Panel', () => {
         const mito = await getMitoFrameWithTestCSV(page);
         await openColumnControlPanel(mito, 'Column1');
 
-        await changeNumType(mito, page, 'Currency');
+        await changeNumTypeInColumnControlPanel(mito, page, 'Currency');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['$1', '$4', '$7', '$10']);
 
-        await changeNumType(mito, page, 'Accounting');
+        await changeNumTypeInColumnControlPanel(mito, page, 'Accounting');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['$1', '$4', '$7', '$10']);
 
-        await changeNumType(mito, page, 'Percent');
+        await changeNumTypeInColumnControlPanel(mito, page, 'Percent');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['100%', '400%', '700%', '1,000%']);
 
-        await changeNumType(mito, page, 'Scientific Notation');
+        await changeNumTypeInColumnControlPanel(mito, page, 'Scientific Notation');
         await checkColumnCellsHaveExpectedValues(mito, 0, ['1e+0', '4e+0', '7e+0', '1e+1']);
     });
 

--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -140,4 +140,20 @@ test.describe('Column Control Panel', () => {
         await expect(mito.locator('.column-describe-table-row', { hasText: 'std' })).toContainText('3.87')
         await expect(mito.locator('.column-describe-table-row', { hasText: 'min' })).toContainText('1.0')
     })
+
+    test('Updates the taskpane when selected column changes', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        await openColumnControlPanel(mito, 'Column1');
+        await expect(mito.locator('.default-taskpane-header-div', { hasText: 'Column1' })).toBeVisible();
+        
+        // Navigate to the stats tab
+        await mito.locator('.control-panel-taskpane-tab', { hasText: 'Stats'}).click();
+
+        // Click on another column
+        await mito.locator('.endo-column-header-final-container', { hasText: 'Column2' }).click();
+        
+        // Expect the tab to still be "Stats" and the header to be "Column2"
+        await expect(mito.locator('.default-taskpane-header-div', { hasText: 'Column2' })).toBeVisible();
+        await expect(mito.getByText('Column Summary Statistics', { exact: true })).toBeVisible();
+    });
 });

--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -59,6 +59,33 @@ test.describe('Column Control Panel', () => {
         await checkColumnCellsHaveExpectedValues(mito, 0, ['7', '10']);
     });
 
+    test('Adding a group of filters', async ({ page }) => {
+        const mito = await getMitoFrameWithTestCSV(page);
+        
+        await openColumnControlPanel(mito, 'Column1');
+        
+        await mito.getByText('Add Filter').click();
+        await mito.getByText('Add a Group').click();
+        await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('7');
+        await awaitResponse(page);
+
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['10']);
+
+        // Add another filter to the group
+        await mito.getByText('Add a Filter').click();
+
+        // Change the "and" to an "or" for the second condition
+        await mito.locator('.filter-group .spacing-row').nth(1).locator('.select-text', { hasText: 'And' }).click();
+        await mito.getByText('Or', { exact: true }).click();
+
+        // Add a filter to the second condition
+        await mito.locator('.filter-group .spacing-row').nth(1).locator('.select-text', { hasText: '>' }).click();
+        await mito.locator('.mito-dropdown-item', { hasText: '<' }).click();
+        await mito.locator('.filter-group .spacing-row').nth(1).locator('input').fill('4');
+        await awaitResponse(page);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1', '10']);
+    });
+
     test('Sorting', async ({ page }) => {
         const mito = await getMitoFrameWithTestCSV(page);
         

--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -21,7 +21,7 @@ const changeNumType = async (mito: FrameLocator, page: Page, numType: string) =>
     await awaitResponse(page);
 }
 
-const checkColumnCellsHaveValues = async (mito: FrameLocator, columnIndex: number, values: any[]) => {
+const checkColumnCellsHaveExpectedValues = async (mito: FrameLocator, columnIndex: number, values: any[]) => {
     const cells = await mito.locator(`.mito-grid-cell[mito-col-index="${columnIndex}"]`).all()
     await expect(mito.locator('.index-header-container')).toHaveCount(values.length);
     for (const cellIndex in values) {
@@ -30,7 +30,7 @@ const checkColumnCellsHaveValues = async (mito: FrameLocator, columnIndex: numbe
     }
 }
 
-const checkColumnControlPanelValuesTab = async (mito: FrameLocator, expectedValues: any[]) => {
+const checkValuesTabHasExpectedValues = async (mito: FrameLocator, expectedValues: any[]) => {
     const values = await mito.locator('.multi-toggle-box').locator('.multi-toggle-box-row').all();
     for (const valueIndex in values) {
         const value = values[valueIndex];
@@ -45,16 +45,16 @@ test.describe('Column Control Panel', () => {
         await openColumnControlPanel(mito, 'Column1');
         
         await changeDtype(mito, page, 'bool');
-        await checkColumnCellsHaveValues(mito, 0, ['true', 'true', 'true', 'true']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['true', 'true', 'true', 'true']);
 
         await changeDtype(mito, page, 'str');
-        await checkColumnCellsHaveValues(mito, 0, ['1', '4', '7', '10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1', '4', '7', '10']);
     
         await changeDtype(mito, page, 'float');
-        await checkColumnCellsHaveValues(mito, 0, ['1.00', '4.00', '7.00', '10.00']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1.00', '4.00', '7.00', '10.00']);
     
         await changeDtype(mito, page, 'datetime');
-        await checkColumnCellsHaveValues(mito, 0, ['1970-01-01 00:00:01', '1970-01-01 00:00:04', '1970-01-01 00:00:07', '1970-01-01 00:00:10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1970-01-01 00:00:01', '1970-01-01 00:00:04', '1970-01-01 00:00:07', '1970-01-01 00:00:10']);
     })
 
     test('Adding filter', async ({ page }) => {
@@ -67,7 +67,7 @@ test.describe('Column Control Panel', () => {
         await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('4');
         await awaitResponse(page);
 
-        await checkColumnCellsHaveValues(mito, 0, ['7', '10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['7', '10']);
     });
 
     test('Sorting', async ({ page }) => {
@@ -78,12 +78,12 @@ test.describe('Column Control Panel', () => {
         await mito.getByText('Descending').click();
         await awaitResponse(page);
 
-        await checkColumnCellsHaveValues(mito, 0, ['10', '7', '4', '1']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['10', '7', '4', '1']);
 
         await mito.getByText('Ascending').click();
         await awaitResponse(page);
 
-        await checkColumnCellsHaveValues(mito, 0, ['1', '4', '7', '10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1', '4', '7', '10']);
     });
 
     test('Change the number type', async ({ page }) => {
@@ -91,16 +91,16 @@ test.describe('Column Control Panel', () => {
         await openColumnControlPanel(mito, 'Column1');
 
         await changeNumType(mito, page, 'Currency');
-        await checkColumnCellsHaveValues(mito, 0, ['$1', '$4', '$7', '$10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['$1', '$4', '$7', '$10']);
 
         await changeNumType(mito, page, 'Accounting');
-        await checkColumnCellsHaveValues(mito, 0, ['$1', '$4', '$7', '$10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['$1', '$4', '$7', '$10']);
 
         await changeNumType(mito, page, 'Percent');
-        await checkColumnCellsHaveValues(mito, 0, ['100%', '400%', '700%', '1,000%']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['100%', '400%', '700%', '1,000%']);
 
         await changeNumType(mito, page, 'Scientific Notation');
-        await checkColumnCellsHaveValues(mito, 0, ['1e+0', '4e+0', '7e+0', '1e+1']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1e+0', '4e+0', '7e+0', '1e+1']);
     });
 
     test('Values tab: filtering values by clicking on them', async ({ page }) => {
@@ -108,11 +108,11 @@ test.describe('Column Control Panel', () => {
         await openColumnControlPanel(mito, 'Column1');
 
         await mito.locator('.control-panel-taskpane-tab', { hasText: 'Values'}).click();
-        await checkColumnControlPanelValuesTab(mito, ['1', '4', '7', '10']);
+        await checkValuesTabHasExpectedValues(mito, ['1', '4', '7', '10']);
 
         await mito.locator('.multi-toggle-box-row', { hasText: '4' }).locator('input[type="checkbox"]').click();
         await awaitResponse(page);
-        await checkColumnCellsHaveValues(mito, 0, ['1', '7', '10']);
+        await checkColumnCellsHaveExpectedValues(mito, 0, ['1', '7', '10']);
     })
 
     test('Loads summary stats', async ({ page }) => {
@@ -124,5 +124,4 @@ test.describe('Column Control Panel', () => {
         await expect(mito.locator('.column-describe-table-row', { hasText: 'std' })).toContainText('3.87')
         await expect(mito.locator('.column-describe-table-row', { hasText: 'min' })).toContainText('1.0')
     })
-    
 });

--- a/tests/streamlit_ui_tests/utils.ts
+++ b/tests/streamlit_ui_tests/utils.ts
@@ -41,6 +41,9 @@ export const checkColumnCellsHaveExpectedValues = async (mito: FrameLocator, col
     await expect(mito.locator('.index-header-container')).toHaveCount(values.length);
     for (const cellIndex in values) {
         const cell = cells[cellIndex];
+        if (cell === undefined) {
+            continue;
+        }
         await expect(cell).toHaveText(values[cellIndex]);
     }
 }

--- a/tests/streamlit_ui_tests/utils.ts
+++ b/tests/streamlit_ui_tests/utils.ts
@@ -36,6 +36,15 @@ export const getMitoFrameWithTestCSV = async (page: Page): Promise<FrameLocator>
     return mito;
 }
 
+export const checkColumnCellsHaveExpectedValues = async (mito: FrameLocator, columnIndex: number, values: any[]) => {
+    const cells = await mito.locator(`.mito-grid-cell[mito-col-index="${columnIndex}"]`).all()
+    await expect(mito.locator('.index-header-container')).toHaveCount(values.length);
+    for (const cellIndex in values) {
+        const cell = cells[cellIndex];
+        await expect(cell).toHaveText(values[cellIndex]);
+    }
+}
+
 export const hasExpectedNumberOfRows = async (mito: any, expectedRows: number) => {
     await expect(mito.locator('.index-header-container', { hasText: `${expectedRows - 1}` })).toBeVisible();
     await expect(mito.locator('.index-header-container', { hasText: `${expectedRows}` })).not.toBeVisible();


### PR DESCRIPTION
Adds tests for:
- Changing column dtype
- Adding a filter
- Sorting
- Changing the number type
- Filtering values through the values tab
- Loading summary stats

Adds utilities for:
- opening the column control panel
- changing the dtype
- changing the number type
- checking that column cells have expected values
- checking the control panel's value tab has expected values