### PR TITLE
0 index evals

### DIFF
--- a/evals/notebook_states.py
+++ b/evals/notebook_states.py
@@ -18,70 +18,28 @@ INITIALIZED_VARIABLES_NOTEBOOK: NotebookState = NotebookState(
 )
 
 MESSY_DATA_NOTEBOOK: NotebookState = NotebookState(
-    global_vars={'df': pd.DataFrame({
-    'Transaction_ID': [1, 2, 3, 4, 5],
-    'Date': ['1/1/23', '1/2/23', '1/2/23', '1/2/23', '3/5/23'],
-    'Stock': ['APPLE-Stock', 'ALPHABET-Stock', 'MICROSOFT-Stock', 'AMAZON-Stock', 'APPLE-Stock'],
-    'Transaction_Price': ['$185.37', '$122.58', '$337.02', '$125.00', '$187.91'],
-    'Type_of_Investment': ['Stock', 'Stock', 'Stock', 'Stock', 'Stock'],
-    'Description_of_each_transaction': [
-        'AAPL shares purchased',
-        'GOOGL shares purchased',
-        'MSFT shares purchased',
-        'AMZN shares purchased',
-        'AAPL shares purchased'
-    ]
-})},
+    global_vars={'df': pd.read_csv('evals/data/messy_data.csv').head(5)},
     cell_contents=["""import pandas as pd
 df = pd.read_csv('evals/data/messy_data.csv')""", '']
 )
 
 LOANS_DF_NOTEBOOK: NotebookState = NotebookState(
-    global_vars={'loans_df': pd.DataFrame({
-        'issue_date': ['2011-01-12', '2011-01-12'],
-        'income_category': ['Low', 'Low'],
-        'annual_income': [24000, 30000],
-        'loan_amount': [5000, 2500],
-        'term': ['36 months', '60 months'],
-        'purpose': ['credit_card', 'car'],
-        'interest_payments': ['Low', 'High'],
-        'loan_condition': ['Good Loan', 'Bad Loan'],
-        'interest_rate': [10.65, 15.27],
-        'total_pymnt': [5861.071414, 1008.710000],
-        'total_rec_prncp': [5000.00, 456.46]
-    })},
+    global_vars={'loans_df': pd.read_csv('evals/data/loans.csv').head(5)},
     cell_contents=["""import pandas as pd
 loans_df = pd.read_csv('evals/data/loans.csv')""", '']
 )
 
 USED_CARS_DF_NOTEBOOK: NotebookState = NotebookState(
-    global_vars={'used_cars_df': pd.DataFrame({
-        'Brand': ['Honda', 'Toyota', 'Volkswagen', 'Maruti Suzuki', 'Maruti Suzuki'],
-        'model': ['City', 'Innova', 'VentoTest', 'Swift', 'Baleno'],
-        'Year': [2001, 2009, 2010, 2017, 2019],
-        'Age': [23, 15, 14, 7, 5],
-        'kmDriven': [98000.0, 190000.0, 77246.0, 83500.0, 45000.0],
-        'Transmission': ['Manual', 'Manual', 'Manual', 'Manual', 'Automatic'],
-        'Owner': ['second', 'second', 'first', 'second', 'first'],
-        'FuelType': ['Petrol', 'Diesel', 'Diesel', 'Diesel', 'Petrol'],
-        'PostedDate': ['Nov-24', 'Jul-24', 'Nov-24', 'Nov-24', 'Nov-24'],
-        'AdditionInfo': [
-            'Honda City v teck in mint condition, valid genuine car,',
-            'Toyota Innova 2.5 G (Diesel) 7 Seater, 2009, Diesel',
-            'Volkswagen Vento 2010-2013 Diesel Breeze, 2010, Diesel',
-            'Maruti Suzuki Swift 2017 Diesel Good Condition',
-            'Maruti Suzuki Baleno Alpha CVT, 2019, Petrol'
-        ],
-        'AskPrice': ['₹ 1,95,000', '₹ 3,75,000', '₹ 1,84,999', '₹ 5,65,000', '₹ 6,85,000']
-    })},
+    global_vars={'used_cars_df': pd.read_csv('evals/data/used_cars.csv').head(5)},
     cell_contents=["""import pandas as pd
 used_cars_df = pd.read_csv('evals/data/used_cars.csv')""", '']
 )
 
 SIMPLE_RECON_NOTEBOOK: NotebookState = NotebookState(
     global_vars={
-        'excel_transactions': pd.DataFrame({'Transaction ID': [12975, 16889, 57686, 53403, 42699], 'Share Quantity': [20, 25, 24, 22, 40]}), 
-        'excel_transactions': pd.DataFrame({'Transaction ID': [12975, 16889, 57686, 53403, 42699], 'Share Quantity': [20, 25, 24, 22, 0]})},
+        'excel_transactions': pd.read_csv('evals/data/simple_recon/transactions_excel.csv').head(5), 
+        'eagle_transactions': pd.read_csv('evals/data/simple_recon/transactions_eagle.csv').head(5)
+    },
     cell_contents=["""import pandas as pd
 excel_transactions = pd.read_csv('evals/data/simple_recon/transactions_excel.csv')
 eagle_transactions = pd.read_csv('evals/data/simple_recon/transactions_eagle.csv')

--- a/evals/prompts/__init__.py
+++ b/evals/prompts/__init__.py
@@ -3,8 +3,8 @@ from evals.prompts.multi_shot_prompt import multi_shot_prompt_generator
 from evals.prompts.production_prompt_v1 import production_prompt_v1_generator
 from evals.prompts.production_prompt_v2 import production_prompt_v2_generator
 PROMPT_GENERATORS = [
-    #single_shot_prompt_generator,
-    #multi_shot_prompt_generator,
+    single_shot_prompt_generator,
+    multi_shot_prompt_generator,
     production_prompt_v1_generator,
     production_prompt_v2_generator
 ]

--- a/evals/test_cases/dataframe_transformation_tests.py
+++ b/evals/test_cases/dataframe_transformation_tests.py
@@ -278,4 +278,38 @@ num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')
 """,
         tags=["function_declaration"],
     ),
