### PR TITLE
mito-ai: create separate prompt for each type of interaction

### DIFF
--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -5,11 +5,13 @@ on:
     branches: [ dev ]
     paths:
       - 'mitosheet/**'
+      - 'tests/**'
+      - 'mito-ai/**'
   pull_request:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
-
+      - 'mito-ai/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:
     runs-on: ubuntu-20.04

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -83,6 +83,7 @@ ${variables?.map(variable => `${JSON.stringify(variable, null, 2)}\n`).join('')}
 Complete the task below. Decide what variables to use and what changes you need to make to the active code cell. Only return the full new active code cell and a concise explanation of the changes you made.
 
 <Reminders>
+
 Do not: 
 - Use the word "I"
 - Include multiple approaches in your response
@@ -136,6 +137,22 @@ Your task: ${input}`};
 
         const aiOptimizedPrompt = `You just ran the active code cell and received an error. Return the full code cell with the error corrected and a short explanation of the error.
         
+<Reminders>
+
+Do not: 
+- Use the word "I"
+- Include multiple approaches in your response
+- Recreate variables that already exist
+
+Do: 
+- Use the variables that you have access to
+- Keep as much of the original code as possible
+- Ask for more context if you need it. 
+
+</Reminders>
+
+<Important Jupyter Context>
+
 Remember that you are executing code inside a Jupyter notebook. That means you will have persistent state issues where variables from previous cells or previous code executions might still affect current code. When those errors occur, here are a few possible solutions:
 1. Restarting the kernel to reset the environment if a function or variable has been unintentionally overwritten.
 2. Identify which cell might need to be rerun to properly initialize the function or variable that is causing the issue.
@@ -143,6 +160,8 @@ Remember that you are executing code inside a Jupyter notebook. That means you w
 For example, if an error occurs because the built-in function 'print' is overwritten by an integer, you should return the code cell with the modification to the print function removed and also return an explanation that tell the user to restart their kernel. Do not add new comments to the code cell, just return the code cell with the modification removed.
         
 When a user hits an error because of a persistent state issue, tell them how to resolve it.
+
+</Important Jupyter Context>
 
 <Example>
 

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -15,7 +15,10 @@ export interface IChatHistory {
     aiOptimizedChatHistory: OpenAI.Chat.ChatCompletionMessageParam[]
 
     // The display optimized chat history is what we display to the user. Each message
-    // is a subset of the corresponding message in aiOptimizedChatHistory. 
+    // is a subset of the corresponding message in aiOptimizedChatHistory. Note that in the 
+    // displayOptimizedChatHistory, we also include connection error messages so that we can 
+    // display them in the chat interface. For example, if the user does not have an API key set, 
+    // we add a message to the chat ui that tells them to set an API key.
     displayOptimizedChatHistory: IDisplayOptimizedChatHistory[]
 }
 
@@ -68,7 +71,7 @@ export class ChatHistoryManager {
         return this.history.displayOptimizedChatHistory;
     }
 
