### PR TITLE
Fix bug switching between cell editor and formula bar

### DIFF
--- a/mitosheet/css/FormulaBar.css
+++ b/mitosheet/css/FormulaBar.css
@@ -21,6 +21,10 @@
     outline: none;
 
     color: var(--mito-text);
+    height: 30px;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
 }
 
 .formula-bar-vertical-line {


### PR DESCRIPTION
When the formula bar was empty, it became not clickable because the height became 0. This sets the height manually (and then adds correct adjustment to make sure that the formula is justified correctly). This css is copied from the `.formula-bar-column-header` style. 

Fixes #614. Fixes #1254.