### PR TITLE
Updated margin and padding

### DIFF
--- a/mito-ai/style/PythonCode.css
+++ b/mito-ai/style/PythonCode.css
@@ -2,8 +2,8 @@
     flex-grow: 1;
     height: 100%;
     width: 100%;
-    margin: 0;
-    padding: 10px;
+    margin: 0 !important;
+    padding: 10px !important;
     font-size: 12px;
     font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New;
     white-space: nowrap;


### PR DESCRIPTION
# Description

Updated margin and padding for `.code-message-part-python-code pre` to include the `!important` keyword. This fixes the issue where code snippets in the AI taskpane are offset. 

# Testing

CSS changes, visually tested on local machine (using Chrome).

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

N/A