-    addGenericUserPromptedMessage(input: string): void {
+    addChatInputMessage(input: string): void {
 
 
         const variables = this.variableManager.variables

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -14,7 +14,7 @@ import { UnifiedDiffLine } from '../../../utils/codeDiff';
 interface IChatMessageProps {
     message: OpenAI.Chat.ChatCompletionMessageParam
     messageIndex: number
-    error: boolean
+    mitoAIConnectionError: boolean
     notebookTracker: INotebookTracker
     rendermime: IRenderMimeRegistry
     app: JupyterFrontEnd
@@ -28,7 +28,7 @@ interface IChatMessageProps {
 const ChatMessage: React.FC<IChatMessageProps> = ({
     message, 
     messageIndex, 
-    error,
+    mitoAIConnectionError,
     notebookTracker,
     rendermime,
     app,
@@ -50,7 +50,6 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
             "message", 
             {"message-user" : message.role === 'user'},
             {'message-assistant' : message.role === 'assistant'},
-            {'message-error': error}
         )}>
             {messageContentParts.map(messagePart => {
                 if (messagePart.startsWith(PYTHON_CODE_BLOCK_START_WITHOUT_NEW_LINE)) {
@@ -75,7 +74,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                     }
                 } else {
                     return (
-                        <p>{error && <span style={{marginRight: '4px'}}><ErrorIcon /></span>}{messagePart}</p>
+                        <p>{mitoAIConnectionError && <span style={{marginRight: '4px'}}><ErrorIcon /></span>}{messagePart}</p>
                     )
                 }
             })}

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -148,7 +148,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
 
         // Step 1: Add the user's message to the chat history
         const newChatHistoryManager = getDuplicateChatHistoryManager()
-        newChatHistoryManager.addGenericUserPromptedMessage(input)
+        newChatHistoryManager.addChatInputMessage(input)
 
         // Step 2: Send the message to the AI
         const aiMessage = await _sendMessageToOpenAI(newChatHistoryManager)

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -46,10 +46,11 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     operatingSystem
 }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const [input, setInput] = useState('');
+
     const [chatHistoryManager, setChatHistoryManager] = useState<ChatHistoryManager>(() => getDefaultChatHistoryManager(notebookTracker, variableManager));
     const chatHistoryManagerRef = useRef<ChatHistoryManager>(chatHistoryManager);
 
-    const [input, setInput] = useState('');
     const [loadingAIResponse, setLoadingAIResponse] = useState<boolean>(false)
 
     const [unifiedDiffLines, setUnifiedDiffLines] = useState<UnifiedDiffLine[] | undefined>(undefined)
@@ -115,17 +116,17 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         This is useful when we want to send the error message from the MIME renderer directly
         to the AI chat.
     */
-    const sendDebugErrorMessage = (errorMessage: string) => {
+    const sendDebugErrorMessage = async (errorMessage: string) => {
 
         // Step 1: Add the user's message to the chat history
         const newChatHistoryManager = getDuplicateChatHistoryManager()
         newChatHistoryManager.addDebugErrorMessage(errorMessage)
 
         // Step 2: Send the message to the AI
-        _sendMessageToOpenAI(newChatHistoryManager)
+        const aiMessage = await _sendMessageToOpenAI(newChatHistoryManager)
 
         // Step 3: Update the code diff stripes
-        updateCodeDiffStripes
+        updateCodeDiffStripes(aiMessage)
     }
 
     const sendExplainCodeMessage = () => {
@@ -143,7 +144,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     /* 
         Send whatever message is currently in the chat input
     */
-    const sendGenericUserPromptedMessage = async () => {
+    const sendChatInputMessage = async () => {
 
         // Step 1: Add the user's message to the chat history
         const newChatHistoryManager = getDuplicateChatHistoryManager()
@@ -399,7 +400,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     // shift + enter to add a new line.
                     if (e.key === 'Enter' && !e.shiftKey) {
                         e.preventDefault();
-                        sendGenericUserPromptedMessage()
+                        sendChatInputMessage()
                     }
                 }}
             />

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1,18 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import OpenAI from 'openai';
 import '../../../style/ChatTaskpane.css';
 import { classNames } from '../../utils/classNames';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { getActiveCellCode, writeCodeToActiveCell } from '../../utils/notebook';
 import ChatMessage from './ChatMessage/ChatMessage';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { ChatHistoryManager, IChatHistory } from './ChatHistoryManager';
+import { ChatHistoryManager } from './ChatHistoryManager';
 import { requestAPI } from '../../utils/handler';
 import { IVariableManager } from '../VariableManager/VariableManagerPlugin';
 import LoadingDots from '../../components/LoadingDots';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { getCodeBlockFromMessage, removeMarkdownCodeFormatting } from '../../utils/strings';
-import { COMMAND_MITO_AI_APPLY_LATEST_CODE, COMMAND_MITO_AI_REJECT_LATEST_CODE, COMMAND_MITO_AI_SEND_MESSAGE } from '../../commands';
+import { COMMAND_MITO_AI_APPLY_LATEST_CODE, COMMAND_MITO_AI_REJECT_LATEST_CODE, COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE } from '../../commands';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import ResetIcon from '../../icons/ResetIcon';
 import IconButton from '../../components/IconButton';
@@ -23,36 +22,11 @@ import { CodeCell } from '@jupyterlab/cells';
 import { StateEffect, Compartment } from '@codemirror/state';
 import { codeDiffStripesExtension } from './CodeDiffDisplay';
 
+const getDefaultChatHistoryManager = (notebookTracker: INotebookTracker, variableManager: IVariableManager): ChatHistoryManager => {
 
-// IMPORTANT: In order to improve the development experience, we allow you dispaly a 
-// cached conversation as a starting point. Before deploying the mito-ai, we must 
-// set USE_DEV_AI_CONVERSATION = false
-// TODO: Write a test to ensure USE_DEV_AI_CONVERSATION is false
-const USE_DEV_AI_CONVERSATION = false
-
-const getDefaultChatHistoryManager = (): ChatHistoryManager => {
-
-    if (USE_DEV_AI_CONVERSATION) {
-        const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-            { role: 'system', content: 'You are an expert Python programmer.' },
-            { role: 'user', content: "```python x = 5\ny=10\nx+y``` update x to 10" },
-            { role: 'assistant', content: "```python x = 10\ny=10\nx+y```" },
-            { role: 'user', content: "```python x = 5\ny=10\nx+y``` Explain what this code does to me" },
-            { role: 'assistant', content: "This code defines two variables, x and y. Variables are named buckets that store a value. ```python x = 5\ny=10``` It then adds them together ```python x+y``` Let me know if you want me to further explain any of those concepts" }
-        ]
-
-        const chatHistory: IChatHistory = {
-            aiOptimizedChatHistory: [...messages],
-            displayOptimizedChatHistory: [...messages].map(message => ({ message: message, error: false }))
-        }
-
-        return new ChatHistoryManager(chatHistory)
-
-    } else {
-        const chatHistoryManager = new ChatHistoryManager()
-        chatHistoryManager.addSystemMessage('You are an expert Python programmer.')
-        return chatHistoryManager
-    }
+    const chatHistoryManager = new ChatHistoryManager(variableManager, notebookTracker)
+    chatHistoryManager.addSystemMessage('You are an expert Python programmer.')
+    return chatHistoryManager
 }
 
 interface IChatTaskpaneProps {
@@ -71,7 +45,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     operatingSystem
 }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const [chatHistoryManager, setChatHistoryManager] = useState<ChatHistoryManager>(() => getDefaultChatHistoryManager());
+    const [chatHistoryManager, setChatHistoryManager] = useState<ChatHistoryManager>(() => getDefaultChatHistoryManager(notebookTracker, variableManager));
     const chatHistoryManagerRef = useRef<ChatHistoryManager>(chatHistoryManager);
 
     const [input, setInput] = useState('');
@@ -122,55 +96,82 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         adjustHeight();
     }, [input]);
 
+    
+
+    const getDuplicateChatHistoryManager = () => {
+
+        /*
+            We use getDuplicateChatHistoryManager() instead of directly accessing the state variable because 
+            the COMMAND_MITO_AI_SEND_MESSAGE is registered in a useEffect on initial render, which
+            would otherwise always use the initial state values. By using a function, we ensure we always
+            get the most recent chat history, even when the command is executed later.        
+        */
+        return chatHistoryManagerRef.current.createDuplicateChatHistoryManager()
+    }
+
     /* 
         Send a message with a specific input, clearing what is currently in the chat input.
         This is useful when we want to send the error message from the MIME renderer directly
         to the AI chat.
     */
-    const sendMessageWithInput = async (input: string) => {
-        _sendMessage(input)
+    const sendDebugErrorMessage = (errorMessage: string) => {
+
+        const newChatHistoryManager = getDuplicateChatHistoryManager()
+        newChatHistoryManager.addGenericUserPromptedMessage(input)
+        _sendMessageToOpenAI(newChatHistoryManager)
+    }
+
+    const sendExplainCodeMessage = () => {
+        const newChatHistoryManager = getDuplicateChatHistoryManager()
+        newChatHistoryManager.addExplainCodeMessage()
+        _sendMessageToOpenAI(newChatHistoryManager)
     }
 
     /* 
-        Send a message with the text currently in the chat input.
+        Send whatever message is currently in the chat input
     */
-    const sendMessageFromChat = async () => {
-        _sendMessage(input)
-    }
+    const sendGenericUserPromptedMessage = async () => {
 
-    const getChatHistoryManager = () => {
-        return chatHistoryManagerRef.current
-    }
+        const newChatHistoryManager = getDuplicateChatHistoryManager()
+        newChatHistoryManager.addGenericUserPromptedMessage(input)
 
-    const _sendMessage = async (input: string) => {
+        setChatHistoryManager(newChatHistoryManager)
 
-        const variables = variableManager.variables
+        const aiMessage = await _sendMessageToOpenAI(newChatHistoryManager)
+
+        if (!aiMessage) {
+            return
+        }
+
         const activeCellCode = getActiveCellCode(notebookTracker)
 
-         /*
-            1. Access ChatHistoryManager via a function:
-            We use getChatHistoryManager() instead of directly accessing the state variable because 
-            the COMMAND_MITO_AI_SEND_MESSAGE is registered in a useEffect on initial render, which
-            would otherwise always use the initial state values. By using a function, we ensure we always
-            get the most recent chat history, even when the command is executed later.
+        // Extract the code from the AI's message and then calculate the code diffs
+        const aiGeneratedCode = getCodeBlockFromMessage(aiMessage);
+        const aiGeneratedCodeCleaned = removeMarkdownCodeFormatting(aiGeneratedCode || '');
+        const { unifiedCodeString, unifiedDiffs } = getCodeDiffsAndUnifiedCodeString(activeCellCode, aiGeneratedCodeCleaned)
 
-            2. Create a new ChatHistoryManager instance:
-            We create a copy of the current chat history and use it to initialize a new ChatHistoryManager to 
-            trigger a re-render in React, as simply appending to the existing ChatHistoryManager
-            (an immutable object) wouldn't be detected as a state change.            
-        */
-        const currentChatHistory = getChatHistoryManager().getHistory()
-        const updatedManager = new ChatHistoryManager(currentChatHistory);
-        updatedManager.addUserMessage(input, activeCellCode, variables)
+        // Store the original code so that we can revert to it if the user rejects the AI's code
+        originalCodeBeforeDiff.current = activeCellCode || ''
+
+        // Temporarily write the unified code string to the active cell so we can display
+        // the code diffs to the user. Once the user accepts or rejects the code, we'll 
+        // apply the correct version of the code.
+        writeCodeToActiveCell(notebookTracker, unifiedCodeString)
+        setUnifiedDiffLines(unifiedDiffs)
+    }
+
+    const _sendMessageToOpenAI = async (newChatHistoryManager: ChatHistoryManager) => {
 
         setInput('');
         setLoadingAIResponse(true)
+
+        let aiRespone = undefined
 
         try {
             const apiResponse = await requestAPI('mito_ai/completion', {
                 method: 'POST',
                 body: JSON.stringify({
-                    messages: updatedManager.getAIOptimizedHistory()
+                    messages: newChatHistoryManager.getAIOptimizedHistory()
                 })
             });
 
@@ -179,34 +180,21 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                 const response = apiResponse.response;
                 const aiMessage = response.choices[0].message;
 
-                updatedManager.addAIMessageFromResponse(aiMessage);
-                setChatHistoryManager(updatedManager);
-
-                // Extract the code from the AI's message and then calculate the code diffs
-                const aiGeneratedCode = getCodeBlockFromMessage(aiMessage);
-                const aiGeneratedCodeCleaned = removeMarkdownCodeFormatting(aiGeneratedCode || '');
-                const { unifiedCodeString, unifiedDiffs } = getCodeDiffsAndUnifiedCodeString(activeCellCode, aiGeneratedCodeCleaned)
-
-                // Store the original code so that we can revert to it if the user rejects the AI's code
-                originalCodeBeforeDiff.current = activeCellCode || ''
-
-                // Temporarily write the unified code string to the active cell so we can display
-                // the code diffs to the user. Once the user accepts or rejects the code, we'll 
-                // apply the correct version of the code.
-                writeCodeToActiveCell(notebookTracker, unifiedCodeString)
-                setUnifiedDiffLines(unifiedDiffs)
+                newChatHistoryManager.addAIMessageFromResponse(aiMessage);
+                setChatHistoryManager(newChatHistoryManager);
+                aiRespone = aiMessage
             } else {
-                updatedManager.addAIMessageFromMessageContent(apiResponse.errorMessage, true)
-                setChatHistoryManager(updatedManager);
+                newChatHistoryManager.addAIMessageFromMessageContent(apiResponse.errorMessage, true)
+                setChatHistoryManager(newChatHistoryManager);
             }
-
-            setLoadingAIResponse(false)
         } catch (error) {
             console.error('Error calling OpenAI API:', error);
         } finally {
             setLoadingAIResponse(false)
+            return aiRespone
         }
-    };
+
+    }
 
     const displayOptimizedChatHistory = chatHistoryManager.getDisplayOptimizedHistory()
 
@@ -275,13 +263,20 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             Add a new command to the JupyterLab command registry that sends the current chat message.
             We use this to automatically send the message when the user adds an error to the chat. 
         */
-        app.commands.addCommand(COMMAND_MITO_AI_SEND_MESSAGE, {
+        app.commands.addCommand(COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, {
             execute: (args?: ReadonlyPartialJSONObject) => {
                 if (args?.input) {
-                    sendMessageWithInput(args.input.toString())
+                    sendDebugErrorMessage(args.input.toString())
                 }
             }
         })
+
+        app.commands.addCommand(COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE, {
+            execute: () => {
+                sendExplainCodeMessage()
+            }
+        })
+
     }, [])
 
     // Create a WeakMap to store compartments per code cell
@@ -348,7 +343,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     icon={<ResetIcon />}
                     title="Clear the chat history"
                     onClick={() => {
-                        setChatHistoryManager(getDefaultChatHistoryManager())
+                        setChatHistoryManager(getDefaultChatHistoryManager(notebookTracker, variableManager))
                     }}
                 />
             </div>
@@ -357,7 +352,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     return (
                         <ChatMessage
                             message={displayOptimizedChat.message}
-                            error={displayOptimizedChat.error || false}
+                            mitoAIConnectionError={displayOptimizedChat.type === 'connection error'}
                             messageIndex={index}
                             notebookTracker={notebookTracker}
                             rendermime={rendermime}
@@ -387,7 +382,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     // shift + enter to add a new line.
                     if (e.key === 'Enter' && !e.shiftKey) {
                         e.preventDefault();
-                        sendMessageFromChat();
+                        sendGenericUserPromptedMessage()
                     }
                 }}
             />

--- a/mito-ai/src/Extensions/AiChat/CodeDiffDisplay.tsx
+++ b/mito-ai/src/Extensions/AiChat/CodeDiffDisplay.tsx
@@ -102,3 +102,4 @@ export function codeDiffStripesExtension(options: { unifiedDiffLines?: UnifiedDi
     showStripes
   ];
 }
+

--- a/mito-ai/src/Extensions/CellToolbarButtons/CellToolbarButtonsPlugin.tsx
+++ b/mito-ai/src/Extensions/CellToolbarButtons/CellToolbarButtonsPlugin.tsx
@@ -3,7 +3,7 @@ import {
     JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { COMMAND_MITO_AI_OPEN_CHAT, COMMAND_MITO_AI_SEND_MESSAGE } from '../../commands';
+import { COMMAND_MITO_AI_OPEN_CHAT, COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE } from '../../commands';
 import { LabIcon } from '@jupyterlab/ui-components';
 import LightbulbIcon from '../../../src/icons/LightbulbIcon.svg'
 
@@ -31,16 +31,12 @@ const CellToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
             execute: () => {
                 /* 
                     In order to click on the cell toolbar button, that cell must be the active cell, 
-                    so the Ai Chat taskpane will take care of providing the cell context.
-
-                    TODO: In the future, instead of directly calling COMMAND_MITO_AI_SEND_MESSAGE, we should
-                    update the AI Chat History Manager so that we can generate an AI optimzied message and a 
-                    display optimized message.
+                    so the ChatHistoryManager will take care of providing the cell context.
                 */
                 app.commands.execute(COMMAND_MITO_AI_OPEN_CHAT)
-                app.commands.execute(COMMAND_MITO_AI_SEND_MESSAGE, { input: `Explain this code` });
+                app.commands.execute(COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE);
             },
-            isVisible: () => notebookTracker.activeCell?.model.type === 'code' && app.commands.hasCommand(COMMAND_MITO_AI_SEND_MESSAGE)
+            isVisible: () => notebookTracker.activeCell?.model.type === 'code' && app.commands.hasCommand(COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE)
         });
     }
 };

