### PR TITLE
Update keyboard shortcut for navigating between tabs to include graph tabs

### DIFF
--- a/mitosheet/src/mito/utils/actions.tsx
+++ b/mitosheet/src/mito/utils/actions.tsx
@@ -2155,13 +2155,44 @@ export const getActions = (
             actionFunction: () => {
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
-                setUIState(prevUIState => {
-                    const sheetIndex = prevUIState.selectedSheetIndex;
-                    return {
-                        ...prevUIState,
-                        selectedSheetIndex: sheetIndex < sheetDataArray.length - 1 ? sheetIndex + 1 : 0
+                
+                const selectedSheetIndex = uiState.selectedSheetIndex;
+                const selectedGraphID = uiState.currOpenTaskpane.type === TaskpaneType.GRAPH ? uiState.currOpenTaskpane.openGraph.graphID : undefined;
+                
+                if (selectedGraphID !== undefined) {
+                    const graphIndex = analysisData.graphDataArray.findIndex(graphData => graphData.graph_id === selectedGraphID);
+                    if (graphIndex === -1 || graphIndex === analysisData.graphDataArray.length - 1) {
+                        setUIState(prevUIState => {
+                            return {
+                                ...prevUIState,
+                                currOpenTaskpane: {type: TaskpaneType.NONE},
+                                selectedTabType: 'data',
+                                selectedSheetIndex: 0
+                            }
+                        });
+                    } else {
+                        void openGraphSidebar(setUIState, uiState, setEditorState, sheetDataArray, mitoAPI, {
+                            type: 'existing_graph',
+                            graphID: analysisData.graphDataArray[graphIndex + 1].graph_id
+                        })
+                        return;
                     }
-                })
+                } else {
+                    if (selectedSheetIndex === sheetDataArray.length - 1 && analysisData.graphDataArray.length > 0) {
+                        void openGraphSidebar(setUIState, uiState, setEditorState, sheetDataArray, mitoAPI, {
+                            type: 'existing_graph',
+                            graphID: analysisData.graphDataArray[0].graph_id
+                        })
+                        return;
+                    } else {
+                        setUIState(prevUIState => {
+                            return {
+                                ...prevUIState,
+                                selectedSheetIndex: selectedSheetIndex === sheetDataArray.length - 1 ? 0 : selectedSheetIndex + 1
+                            }
+                        });
+                    }
+                }
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['sheet', 'index', 'next', 'forward'],
@@ -2174,13 +2205,44 @@ export const getActions = (
             actionFunction: () => {
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
-                setUIState(prevUIState => {
-                    const sheetIndex = prevUIState.selectedSheetIndex;
-                    return {
-                        ...prevUIState,
-                        selectedSheetIndex: sheetIndex > 0 ? sheetIndex - 1 : sheetDataArray.length - 1
+
+                const selectedSheetIndex = uiState.selectedSheetIndex;
+                const selectedGraphID = uiState.currOpenTaskpane.type === TaskpaneType.GRAPH ? uiState.currOpenTaskpane.openGraph.graphID : undefined;
+                
+                if (selectedGraphID !== undefined) {
+                    const graphIndex = analysisData.graphDataArray.findIndex(graphData => graphData.graph_id === selectedGraphID);
+                    if (graphIndex === -1 || graphIndex === 0) {
+                        setUIState(prevUIState => {
+                            return {
+                                ...prevUIState,
+                                currOpenTaskpane: {type: TaskpaneType.NONE},
+                                selectedTabType: 'data',
+                                selectedSheetIndex: sheetDataArray.length - 1
+                            }
+                        });
+                    } else {
+                        void openGraphSidebar(setUIState, uiState, setEditorState, sheetDataArray, mitoAPI, {
+                            type: 'existing_graph',
+                            graphID: analysisData.graphDataArray[graphIndex - 1].graph_id
+                        })
+                        return;
                     }
-                })
+                } else {
+                    if (selectedSheetIndex === 0 && analysisData.graphDataArray.length > 0) {
+                        void openGraphSidebar(setUIState, uiState, setEditorState, sheetDataArray, mitoAPI, {
+                            type: 'existing_graph',
+                            graphID: analysisData.graphDataArray[analysisData.graphDataArray.length - 1].graph_id
+                        })
+                        return;
+                    } else {
+                        setUIState(prevUIState => {
+                            return {
+                                ...prevUIState,
+                                selectedSheetIndex: selectedSheetIndex === 0 ? sheetDataArray.length - 1 : selectedSheetIndex - 1
+                            }
+                        });
+                    }
+                }
             },
             isDisabled: () => {return defaultActionDisabledMessage},
             searchTerms: ['sheet', 'index', 'previous', 'last'],

--- a/tests/streamlit_ui_tests/grid/keyboard_shortcuts.spec.ts
+++ b/tests/streamlit_ui_tests/grid/keyboard_shortcuts.spec.ts
@@ -54,27 +54,37 @@ test.describe('Keyboard Shortcuts', () => {
 
     test('Next/prev sheet with graphs', async ({ page }) => {
       const mito = await getMitoFrameWithTestCSV(page);
+
+      /* Import another csv and create 2 graphs so that we have enough tabs to navigate between */
       await importCSV(page, mito, 'test.csv');
+      
+      // Create a graph
       await mito.getByText('Graph').click();
       await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+
+      // Create another graph off of test_1
       await mito.locator('.tab', { hasText: 'test_1' }).click();
       await mito.getByText('Graph', { exact: true }).click();
       await expect(mito.getByText('Column1 bar chart')).toBeVisible();
 
+      /* Test navigation */
       await mito.locator('.mito-container').press('Alt+ArrowRight');
-      await awaitResponse(page);
       await expect(mito.locator('.tab-selected')).toHaveText('test');
+
       await mito.locator('.mito-container').press('Alt+ArrowRight');
-      await awaitResponse(page);
       await expect(mito.locator('.tab-selected')).toHaveText('test_1');
 
       await mito.locator('.mito-container').press('Alt+ArrowRight');
-      await awaitResponse(page);
       await expect(mito.locator('.tab-selected')).toHaveText('graph0');
 
       await mito.locator('.mito-container').press('Alt+ArrowLeft');
-      await awaitResponse(page);
       await expect(mito.locator('.tab-selected')).toHaveText('test_1');
+
+      await mito.locator('.mito-container').press('Alt+ArrowLeft');
+      await expect(mito.locator('.tab-selected')).toHaveText('test');
+
+      await mito.locator('.mito-container').press('Alt+ArrowLeft');
+      await expect(mito.locator('.tab-selected')).toHaveText('graph1');
     });
   
     test('Previous Sheet', async ({ page }) => {

--- a/tests/streamlit_ui_tests/grid/keyboard_shortcuts.spec.ts
+++ b/tests/streamlit_ui_tests/grid/keyboard_shortcuts.spec.ts
@@ -51,6 +51,31 @@ test.describe('Keyboard Shortcuts', () => {
       // with the text test
       await expect(mito.locator('.tab-selected').locator('div').filter({ hasText: "test" }).first()).toBeVisible();
     });
+
+    test('Next/prev sheet with graphs', async ({ page }) => {
+      const mito = await getMitoFrameWithTestCSV(page);
+      await importCSV(page, mito, 'test.csv');
+      await mito.getByText('Graph').click();
+      await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+      await mito.locator('.tab', { hasText: 'test_1' }).click();
+      await mito.getByText('Graph', { exact: true }).click();
+      await expect(mito.getByText('Column1 bar chart')).toBeVisible();
+
+      await mito.locator('.mito-container').press('Alt+ArrowRight');
+      await awaitResponse(page);
+      await expect(mito.locator('.tab-selected')).toHaveText('test');
+      await mito.locator('.mito-container').press('Alt+ArrowRight');
+      await awaitResponse(page);
+      await expect(mito.locator('.tab-selected')).toHaveText('test_1');
+
+      await mito.locator('.mito-container').press('Alt+ArrowRight');
+      await awaitResponse(page);
+      await expect(mito.locator('.tab-selected')).toHaveText('graph0');
+
+      await mito.locator('.mito-container').press('Alt+ArrowLeft');
+      await awaitResponse(page);
+      await expect(mito.locator('.tab-selected')).toHaveText('test_1');
+    });
   
     test('Previous Sheet', async ({ page }) => {
       const mito = await getMitoFrameWithTestCSV(page);


### PR DESCRIPTION
Adds extra logic into the action handler for open previous/next sheet when user presses opt+arrow to check for graph tabs. 