### PR TITLE
mitosheet: fix convert to datetime with mixed dtype column

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
@@ -89,7 +89,10 @@ def get_conversion_code(state: State, sheet_index: int, column_id: ColumnID, old
 
             datetime_params_string = get_param_dict_as_code(to_datetime_params, as_single_line=True)
 
-            return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], {datetime_params_string}, errors=\'coerce\')'
+            if datetime_params_string:
+                return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], {datetime_params_string}, errors=\'coerce\')'
+            else:
+                return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], errors=\'coerce\')'
         elif is_timedelta_dtype(new_dtype):
             return f'{df_name}[{transpiled_column_header}] = pd.to_timedelta({df_name}[{transpiled_column_header}], errors=\'coerce\')'
     elif is_datetime_dtype(old_dtype):

--- a/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
+++ b/mitosheet/mitosheet/public/v1/sheet_functions/types/utils.py
@@ -60,6 +60,12 @@ def put_nan_indexes_back(series: pd.Series, original_index: pd.Index) -> pd.Seri
 
 def get_to_datetime_params(string_series: pd.Series) -> Dict[str, Any]:
 
+    # If the series is already full of datetime objects, then we don't need to 
+    # guess a datetime format. 
+    if is_series_full_of_datetimes(string_series):
+        return {}
+
+
     detected_format = get_datetime_format(string_series)
 
     # If we detect a format, we return that. This works for all pandas versions
@@ -80,6 +86,9 @@ def get_to_datetime_params(string_series: pd.Series) -> Dict[str, Any]:
         'format': 'mixed'
     }
 
+def is_series_full_of_datetimes(string_series: pd.Series) -> bool:
+    return all(isinstance(x, datetime.datetime) for x in string_series)
+
 
 def get_datetime_format(string_series: pd.Series) -> Optional[str]:
     """
@@ -87,7 +96,7 @@ def get_datetime_format(string_series: pd.Series) -> Optional[str]:
     """
     # Import log function here to avoid circular import
     from mitosheet.telemetry.telemetry_utils import log
-
+    
     # Filter to only the strings since that is all we're convertin
     string_series = string_series[string_series.apply(lambda x: isinstance(x, str))]
 
@@ -102,7 +111,6 @@ def get_datetime_format(string_series: pd.Series) -> Optional[str]:
 
     # TODO: Add the most popular formats to here and check them first before 
     # trying all of the formats below for performance.
-
     sample_string_datetime = string_series[string_series.first_valid_index()]
     FORMATS = [
         '%m{s}%d{s}%Y', 

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -388,3 +388,12 @@ def test_change_dtype_to_datetime_finds_first_string():
             ]
         })
     )
+
+def test_change_dtype_to_datetime_with_datetime_objects_in_string_series():
+    df = pd.DataFrame({'A': [pd.to_datetime('2020-01-01'), pd.to_datetime('2020-01-02'), pd.to_datetime('2020-01-03')]}, dtype=object)
+    mito = create_mito_wrapper(df)
+
+    mito.change_column_dtype(0, ['A'], 'datetime')
+
+    expected_df = pd.DataFrame({'A': [pd.to_datetime('2020-01-01'), pd.to_datetime('2020-01-02'), pd.to_datetime('2020-01-03')]})
+    assert mito.dfs[0].equals(expected_df)


### PR DESCRIPTION
# Description

Fixes bug where pandas object columns that are full of datetime values does not convert to datetime. This commonly occurs in the following case:

1. Import a dataset that has several rows of comments at the top of the file followed by a table of data. One of the columns contains datetime values
2. Delete the comments and promote the first row of the table to the header of the dataframe. Although each individual cell data type is now a datetime, the entire column is still recognized as an object column, so dates are not formatted correctly. 
3. Convert the date column to a datetime dtype. 
4. Previously this would error because Mito was looking for string values in the column to convert to datetime and not finding any. 

# Testing

See the new pytest

# Documentation

Not needed. 