--- a/mito-ai/src/Extensions/ErrorMimeRenderer/ErrorMimeRendererPlugin.tsx
+++ b/mito-ai/src/Extensions/ErrorMimeRenderer/ErrorMimeRendererPlugin.tsx
@@ -4,7 +4,7 @@ import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application'
 import { IRenderMimeRegistry} from '@jupyterlab/rendermime';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Widget } from '@lumino/widgets';
-import { COMMAND_MITO_AI_OPEN_CHAT, COMMAND_MITO_AI_SEND_MESSAGE } from '../../commands';
+import { COMMAND_MITO_AI_OPEN_CHAT, COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE } from '../../commands';
 import MagicWandIcon from '../../icons/MagicWand';
 import '../../../style/ErrorMimeRendererPlugin.css'
 
@@ -81,7 +81,7 @@ class AugmentedStderrRenderer extends Widget implements IRenderMime.IRenderer {
     openChatInterfaceWithError(model: IRenderMime.IMimeModel): void {
         const conciseErrorMessage = this.getErrorString(model);
         this.app.commands.execute(COMMAND_MITO_AI_OPEN_CHAT)
-        this.app.commands.execute(COMMAND_MITO_AI_SEND_MESSAGE, { input: conciseErrorMessage });
+        this.app.commands.execute(COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, { input: conciseErrorMessage });
     }
 
     /* 

--- a/mito-ai/src/commands.tsx
+++ b/mito-ai/src/commands.tsx
@@ -4,3 +4,5 @@ export const COMMAND_MITO_AI_OPEN_CHAT = `${MITO_AI}:open-chat`
 export const COMMAND_MITO_AI_APPLY_LATEST_CODE = `${MITO_AI}:apply-latest-code`
 export const COMMAND_MITO_AI_REJECT_LATEST_CODE = `${MITO_AI}:reject-latest-code`
 export const COMMAND_MITO_AI_SEND_MESSAGE = `${MITO_AI}:send-message`
+export const COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE = `${MITO_AI}:send-explain-code-message`
+export const COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE = `${MITO_AI}:send-debug-error-message`


### PR DESCRIPTION
# Description

Creates a separate code path for each type of AI completion. Each time we send a message to the AI there are three steps. 
1. Create a message. Some types of messages (like generating code) are more context hungry than others (explain active code cell). This step is responsible for building the write prompt with the right context for the specific message type.
2. Send the message to the AI and handle errors properly. This is the same for all types of AI messages. 
3. Post process. Currently, the only post processing step we have is showing code diffs. We want to do this in all cases except explaining code which should not return new code. 

# Testing

Try it out + see tests. 

# Documentation

No. 