### PR TITLE
Moved mito-ai tests into separate workflow

### DIFF
--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -1,0 +1,64 @@
+name: Test - Mito AI
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mito-ai/**'
+  pull_request:
+    paths:
+      - 'mito-ai/**'
+jobs:
+  test-mitoai-frontend-jupyterlab:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.10', '3.11']
+      fail-fast: false
+
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          mito-ai/setup.py
+          tests/requirements.txt
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+        cache-dependency-path: mito-ai/package-lock.json
+    - name: Install dependencies
+      run: |
+        cd tests
+        bash mac-setup.sh
+    - name: Setup JupyterLab
+      run: |
+        cd tests
+        source venv/bin/activate
+        cd ../mito-ai
+        jupyter labextension develop . --overwrite
+        jupyter server extension enable --py mito-ai
+    - name: Start a server and run tests
+      run: |
+        cd tests
+        source venv/bin/activate
+        jupyter lab --config jupyter_server_test_config.py &
+        npm run test:mitoai
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    - name: Upload test-results
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: mitoai-jupyterlab-playwright-report-${{ matrix.python-version }}
+        path: tests/playwright-report/
+        retention-days: 14

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -6,12 +6,10 @@ on:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
-      - 'mito-ai/**'
   pull_request:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
-      - 'mito-ai/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:
     runs-on: ubuntu-20.04
@@ -112,60 +110,6 @@ jobs:
       if: failure()
       with:
         name: jupyternotebook-playwright-report-${{ matrix.python-version }}
-        path: tests/playwright-report/
-        retention-days: 14
-
-  test-mitoai-frontend-jupyterlab:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.10', '3.11']
-      fail-fast: false
-
-    steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          mito-ai/setup.py
-          tests/requirements.txt
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-        cache: 'npm'
-        cache-dependency-path: mito-ai/package-lock.json
-    - name: Install dependencies
-      run: |
-        cd tests
-        bash mac-setup.sh
-    - name: Setup JupyterLab
-      run: |
-        cd tests
-        source venv/bin/activate
-        cd ../mito-ai
-        jupyter labextension develop . --overwrite
-        jupyter server extension enable --py mito-ai
-    - name: Start a server and run tests
-      run: |
-        cd tests
-        source venv/bin/activate
-        jupyter lab --config jupyter_server_test_config.py &
-        npm run test:mitoai
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    - name: Upload test-results
-      uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: mitoai-jupyterlab-playwright-report-${{ matrix.python-version }}
         path: tests/playwright-report/
         retention-days: 14
 


### PR DESCRIPTION
# Description

test-mitosheet-frontend will only be triggered if changes are made to `mitosheet/` or `tests/`; while test-mito-ai will cover changes made to the `mito-ai/` dir. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

N/A