### PR TITLE
Fix multiple vlookup bug

### DIFF
--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -477,13 +477,14 @@ def get_raw_parser_matches(
 
     for other_sheet_index, sheet_name in enumerate(df_names):
         if safe_contains(formula, f'{sheet_name}!', column_headers):
-            raw_parser_matches.append({
-                'type': '{SHEET}',
-                'substring_range': (formula.index(f'{sheet_name}!'), formula.index(f'{sheet_name}!') + len(sheet_name)),
-                'unparsed': f'{sheet_name}!',
-                'parsed': sheet_name,
-                'row_offset': 0
-            })
+            for match_info in re.finditer(f'{sheet_name}!', formula):
+                raw_parser_matches.append({
+                    'type': '{SHEET}',
+                    'substring_range': (match_info.start(), match_info.end()-1),
+                    'unparsed': f'{sheet_name}!',
+                    'parsed': sheet_name,
+                    'row_offset': 0
+                })
 
             # Update to look at the column headers in the other sheet
             column_headers = deduplicate_array(column_headers + dfs[other_sheet_index].columns.to_list())

--- a/mitosheet/mitosheet/tests/test_parse.py
+++ b/mitosheet/mitosheet/tests/test_parse.py
@@ -1219,6 +1219,27 @@ VLOOKUP_TESTS = [
         'df_1[\'B\'] = SUM(df_1[\'C\'], VLOOKUP(df_1[\'A\'], df_2.loc[:, \'B\':\'C\'], 2))',
         set(['VLOOKUP', 'SUM']),
         set(['A', 'B', 'C'])
+    ),
+    # Test for two calls to VLOOKUP
+    (
+        '=CONCAT(VLOOKUP(A0, df_2!C:D, 2), VLOOKUP(A0, df_2!C:E, 2))',
+        'B',
+        0,
+        [
+            pd.DataFrame(
+                get_number_data_for_df(['A', 'B'], 2),
+                index=pd.RangeIndex(0, 2)
+            ),
+            pd.DataFrame(
+                get_number_data_for_df(['C', 'D', 'E'], 2),
+                index=pd.RangeIndex(0, 2)
+            )
+        ],
+        ['df_1', 'df_2'],
+        0,
+        'df_1[\'B\'] = CONCAT(VLOOKUP(df_1[\'A\'], df_2.loc[:, \'C\':\'D\'], 2), VLOOKUP(df_1[\'A\'], df_2.loc[:, \'C\':\'E\'], 2))',
+        set(['VLOOKUP', 'CONCAT']),
+        set(['A', 'E', 'D', 'C'])
     )
 ]
 


### PR DESCRIPTION
Fixes #1243. The issue was that the parser was only using the first index that matched a given sheet name to identify cross-sheet formulas, so the resulting code wasn't identifying any sheets after the first. 