### PR TITLE
Add utils for filling input and selects

### DIFF
--- a/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
+++ b/tests/streamlit_ui_tests/features/column_control_panel.spec.ts
@@ -1,5 +1,5 @@
 import { FrameLocator, Page, expect, test } from '@playwright/test';
-import { awaitResponse, getMitoFrameWithTestCSV, checkColumnCellsHaveExpectedValues } from '../utils';
+import { awaitResponse, getMitoFrameWithTestCSV, checkColumnCellsHaveExpectedValues, fillInput, updateSelectedValue } from '../utils';
 
 const openColumnControlPanel = async (mito: any, columnName: string) => {
     const columnHeader = await mito.locator('.endo-column-header-final-container', { hasText: columnName });
@@ -8,15 +8,11 @@ const openColumnControlPanel = async (mito: any, columnName: string) => {
 };
 
 const changeDtypeInColumnControlPanel = async (mito: FrameLocator, page: Page, dtype: string) => {
-    await mito.locator('.spacing-row', { hasText: 'Dtype' }).locator('.select-text').click();
-    await mito.locator('.mito-dropdown-item', { hasText: dtype }).click();
-    await awaitResponse(page);
+    await updateSelectedValue(mito, 'Dtype', dtype);
 }
 
 const changeNumTypeInColumnControlPanel = async (mito: FrameLocator, page: Page, numType: string) => {
-    await mito.locator('.spacing-row', { hasText: 'Num Type' }).locator('.select-text').click();
-    await mito.locator('.mito-dropdown-item', { hasText: numType }).click();
-    await awaitResponse(page);
+    await updateSelectedValue(mito, 'Num Type', numType);
 }
 
 const checkValuesTabHasExpectedValues = async (mito: FrameLocator, expectedValues: any[]) => {
@@ -53,7 +49,7 @@ test.describe('Column Control Panel', () => {
         
         await mito.getByText('Add Filter').click();
         await mito.getByText('Add a Filter').click();
-        await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('4');
+        await fillInput(mito, 'Where', '4');
         await awaitResponse(page);
 
         await checkColumnCellsHaveExpectedValues(mito, 0, ['7', '10']);
@@ -66,7 +62,7 @@ test.describe('Column Control Panel', () => {
         
         await mito.getByText('Add Filter').click();
         await mito.getByText('Add a Group').click();
-        await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('7');
+        await fillInput(mito, 'Where', '7');
         await awaitResponse(page);
 
         await checkColumnCellsHaveExpectedValues(mito, 0, ['10']);

--- a/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
+++ b/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
@@ -1,5 +1,5 @@
 import { FrameLocator, Page, expect, test } from '@playwright/test';
-import { awaitResponse, clickButtonAndAwaitResponse, clickTab, getMitoFrameWithTestCSV, getMitoFrameWithTypeCSV } from '../utils';
+import { awaitResponse, clickButtonAndAwaitResponse, clickTab, fillInput, getMitoFrameWithTestCSV, getMitoFrameWithTypeCSV, updateSelectedValue } from '../utils';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -44,8 +44,7 @@ const testDeleteTitleThroughContextMenu = async (page, selector) => {
 };
 
 const addColumnToAxis = async (mito: FrameLocator, page: Page, axis: 'X' | 'Y', columnName: string) => {
-  await mito.locator('.spacing-row', { hasText: `${axis} axis` }).locator('.mito-dropdown-button').click();
-  await mito.locator('.mito-dropdown-item', { hasText: columnName }).click();
+  await updateSelectedValue(mito, `${axis} Axis`, columnName);
   await awaitResponse(page);
 }
 
@@ -241,14 +240,13 @@ test.describe('Graph Functionality', () => {
     await mito.locator('.endo-column-header-final-container').first().getByTitle('Edit Filters').click();
     await mito.getByText('Add Filter').click();
     await mito.getByText('Add a Filter').click();
-    await mito.locator('.spacing-row', { hasText: 'Where' }).locator('input').fill('1');
+    await fillInput(mito, 'Where', '1');
     await expect(mito.locator('.mito-grid-cell-selected')).toHaveCount(3);
 
     // Check that the graph has been updated
     await expect(mito.locator('.g-gtitle', { hasText: 'Column1 bar chart'})).not.toBeVisible();
     await mito.locator('.footer').getByText('graph0').click();
 
-    await awaitResponse(page);
     await awaitResponse(page);
     await expect(mito.locator('.g-gtitle', { hasText: 'Column1 bar chart'})).toBeVisible();
     await expect(mito.locator('g.point')).toHaveCount(6);

--- a/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
+++ b/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
@@ -44,7 +44,7 @@ const testDeleteTitleThroughContextMenu = async (page, selector) => {
 };
 
 const addColumnToAxis = async (mito: FrameLocator, page: Page, axis: 'X' | 'Y', columnName: string) => {
-  await updateSelectedValue(mito, `${axis} Axis`, columnName);
+  await updateSelectedValue(mito, `${axis} axis`, columnName);
   await awaitResponse(page);
 }
 

--- a/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
+++ b/tests/streamlit_ui_tests/taskpanes/graph.spec.ts
@@ -1,5 +1,5 @@
 import { FrameLocator, Page, expect, test } from '@playwright/test';
-import { awaitResponse, clickButtonAndAwaitResponse, clickTab, fillInput, getMitoFrameWithTestCSV, getMitoFrameWithTypeCSV, updateSelectedValue } from '../utils';
+import { awaitResponse, clickButtonAndAwaitResponse, clickTab, fillInput, getMitoFrameWithTestCSV, getMitoFrameWithTypeCSV } from '../utils';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -44,7 +44,8 @@ const testDeleteTitleThroughContextMenu = async (page, selector) => {
 };
 
 const addColumnToAxis = async (mito: FrameLocator, page: Page, axis: 'X' | 'Y', columnName: string) => {
-  await updateSelectedValue(mito, `${axis} axis`, columnName);
+  await mito.locator('.spacing-row', { hasText: `${axis} axis` }).locator('.mito-dropdown-button').click();
+  await mito.locator('.mito-dropdown-item', { hasText: columnName }).click();
   await awaitResponse(page);
 }
 

--- a/tests/streamlit_ui_tests/utils.ts
+++ b/tests/streamlit_ui_tests/utils.ts
@@ -48,6 +48,15 @@ export const checkColumnCellsHaveExpectedValues = async (mito: FrameLocator, col
     }
 }
 
+export const fillInput = async (mito: FrameLocator, title: string, value: string): Promise<void> => {
+    await mito.locator('.spacing-row', { hasText: title }).locator('input').fill(value);
+}
+
+export const updateSelectedValue = async (mito: FrameLocator, title: string, value: string): Promise<void> => {
+    await mito.locator('.spacing-row', { hasText: title }).locator('.select-text').click();
+    await mito.locator('.mito-dropdown-item', { hasText: value }).click();
+}
+
 export const hasExpectedNumberOfRows = async (mito: any, expectedRows: number) => {
     await expect(mito.locator('.index-header-container', { hasText: `${expectedRows - 1}` })).toBeVisible();
     await expect(mito.locator('.index-header-container', { hasText: `${expectedRows}` })).not.toBeVisible();


### PR DESCRIPTION
Adds `fillInput` and `updateSelectedValue` functions, which takes the `title` of an input (which is assumed to be in a `.spacing-row` div with the input), and fills with the given `value`. This allows for more precision and cleaner code when looking for inputs to fill. This allows us to avoid relying on things like the "nth" input. 