### PR TITLE
Accounts v1

### DIFF
--- a/mito-ai/README.md
+++ b/mito-ai/README.md
@@ -50,24 +50,25 @@ pip install -e ".[test, deploy]"
 # Install the node modules
 jlpm install
 
+# Build the extension
+jlpm build
+
 # Link your development version of the extension with JupyterLab
 jupyter labextension develop . --overwrite
 
 # Start the jupyter server extension for development
 jupyter server extension enable --py mito-ai
 
-# Rebuild extension Typescript source after making changes
+# Watch the source directory in one terminal, automatically rebuilding when needed
 # In case of Error: If this command fails because the lib directory was not created (the error will say something like
 # unable to find main entry point) then run `jlpm run clean:lib` first to get rid of the old buildcache 
 # that might be preventing a new lib directory from getting created. 
-jlpm build
+jlpm watch
 ```
 
-You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+Then, in a new terminal, run:
 
 ```bash
-# Watch the source directory in one terminal, automatically rebuilding when needed
-jlpm watch
 # Run JupyterLab in another terminal
 jupyter lab
 ```

--- a/mito-ai/mito-ai/utils/create.py
+++ b/mito-ai/mito-ai/utils/create.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+
+"""
+Utilities for creating and initializing the user.json
+file with the current schema
+"""
+
+import json
+import os
+
+from .db import (MITO_FOLDER, USER_JSON_PATH, set_user_field)
+from .schema import (GITHUB_ACTION_EMAIL, GITHUB_ACTION_ID,
+                                    UJ_STATIC_USER_ID, UJ_USER_EMAIL,
+                                    USER_JSON_DEFAULT)
+
+
+def is_user_json_exists_and_valid_json() -> bool:
+    """
+    Helper function that determines if the current user.json both
+    exists and is valid json
+    """
+    if not os.path.exists(USER_JSON_PATH):
+        return False
+
+    try:
+        with open(USER_JSON_PATH, 'r') as f:
+            json.loads(f.read())
+        return True
+    except:
+        return False
+
+
+def try_create_user_json_file() -> None:
+    # Create the mito folder if it does not exist
+    if not os.path.exists(MITO_FOLDER):
+        os.mkdir(MITO_FOLDER)
+
+    # We create a user.json file if it does not exist, or if it
+    # is invalid (e.g. it is not parseable JSON).
+    if not is_user_json_exists_and_valid_json():
+        # First, we write an empty default object
+        with open(USER_JSON_PATH, 'w+') as f:
+            f.write(json.dumps(USER_JSON_DEFAULT))
+
+        # Then, we take special care to put all the testing/CI environments 
+        # (e.g. Github actions) under one ID and email
+        from mitosheet.user.utils import is_running_test
+        if is_running_test():
+            set_user_field(UJ_STATIC_USER_ID, GITHUB_ACTION_ID)
+            set_user_field(UJ_USER_EMAIL, GITHUB_ACTION_EMAIL)
+
+
+def initialize_user(call_identify: bool=True) -> None:
+    """
+    Internal helper function that gets called every time mitosheet 
+    is imported.
+
+    It:
+    1. Creates the user.json if it does not exist (though it usually does, from the installer)
+    2. Upgrades the user.json to the most up to date format
+    3. Updates the user.json file with any usage or upgrading, logging anything interesting.
+    
+    By default, also identifies the user, but may not do this in some cases (when identify
+    is False), as the user may just be turning logging off or something.
+    """
+    # Try to create the user.json file, if it does not already exist
+    try_create_user_json_file()
+
+    # Note, its possible that a user has a previous version of the user.json file if they 
+    # downloaded Mito >1 year ago and have not yet upgraded. But for simplicity, let's not 
+    # try to upgrade it here. We will either move away from user.json all together
+    # or unify the utilities for mitosheet and mitoai.

--- a/mito-ai/mito-ai/utils/db.py
+++ b/mito-ai/mito-ai/utils/db.py
@@ -1,0 +1,31 @@
+"""
+Helpers for accessing the user.json file
+"""
+import os
+import json
+from typing import Any, Dict, Optional
+from .schema import MITO_FOLDER
+
+# The path of the user.json file
+USER_JSON_PATH = os.path.join(MITO_FOLDER, 'user.json')
+
+def get_user_field(field: str) -> Optional[Any]:
+    """
+    Returns the value stored at field in the user.json file,
+    but may read a different file if it passed
+    """
+    try:
+        with open(USER_JSON_PATH) as f:
+            return json.load(f)[field]
+    except: 
+        return None
+    
+def set_user_field(field: str, value: Any) -> None:
+    """
+    Updates the value of a specific feild in user.json
+    """
+    with open(USER_JSON_PATH, 'r') as user_file_old:
+        old_user_json = json.load(user_file_old)
+        old_user_json[field] = value
+        with open(USER_JSON_PATH, 'w+') as f:
+            f.write(json.dumps(old_user_json))

--- a/mito-ai/mito-ai/utils/open_ai_utils.py
+++ b/mito-ai/mito-ai/utils/open_ai_utils.py
@@ -6,11 +6,18 @@
 import os
 import requests
 from typing import Any, Dict, List
+from .db import get_user_field, set_user_field
+from .schema import UJ_AI_MITO_API_NUM_USAGES, UJ_STATIC_USER_ID, UJ_USER_EMAIL
+from .version_utils import is_pro
 
 OPEN_AI_URL = 'https://api.openai.com/v1/chat/completions'
 MITO_AI_URL = 'https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/'
 
 OPEN_SOURCE_AI_COMPLETIONS_LIMIT = 100
+
+__user_email = None
+__user_id = None
+__num_usages = None
 
 def _get_ai_completion_data(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {
@@ -19,12 +26,28 @@ def _get_ai_completion_data(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
             "temperature": 0,
         }
 
-__user_email = None
-__user_id = None
-__num_usages = None
+def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> Dict[str, Any]:   
+        
+        global __user_email, __user_id, __num_usages
 
-def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> Dict[str, Any]:          
+        if __user_email is None:
+                __user_email = get_user_field(UJ_USER_EMAIL)
+        if __user_id is None:
+                __user_id = get_user_field(UJ_STATIC_USER_ID)
+        if __num_usages is None:
+                __num_usages = get_user_field(UJ_AI_MITO_API_NUM_USAGES)
 
+
+        if __num_usages is None:
+                __num_usages = 0
+
+        pro = is_pro()
+
+        if not pro and __num_usages >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
+                return {
+                        'error': f'You have used Mito AI {OPEN_SOURCE_AI_COMPLETIONS_LIMIT} times.'
+                }
+                
         data = {
                 'email': __user_email,
                 'user_id': __user_id,
@@ -47,6 +70,7 @@ def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> D
                 # so we just return that.
                 return res.json()
 
+
         except Exception as e:
                 print('Error using mito server', e)
                 raise e
@@ -58,9 +82,13 @@ def get_open_ai_completion(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
         ai_completion_data = _get_ai_completion_data(messages)
 
         if OPENAI_API_KEY is None:
-                # If they don't have an Open AI key,
-                # use the mito server to get a completion
+                # If they don't have an Open AI key, use the mito server to get a completion
                 completion = _get_ai_completion_from_mito_server(ai_completion_data)
+
+                # Increment the number of usages
+                global __num_usages
+                __num_usages = __num_usages + 1
+                set_user_field(UJ_AI_MITO_API_NUM_USAGES, __num_usages)
                 return completion
 
         headers = {

--- a/mito-ai/mito-ai/utils/open_ai_utils.py
+++ b/mito-ai/mito-ai/utils/open_ai_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from .db import get_user_field, set_user_field
 from .schema import UJ_AI_MITO_API_NUM_USAGES, UJ_STATIC_USER_ID, UJ_USER_EMAIL
 from .version_utils import is_pro
+from .create import initialize_user, is_user_json_exists_and_valid_json
 
 OPEN_AI_URL = 'https://api.openai.com/v1/chat/completions'
 MITO_AI_URL = 'https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/'
@@ -26,7 +27,10 @@ def _get_ai_completion_data(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
             "temperature": 0,
         }
 
-def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> Dict[str, Any]:   
+def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> Dict[str, Any]: 
+
+        if not is_user_json_exists_and_valid_json():
+                initialize_user()
         
         global __user_email, __user_id, __num_usages
 

--- a/mito-ai/mito-ai/utils/open_ai_utils.py
+++ b/mito-ai/mito-ai/utils/open_ai_utils.py
@@ -13,7 +13,7 @@ from .version_utils import is_pro
 OPEN_AI_URL = 'https://api.openai.com/v1/chat/completions'
 MITO_AI_URL = 'https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/'
 
-OPEN_SOURCE_AI_COMPLETIONS_LIMIT = 100
+OPEN_SOURCE_AI_COMPLETIONS_LIMIT = 500
 
 __user_email = None
 __user_id = None
@@ -45,7 +45,7 @@ def _get_ai_completion_from_mito_server(ai_completion_data: Dict[str, Any]) -> D
 
         if not pro and __num_usages >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
                 return {
-                        'error': f'You have used Mito AI {OPEN_SOURCE_AI_COMPLETIONS_LIMIT} times.'
+                        'error': f'You have used Mito AI {OPEN_SOURCE_AI_COMPLETIONS_LIMIT} times. Either upgrade to Pro for unlimited uses or supply your own OpenAI API key.'
                 }
                 
         data = {

--- a/mito-ai/mito-ai/utils/schema.py
+++ b/mito-ai/mito-ai/utils/schema.py
@@ -1,0 +1,17 @@
+import os
+
+# Current field names
+UJ_USER_EMAIL = 'user_email'
+UJ_STATIC_USER_ID = 'static_user_id'
+UJ_MITOSHEET_PRO = 'mitosheet_pro'
+UJ_MITOSHEET_ENTERPRISE = 'mitosheet_enterprise'
+UJ_AI_MITO_API_NUM_USAGES = 'ai_mito_api_num_usages'
+
+MITO_CONFIG_KEY_HOME_FOLDER = 'MITO_CONFIG_HOME_FOLDER'
+if MITO_CONFIG_KEY_HOME_FOLDER in os.environ:
+    HOME_FOLDER = os.path.expanduser(os.environ[MITO_CONFIG_KEY_HOME_FOLDER])
+else:
+    HOME_FOLDER = os.path.expanduser('~')
+
+# Where all global .mito files are stored
+MITO_FOLDER = os.path.join(HOME_FOLDER, ".mito")

--- a/mito-ai/mito-ai/utils/schema.py
+++ b/mito-ai/mito-ai/utils/schema.py
@@ -1,11 +1,36 @@
 import os
+from datetime import datetime
+from .utils import get_random_id
 
 # Current field names
-UJ_USER_EMAIL = 'user_email'
+# Some helpful constants
+GITHUB_ACTION_ID = 'github_action'
+GITHUB_ACTION_EMAIL = 'github@action.com'
+
+# Old field names
+UJ_INTENDED_BEHAVIOR = 'intended_behavior'
+UJ_CLOSED_FEEDBACK = 'closed_feedback'
+UJ_MITOSHEET_LAST_FIVE_USAGES = 'mitosheet_last_five_usages'
+
+# Current field names
+UJ_USER_JSON_VERSION = 'user_json_version'
 UJ_STATIC_USER_ID = 'static_user_id'
+UJ_USER_SALT = 'user_salt'
+UJ_USER_EMAIL = 'user_email'
+UJ_RECEIVED_TOURS = 'received_tours'
+UJ_FEEDBACKS = 'feedbacks'
+UJ_FEEDBACKS_V2 = 'feedbacks_v2'
+UJ_MITOSHEET_CURRENT_VERSION = 'mitosheet_current_version'
+UJ_MITOSHEET_LAST_UPGRADED_DATE = 'mitosheet_last_upgraded_date'
+UJ_MITOSHEET_LAST_FIFTY_USAGES = 'mitosheet_last_fifty_usages'
+UJ_MITOSHEET_TELEMETRY = 'mitosheet_telemetry'
 UJ_MITOSHEET_PRO = 'mitosheet_pro'
 UJ_MITOSHEET_ENTERPRISE = 'mitosheet_enterprise'
+UJ_EXPERIMENT = 'experiment'
+UJ_RECEIVED_CHECKLISTS = 'received_checklists'
+UJ_AI_PRIVACY_POLICY = 'ai_privacy_policy'
 UJ_AI_MITO_API_NUM_USAGES = 'ai_mito_api_num_usages'
+
 
 MITO_CONFIG_KEY_HOME_FOLDER = 'MITO_CONFIG_HOME_FOLDER'
 if MITO_CONFIG_KEY_HOME_FOLDER in os.environ:
@@ -15,3 +40,39 @@ else:
 
 # Where all global .mito files are stored
 MITO_FOLDER = os.path.join(HOME_FOLDER, ".mito")
+
+"""
+The most up to date version of the user.json object
+"""
+USER_JSON_VERSION_10 = {
+    # The new version of the user json object
+    UJ_USER_JSON_VERSION: 10,
+    # The static id of the user
+    UJ_STATIC_USER_ID: get_random_id(),
+    # A random secret that the user can use as salt when hashing things
+    UJ_USER_SALT: get_random_id(),
+    # Email of the user
+    UJ_USER_EMAIL: '',
+    # Tours that the user has received
+    UJ_RECEIVED_TOURS: [],
+    # A list of all the feedback the user has given
+    UJ_FEEDBACKS: [],
+    UJ_FEEDBACKS_V2: {},
+    UJ_MITOSHEET_CURRENT_VERSION: 0,
+    UJ_MITOSHEET_LAST_UPGRADED_DATE: datetime.today().strftime('%Y-%m-%d'),
+    UJ_MITOSHEET_LAST_FIFTY_USAGES: [datetime.today().strftime('%Y-%m-%d')],
+    UJ_MITOSHEET_TELEMETRY: True,
+    UJ_MITOSHEET_PRO: False,
+    UJ_MITOSHEET_ENTERPRISE: False,
+    UJ_EXPERIMENT: {
+        'experiment_id': 'installer_communication_and_time_to_value',
+        'variant': 'B',
+    },
+    UJ_RECEIVED_CHECKLISTS: {},
+    UJ_AI_PRIVACY_POLICY: False,
+    UJ_AI_MITO_API_NUM_USAGES: 0
+}
+
+# This is the most up to date user json, and you must update it when
+# you add a new schema
+USER_JSON_DEFAULT = USER_JSON_VERSION_10

--- a/mito-ai/mito-ai/utils/utils.py
+++ b/mito-ai/mito-ai/utils/utils.py
@@ -1,0 +1,8 @@
+import uuid
+
+def get_random_id() -> str:
+    """
+    Creates a new random ID for the user, which for any given user,
+    should only happen once.
+    """
+    return str(uuid.uuid1())

--- a/mito-ai/mito-ai/utils/version_utils.py
+++ b/mito-ai/mito-ai/utils/version_utils.py
@@ -1,0 +1,68 @@
+import os
+from .schema import UJ_MITOSHEET_ENTERPRISE, UJ_MITOSHEET_PRO
+from .db import get_user_field
+
+try:
+    import mitosheet_helper_pro
+    MITOSHEET_HELPER_PRO = True
+except ImportError:
+    MITOSHEET_HELPER_PRO = False
+try:
+    import mitosheet_helper_enterprise
+    MITOSHEET_HELPER_ENTERPRISE = True
+except ImportError:
+    MITOSHEET_HELPER_ENTERPRISE = False
+
+try:
+    import mitosheet_private
+    MITOSHEET_PRIVATE = True
+except ImportError:
+    MITOSHEET_PRIVATE = False
+
+
+def is_pro() -> bool:
+    """
+    Helper function for returning if this is a
+    pro deployment of mito
+    """
+
+    # This package overides the user.json
+    if MITOSHEET_HELPER_PRO:
+        return MITOSHEET_HELPER_PRO
+
+    # This package overides the user.json
+    if MITOSHEET_PRIVATE:
+        return MITOSHEET_PRIVATE
+
+    # Check if the config is set
+    if os.environ.get('MITO_CONFIG_PRO') is not None:
+        from mitosheet.enterprise.mito_config import is_env_variable_set_to_true
+        return is_env_variable_set_to_true(os.environ.get('MITO_CONFIG_PRO', ''))
+
+    # If you're on Mito Enterprise, then you get all Mito Pro features
+    if is_enterprise():
+        return True
+
+    pro = get_user_field(UJ_MITOSHEET_PRO)
+
+    return pro if pro is not None else False
+
+def is_enterprise() -> bool:
+    """
+    Helper function for returning if this is a Mito Enterprise
+    users
+    """
+    is_enterprise = get_user_field(UJ_MITOSHEET_ENTERPRISE)
+
+    # This package overides the user.json
+    if MITOSHEET_HELPER_ENTERPRISE:
+        return MITOSHEET_HELPER_ENTERPRISE
+    
+    # Check if the config is set
+    mito_config_enterprise = os.environ.get('MITO_CONFIG_ENTERPRISE')
+    mito_config_enterprise_temp_license = os.environ.get('MITO_CONFIG_ENTERPRISE_TEMP_LICENSE')
+    from mitosheet.enterprise.mito_config import get_enterprise_from_config
+    if get_enterprise_from_config(mito_config_enterprise, mito_config_enterprise_temp_license):
+        return True
+
+    return is_enterprise if is_enterprise is not None else False

--- a/mito-ai/src/utils/handler.ts
+++ b/mito-ai/src/utils/handler.ts
@@ -86,16 +86,27 @@ export async function requestAPI(
         
         // TODO: Update the lambda funciton to return the entire message instead of
         // just the content so we don't have to recreate the message here.
-        const aiMessage: OpenAI.Chat.Completions.ChatCompletionMessage = {
-            role: 'assistant',
-            content: data['completion'],
-            refusal: null
+        if ('completion' in data) {
+            const aiMessage: OpenAI.Chat.Completions.ChatCompletionMessage = {
+                role: 'assistant',
+                content: data['completion'],
+                refusal: null
+            }
+
+            return {
+                type: 'success',
+                response: aiMessage            
+            }
+        } else if ('error' in data) {
+            return {
+                type: 'error',
+                errorMessage: data['error']
+            }
+        } else {
+            throw new Error('Invalid response from the Mito AI server')
         }
 
-        return {
-            type: 'success',
-            response: aiMessage            
-        }
+        
     } catch (error) {
         console.error('Not a JSON response body.', response);
         return {


### PR DESCRIPTION
# Description

Reuses the mito accounts infrastructure to rate limit open source usage of the Mito AI server. When users hit the free tier limit, they must either upgrade to Mito pro or set their own open ai api key.


# Documentation

Yes, we need some new docs on getting started with mito-ai