### PR TITLE
Python cheat sheet form

### DIFF
--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -122,6 +122,12 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPag
       </Head>
       <Header />
 
+      {/* 
+        A popup typeform that asks the user if they want to download a Pandas Cheat Sheet.
+        To configure this typeform, ask Aaron for typeform access.
+      */}
+      <div data-tf-live="01HV27JPE2P9SQVJAPTXGNETA9" data-tf-redirect-target='_blank'></div><script src="//embed.typeform.com/next/embed.js"></script>
+
       <div className={pageStyles.container}>
         <main className={classNames(pageStyles.main, excelToPythonStyles.main)}>
           <div className={excelToPythonStyles.content_and_table_of_contents_container}>

--- a/trymito.io/pages/excel-to-python/[...slug].tsx
+++ b/trymito.io/pages/excel-to-python/[...slug].tsx
@@ -126,7 +126,7 @@ const ExcelToPythonGlossaryPage = (props: {pageContent: PageContent, glossaryPag
         A popup typeform that asks the user if they want to download a Pandas Cheat Sheet.
         To configure this typeform, ask Aaron for typeform access.
       */}
-      <div data-tf-live="01HV27JPE2P9SQVJAPTXGNETA9" data-tf-redirect-target='_blank'></div><script src="//embed.typeform.com/next/embed.js"></script>
+      <div data-tf-live="01HV27JPE2P9SQVJAPTXGNETA9" data-tf-redirect-target='_blank'></div><script src="//embed.typeform.com/next/embed.js" defer></script>
 
       <div className={pageStyles.container}>
         <main className={classNames(pageStyles.main, excelToPythonStyles.main)}>


### PR DESCRIPTION
# Description

Adds a popup to the excel to python glossary pages that offers a free Pandas Cheat Sheet if the user adds shares their email and company. 

# Testing

For testing, it is configured to appear 5 seconds after page load on each page load. If we're happy with it, I'll change the settings so each user only gets it once per session

# Documentation

No. 