### PR TITLE
Improve markdown styling

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -113,7 +113,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                     }
                 } else {
                     return (
-                        <div style={{ position: 'relative' }}>
+                        <div className={classNames('markdown-message-part')} style={{ position: 'relative' }}>
                             <p key={index + messagePart} onDoubleClick={() => setIsEditing(true)}>
                                 {mitoAIConnectionError && <span style={{ marginRight: '4px' }}><ErrorIcon /></span>}
                                 <MarkdownBlock

--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -61,6 +61,14 @@
     color: var(--chat-assistant-message-font-color);
 }
 
+.markdown-message-part * .jp-RenderedHTMLCommon :not(pre) > code {
+    background-color: var(--purple-300);
+    color: var(--purple-700);
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+}
+
 .chat-input {
     outline: none;
     border: none;

--- a/mito-ai/style/base.css
+++ b/mito-ai/style/base.css
@@ -11,4 +11,23 @@
     --chat-assistant-message-font-color: #0E1119;
     --item-selected-color: #E9E0FD;
     --muted-text-color: #888;
+
+    --grey-900: #222934;
+    --grey-800: #5F6B7A;
+    --grey-700: #8795A7;
+    --grey-500: #B8C4CE;
+    --grey-400: #CFD6DE;
+    --grey-300: #E1E7EB;
+    --grey-200: #F8F9FA;
+
+    --purple-700: #844AF7;
+    --purple-600: #9D6CFF;
+    --purple-500: #BA9BF8;
+    --purple-400: #D0B9FE;
+    --purple-300: #E9E0FD;
+
+
+
+    
+
 }


### PR DESCRIPTION
# Description

Makes the markdown variables pop. I think this is much more polished looking. 

Also, adds the css variables for more colors so we can continue to create uniform, polished features. These colors are also loaded into Figma :) 

<img width="451" alt="Screenshot 2024-12-02 at 3 37 05 PM" src="https://github.com/user-attachments/assets/faf36125-2c0c-47ec-84fe-3275daa3a64b">


# Testing

Check it out. 

# Documentation

At some point we can update the photos in docs to reflect more polished UI. 