### PR TITLE
mito-ai: fix bug with registering command in UseEffect

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -44,6 +44,7 @@ const getDefaultChatHistoryManager = (): ChatHistoryManager => {
         return new ChatHistoryManager(chatHistory)
 
     } else {
+        console.log("HERE")
         const chatHistoryManager = new ChatHistoryManager()
         chatHistoryManager.addSystemMessage('You are an expert Python programmer.')
         return chatHistoryManager
@@ -129,13 +130,29 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         _sendMessage(input)
     }
 
+    const getChatHistoryManager = () => {
+        return chatHistoryManagerRef.current
+    }
+
     const _sendMessage = async (input: string) => {
 
         const variables = variableManager.variables
         const activeCellCode = getActiveCellCode(notebookTracker)
 
-        // Create a new chat history manager so we can trigger a re-render of the chat
-        const updatedManager = new ChatHistoryManager(chatHistoryManager.getHistory());
+         /*
+            1. Access ChatHistoryManager via a function:
+            We use getChatHistoryManager() instead of directly accessing the state variable because 
+            the COMMAND_MITO_AI_SEND_MESSAGE is registered in a useEffect on initial render, which
+            would otherwise always use the initial state values. By using a function, we ensure we always
+            get the most recent chat history, even when the command is executed later.
+
+            2. Create a new ChatHistoryManager instance:
+            We create a copy of the current chat history and use it to initialize a new ChatHistoryManager to 
+            trigger a re-render in React, as simply appending to the existing ChatHistoryManager
+            (an immutable object) wouldn't be detected as a state change.            
+        */
+        const currentChatHistory = getChatHistoryManager().getHistory()
+        const updatedManager = new ChatHistoryManager(currentChatHistory);
         updatedManager.addUserMessage(input, activeCellCode, variables)
 
         setInput('');

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -44,7 +44,6 @@ const getDefaultChatHistoryManager = (): ChatHistoryManager => {
         return new ChatHistoryManager(chatHistory)
 
     } else {
-        console.log("HERE")
         const chatHistoryManager = new ChatHistoryManager()
         chatHistoryManager.addSystemMessage('You are an expert Python programmer.')
         return chatHistoryManager


### PR DESCRIPTION
# Description

Fixes bug where the following would occur: 
1. Send message
2. Clear Chat
3. Click explain code
4. See first chat message reappear. 

This would happen because the COMMAND_MITO_AI_SEND_MESSAGE is registered in a useEffect on initial render, which will always use the initial state values. Now, we access the chat history manager via a function to ensure we always get the most recent chat history, even when the command is executed later.

# Testing

Add a test for this: 
1. Send message
2. Clear Chat
3. Click explain code
4. See first chat message reappear. **It should not have the original message**


# Documentation

Not yet