### PR TITLE
Fix bug when opening graph editor then pressing undo

### DIFF
--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -335,6 +335,23 @@ export const Mito = (props: MitoProps): JSX.Element => {
         loadPlotly()
     }, [])
 
+    /**
+     * This useEffect handles when the user creates a graph, then presses undo.
+     */
+    useEffect(() => {
+        if (uiState.currOpenTaskpane.type === TaskpaneType.GRAPH &&
+            analysisData.graphDataArray.length === 0) {
+            setUIState(prevUIState => {
+                return {
+                    ...prevUIState,
+                    currOpenTaskpane: {type: TaskpaneType.NONE},
+                    selectedTabType: 'data',
+                    selectedSheetIndex: 0
+                }
+            })
+        }
+    }, [analysisData.graphDataArray])
+
     /* 
         When the number of sheets increases, we make sure
         that the last sheet is highlighted. If it decreases,

--- a/mitosheet/src/mito/Mito.tsx
+++ b/mitosheet/src/mito/Mito.tsx
@@ -350,7 +350,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                 }
             })
         }
-    }, [analysisData.graphDataArray])
+    }, [analysisData.graphDataArray.length])
 
     /* 
         When the number of sheets increases, we make sure

--- a/tests/streamlit_ui_tests/graph.spec.ts
+++ b/tests/streamlit_ui_tests/graph.spec.ts
@@ -196,7 +196,7 @@ test.describe('Graph Functionality', () => {
   test('Pressing undo after opening graph editor closes the graph editor', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     await openGraphEditor(mito, page);
-    await mito.getByTitle('Undo the most recent edit. (Ctrl+Z)').click();
+    await mito.getByTitle(/Undo the most recent edit/).click();
     await expect(mito.locator('.tab-selected', { hasText: 'test' })).toBeVisible();
     await expect(mito.locator('.endo-column-header-final-text').first()).toHaveText('Column1');
   });

--- a/tests/streamlit_ui_tests/graph.spec.ts
+++ b/tests/streamlit_ui_tests/graph.spec.ts
@@ -193,6 +193,14 @@ test.describe('Graph Functionality', () => {
     await expect(mito.getByText('Facet row')).toBeInViewport();
   });
 
+  test('Pressing undo after opening graph editor closes the graph editor', async ({ page }) => {
+    const mito = await getMitoFrameWithTestCSV(page);
+    await openGraphEditor(mito, page);
+    await mito.getByTitle('Undo the most recent edit. (Ctrl+Z)').click();
+    await expect(mito.locator('.tab-selected', { hasText: 'test' })).toBeVisible();
+    await expect(mito.locator('.endo-column-header-final-text').first()).toHaveText('Column1');
+  });
+
   test('Make a histogram and change the histogram specific configurations', async ({ page }) => {
     const mito = await getMitoFrameWithTestCSV(page);
     


### PR DESCRIPTION
Fixes #1092. The issue describes a different bug (which I assume was fixed somewhere?) but in trying to reproduce it I caught a different bug. The bug I saw was that pressing undo would get rid of the graph, but not close the graph editor. There would be no graph, but because the graph editor is designed to create a new graph when it sees the graph editor is open, it would just create a new graph. I chose to solve this by adding a `useEffect` that would check in the `Mito` component when the `graphDataArray` changed, and if the graphDataArray was empty but the graph taskpane was open, it just closes that taskpane. 