### PR TITLE
mitosheet: add error log severity codes

### DIFF
--- a/mitosheet/mitosheet/enterprise/telemetry/mito_log_uploader.py
+++ b/mitosheet/mitosheet/enterprise/telemetry/mito_log_uploader.py
@@ -90,7 +90,7 @@ def preprocess_log_for_upload(log_event: str, log_params: Dict[str, Any]) -> Opt
         'edit_event',
         'error', 
         'mitosheet_rendered',
-        'frontend_render'
+        'frontend_render_failed',
     ]
 
     whitelisted_log_params = [
@@ -102,7 +102,6 @@ def preprocess_log_for_upload(log_event: str, log_params: Dict[str, Any]) -> Opt
     ]
 
     # Remove non-whitelisted events
-    print(log_params)
     if log_event not in whitelisted_log_events:
         return None
 
@@ -120,10 +119,11 @@ def preprocess_log_for_upload(log_event: str, log_params: Dict[str, Any]) -> Opt
     else:
         filtered_log_params['event'] = log_event
 
-    # If it is an error, add the severity code to the log and default to -1 if not found
-
+    # Add the severity code to the log and default to -1 if not found
     if log_event == 'error':
         filtered_log_params['error_severity_code'] = error_severity_codes.get(filtered_log_params['params_failed_log_event'], '-1')
+    if log_event == 'frontend_render_failed':
+        filtered_log_params['error_severity_code'] = error_severity_codes.get(log_event, '-1')
 
     return filtered_log_params
 

--- a/mitosheet/mitosheet/tests/test_mito_log_uploader.py
+++ b/mitosheet/mitosheet/tests/test_mito_log_uploader.py
@@ -160,7 +160,7 @@ def test_log_uploader_error_events():
         data = log_call[1]['data']
         log_event = json.loads(data)[0]
 
-        assert len(log_event) == 14
+        assert len(log_event) == 15
         assert log_event["error_traceback"] is not None
         assert log_event["error_traceback_last_line"] is not None
         assert log_event["params_sheet_index"] == 0
@@ -175,6 +175,8 @@ def test_log_uploader_error_events():
         assert log_event["timestamp_gmt"] is not None
         assert log_event["event"] == "error"
         assert log_event["params_failed_log_event"] == "set_column_formula_edit_failed"
+        assert log_event["error_severity_code"] == "10"
+
 
     delete_all_mito_config_environment_variables()
     
@@ -234,7 +236,7 @@ def test_log_uploaded_frontend_render_failed():
             'id': '_pt4wgfw0z'
         })
 
-        time.sleep(.5)
+        time.sleep(1)
 
         assert len(mock_post.call_args_list) == 1
 
@@ -252,6 +254,7 @@ def test_log_uploaded_frontend_render_failed():
         assert log_event['params_error_stack'] is not None
         assert log_event['params_error_message'] is not None
         assert log_event['event'] == 'frontend_render_failed'
+        assert log_event['error_severity_code'] == '50'
 
     delete_all_mito_config_environment_variables()
 


### PR DESCRIPTION
# Description

Error severity codes are used to help enterprise admins triage errors. When managing the Mito environment of 1000's of users, error severity codes are useful for building dashboards to identify changes in the user experience and prioritize improvements. 

# Testing

See new tests. 

# Documentation

Update docs before merging. 