### PR TITLE
mito-ai: fix small chat input bug

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -87,11 +87,11 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (!textarea) {
             return
         }
-        textarea.style.height = 'auto';
+        textarea.style.minHeight = 'auto';
 
         // The height should be 20 at minimum to support the placeholder
-        const height = textarea.scrollHeight < 20 ? 20 : textarea.scrollHeight
-        textarea.style.height = `${height}px`;
+        const minHeight = textarea.scrollHeight < 20 ? 20 : textarea.scrollHeight
+        textarea.style.minHeight = `${minHeight}px`;
     };
 
     useEffect(() => {


### PR DESCRIPTION
# Description

Fixes bug where dynamic calculation of chat input height was sometimes resulting in too small of an input. 

<img width="352" alt="Screenshot 2024-11-04 at 10 00 13 AM" src="https://github.com/user-attachments/assets/efaf32b1-84a9-4d13-9271-e118bb010933">

# Testing

This bug would only some of the times, and only when first opening the chat input without any messages already sent.  Try opening the chat input a few times and making sure you never see this bug. 

# Documentation

No. 