### PR TITLE
trymito: use ghost og_image

### DIFF
--- a/trymito.io/pages/blog/[slug].tsx
+++ b/trymito.io/pages/blog/[slug].tsx
@@ -84,6 +84,8 @@ const PostPage = (props: {post: PostOrPage}) => {
         <meta
           name="description"
           content={props.post.meta_description || props.post.excerpt?.slice(0, 99)}
+          
+          og-image={props.post.og_image}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>

--- a/trymito.io/pages/blog/[slug].tsx
+++ b/trymito.io/pages/blog/[slug].tsx
@@ -85,7 +85,7 @@ const PostPage = (props: {post: PostOrPage}) => {
           name="description"
           content={props.post.meta_description || props.post.excerpt?.slice(0, 99)}
           
-          og-image={props.post.og_image}
+          og-image={props.post.feature_image}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>

--- a/trymito.io/pages/blog/[slug].tsx
+++ b/trymito.io/pages/blog/[slug].tsx
@@ -84,9 +84,8 @@ const PostPage = (props: {post: PostOrPage}) => {
         <meta
           name="description"
           content={props.post.meta_description || props.post.excerpt?.slice(0, 99)}
-          
-          og-image={props.post.feature_image}
         />
+        <meta name="image" property="og:image" content={props.post.feature_image || undefined}></meta>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
 


### PR DESCRIPTION
# Description

Use the ghost feature image as the blog post og-image so we have control over what image is displayed on LinkedIn, Facebook, Twitter, etc. previews

# Testing

Link to this preview website target blog on a draft linked in post

# Documentation

Note if any new documentation needs to addressed or reviewed.