### PR TITLE
update font size and line wrap of chat code

### DIFF
--- a/mito-ai/style/PythonCode.css
+++ b/mito-ai/style/PythonCode.css
@@ -8,7 +8,7 @@
     overflow-x: auto;
 }
 
-code {
+.code-message-part-python-code code {
     white-space: pre !important;
 }
 

--- a/mito-ai/style/PythonCode.css
+++ b/mito-ai/style/PythonCode.css
@@ -5,8 +5,11 @@
     margin: 0 !important;
     padding: 10px !important;
     font-size: 12px !important;
-    white-space: pre !important;
     overflow-x: auto;
+}
+
+code {
+    white-space: pre !important;
 }
 
 .code-message-part-python-code .jp-RenderedHTMLCommon > *:last-child {

--- a/mito-ai/style/PythonCode.css
+++ b/mito-ai/style/PythonCode.css
@@ -4,9 +4,8 @@
     width: 100%;
     margin: 0 !important;
     padding: 10px !important;
-    font-size: 12px;
-    font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New;
-    white-space: nowrap;
+    font-size: 12px !important;
+    white-space: pre !important;
     overflow-x: auto;
 }
 


### PR DESCRIPTION
# Description

1. Updates the text wrapping in the AI chat taskpane so that one line of code does not wrap to a second line in the code preview. Instead, you can scroll to see the full line of code. I think this makes the code more readable. 
2. Uses the jupyter default code family so if the user changes their settings, its reflected in our code preview
3. Set the font size to 12px so it takes up less space. 

# Testing

Try it out. 

# Documentation

No. 