+    TestCase(
+        name="0_index_column_numbers",
+        notebook_state=NotebookState(
+            global_vars={'df': pd.DataFrame({
+                'company_name': ['Apple', 'Google', 'Microsoft', 'Amazon', 'Apple'],
+                'currently_active': [True, True, True, True, False],
+                'active_in_june': [True, False, True, True, True],
+                'active_in_july': [False, True, True, False, True],
+                'active_in_august': [False, True, False, False, False],
+                'active_in_september': [True, False, True, False, True],
+                'active_in_october': [True, True, False, False, True],
+                'active_in_november': [False, False, False, True, True],
+                'active_in_december': [True, False, False, False, False],
+                'active_in_january': [True, False, True, False, False],
+            })},
+            cell_contents=["""import pandas as pd
+df = pd.DataFrame({
+    'company_name': ['Apple', 'Google', 'Microsoft', 'Amazon', 'Apple'],
+    'currently_active': [True, True, True, True, False],
+    'active_in_june': [True, False, True, True, True],
+    'active_in_july': [False, True, True, False, True],
+    'active_in_august': [False, True, False, False, False],
+    'active_in_september': [True, False, True, False, True],
+    'active_in_october': [True, True, False, False, True],
+    'active_in_november': [False, False, False, True, True],
+    'active_in_december': [True, False, False, False, False],
+    'active_in_january': [True, False, True, False, False],
+})""", '']
+        
+    ),
+    user_input="Create a new column called active_months that is total number of times the company is True for columns 3 through 9",
+        expected_code="df['active_months'] = df.iloc[:, 3:10].sum(axis=1)",
+        tags=["df_transformation", "pandas"],
+    ),
 ]


### PR DESCRIPTION
# Description

Adds an eval for 1-indexed user inputs that requires 0-indexed python code gen. 

All four of our prompts are currently failing this. However, this doesn't seem like a rule we would want to add to every prompt! Just to relevant ones. Conditionally building prompts would be interesting. But maybe premature for now...

# Testing

Just check it out. 

# Documentation

No. 