### PR TITLE
Added check for isLastAiMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+scratch*
 
 # Mac Specific 
 

--- a/mito-ai/Untitled.ipynb
+++ b/mito-ai/Untitled.ipynb
@@ -122,7 +122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
@@ -24,18 +24,18 @@ interface ICodeBlockProps {
 }
 
 const CodeBlock: React.FC<ICodeBlockProps> = ({
-    code, 
-    role, 
-    rendermime, 
-    notebookTracker, 
-    app, 
+    code,
+    role,
+    rendermime,
+    notebookTracker,
+    app,
     isLastAiMessage,
     operatingSystem,
     setDisplayCodeDiff,
     acceptAICode,
     rejectAICode
 }): JSX.Element => {
-    
+
     const notebookName = getNotebookName(notebookTracker)
 
     const copyCodeToClipboard = () => {
@@ -61,12 +61,16 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
                     <div className='code-location'>
                         {notebookName}
                     </div>
-                    <button onClick={() => {acceptAICode()}}>
-                        Apply {isLastAiMessage ? (operatingSystem === 'mac' ? 'CMD+Y' : 'CTRL+Y') : ''}
-                    </button>
-                    <button onClick={() => {rejectAICode()}}>
-                        Deny {isLastAiMessage ? (operatingSystem === 'mac' ? 'CMD+D' : 'CTRL+D') : ''}
-                    </button>
+                    {isLastAiMessage && (
+                        <>
+                            <button onClick={() => { acceptAICode() }}>
+                                Apply {operatingSystem === 'mac' ? 'CMD+Y' : 'CTRL+Y'}
+                            </button>
+                            <button onClick={() => { rejectAICode() }}>
+                                Deny {operatingSystem === 'mac' ? 'CMD+D' : 'CTRL+D'}
+                            </button>
+                        </>
+                    )}
                     <button onClick={copyCodeToClipboard}>Copy</button>
                 </div>
                 <PythonCode


### PR DESCRIPTION
# Description

The Mito AI taskpane now only shows the Accept/Deny buttons on the last message. Previous message will only display the option to copy code. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

N/A