### PR TITLE
Smart Debugger Evals

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -27,14 +27,14 @@ python -m evals.main --test-type=chat
 ```
 3. To run the `smart-debugger` tests, run the command: 
 ```
-python -m evals.main --test-type=smart_debug
+python -m evals.main --test_type=smart_debug
 ```
 
 ## Running specific tests
 To specify which tests to run, set some of the following flags: 
 
-- `--test-name`
-- `--prompt-name`
+- `--test_name`
+- `--prompt_name`
 - `--tags`
 
 

--- a/evals/asserts/equal_globals.py
+++ b/evals/asserts/equal_globals.py
@@ -1,4 +1,3 @@
-
 from typing import Any, Dict, List, Optional
 import pandas as pd
 
@@ -41,6 +40,11 @@ def assert_equal_globals(expected_globals: Dict[str, Any], actual_globals: Dict[
 
         if isinstance(var_one, pd.DataFrame) and isinstance(var_two, pd.DataFrame):
             if not var_one.equals(var_two):
+                return False
+        elif hasattr(var_one, '__array__') and hasattr(var_two, '__array__'):
+            # Handle numpy arrays and array-like objects
+            import numpy as np
+            if not np.array_equal(var_one, var_two, equal_nan=True):
                 return False
         else:
             if var_one != var_two:

--- a/evals/asserts/equal_globals.py
+++ b/evals/asserts/equal_globals.py
@@ -5,13 +5,19 @@ def get_globals_to_compare(globals: Dict[str, Any], variables_to_compare: Option
     """
     Globals have a lot of stuff we don't actually care about comparing. 
     For now, we only care about comparing variables created by the script.
-    This functionremoves everything else
+    This function removes everything else including:
+    1. Builtins
+    2. Functions
+    3. Variables not in variables_to_compare
+    4. Warnings
     """
     if variables_to_compare is not None:
         # Get the variables to compare from the globals and remove everything else
         return {k: v for k, v in globals.items() if k in variables_to_compare}
 
+    # Remove builtins and warnings from the globals
     globals = {k: v for k, v in globals.items() if k != "__builtins__"}
+    globals = {k: v for k, v in globals.items() if k != "__warningregistry__"}
 
     # Remove functions from the globals since we don't want to compare them
     globals = {k: v for k, v in globals.items() if not callable(v)}

--- a/evals/asserts/equal_globals.py
+++ b/evals/asserts/equal_globals.py
@@ -34,7 +34,6 @@ def assert_equal_globals(expected_globals: Dict[str, Any], actual_globals: Dict[
     expected_globals = get_globals_to_compare(expected_globals, variables_to_compare)
     actual_globals = get_globals_to_compare(actual_globals, variables_to_compare)
 
-
     # First, check if the keys are the same
     if expected_globals.keys() != actual_globals.keys():
         return False
@@ -44,7 +43,14 @@ def assert_equal_globals(expected_globals: Dict[str, Any], actual_globals: Dict[
         var_one = expected_globals[key]
         var_two = actual_globals[key]
 
+        # If they are different types, then they are not equal
+        if type(var_one) != type(var_two):
+            return False
+
         if isinstance(var_one, pd.DataFrame) and isinstance(var_two, pd.DataFrame):
+            if not var_one.equals(var_two):
+                return False
+        elif isinstance(var_one, pd.Series) and isinstance(var_two, pd.Series):
             if not var_one.equals(var_two):
                 return False
         elif hasattr(var_one, '__array__') and hasattr(var_two, '__array__'):

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -41,7 +41,16 @@ class SmartDebugTestCase:
     notebook_state: NotebookState
     invalid_code: str
     correct_code: str
-    tags: List[Literal['simple', 'function', 'pandas', 'import', 'typo', 'type_error', 'logic_correction']] 
+    tags: List[Literal[
+        'simple', 
+        'function', 
+        'pandas', 
+        'import', 
+        'typo', 
+        'type_error', 
+        'logic_correction', 
+        'matplotlib'
+    ]] 
     variables_to_compare: Optional[List[str]] = None
 
 

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -48,6 +48,8 @@ class SmartDebugTestCase:
         'import', 
         'typo', 
         'type_error', 
+        'value_error',
+        'argument_error',
         'logic_correction', 
         'matplotlib'
     ]] 

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -41,7 +41,7 @@ class SmartDebugTestCase:
     notebook_state: NotebookState
     invalid_code: str
     correct_code: str
-    tags: List[Literal['simple', 'function', 'pandas', 'import', 'typo', 'type_error']] 
+    tags: List[Literal['simple', 'function', 'pandas', 'import', 'typo', 'type_error', 'logic_correction']] 
     variables_to_compare: Optional[List[str]] = None
 
 

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -47,11 +47,17 @@ class SmartDebugTestCase:
         'pandas', 
         'import', 
         'typo', 
-        'type_error', 
-        'value_error',
-        'argument_error',
+        'type_conversion', 
         'logic_correction', 
-        'matplotlib'
+        'matplotlib',
+        'SyntaxError',
+        'NameError',
+        'TypeError',
+        'IndentationError',
+        'AttributeError',
+        'ValueError',
+        'OutOfBoundsDatetime',
+        'KeyError'
     ]] 
     variables_to_compare: Optional[List[str]] = None
 

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -14,7 +14,7 @@ class CodeGenTestCaseCore:
     expected_code: str
     tags: List[Literal[
         'variable_declaration', 
-        'function_declaration',
+        'function',
         'df_transformation',
         'df_creation',
         'pandas',
@@ -41,7 +41,7 @@ class SmartDebugTestCase:
     notebook_state: NotebookState
     invalid_code: str
     correct_code: str
-    tags: List[Literal['simple']] 
+    tags: List[Literal['simple', 'function', 'pandas', 'import', 'typo', 'type_error']] 
     variables_to_compare: Optional[List[str]] = None
 
 

--- a/evals/main.py
+++ b/evals/main.py
@@ -6,9 +6,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run evaluation tests')
         
     # Require the user to specify if they want to run chat or smart debug tests
-    parser.add_argument('--test-type', type=str, required=True, choices=['chat', 'smart_debug'], help='Type of tests to run (chat or smart_debug)')
-    parser.add_argument('--test-name', type=str, help='Name of specific test to run')
-    parser.add_argument('--prompt-name', type=str, help='Name of specific prompt to run')
+    parser.add_argument('--test_type', type=str, required=True, choices=['chat', 'smart_debug'], help='Type of tests to run (chat or smart_debug)')
+    parser.add_argument('--test_name', type=str, help='Name of specific test to run')
+    parser.add_argument('--prompt_name', type=str, help='Name of specific prompt to run')
     parser.add_argument('--tags', type=str, help='Comma separated list of tags to filter tests by')
     args = parser.parse_args()
 

--- a/evals/notebook_states.py
+++ b/evals/notebook_states.py
@@ -1,6 +1,6 @@
 from evals.eval_types import NotebookState
 import pandas as pd
-
+import numpy as np
 
 EMPTY_NOTEBOOK: NotebookState = NotebookState(
   global_vars={},
@@ -86,5 +86,35 @@ df = pd.DataFrame({
     'active_in_november': [False, False, False, True, True],
     'active_in_december': [True, False, False, False, False],
     'active_in_january': [True, False, True, False, False],
+})""", '']
+)
+
+
+
+np.random.seed(42)
+stock_df = pd.DataFrame({
+    'date': pd.date_range(start='2023-01-01', periods=100),
+    'ticker': np.random.choice(['AAPL', 'GOOGL', 'MSFT', 'AMZN'], 100),
+    'price': np.random.uniform(100, 1000, 100),
+    'volume': np.random.randint(1000, 1000000, 100),
+    'market_cap': ['$1.5T', '$800B', '$2.1T', '$1.2T'] * 25,
+    'sector': ['Tech', 'Tech', 'Tech', 'Consumer'] * 25,
+    'pe_ratio': np.random.uniform(10, 50, 100),
+    'dividend_yield': ['2.5%', '1.8%', None, '0%'] * 25
+})
+STOCK_MARKET_DATA_NOTEBOOK: NotebookState = NotebookState(
+    global_vars={'stock_df': stock_df.head(5)},
+    cell_contents=["""import pandas as pd
+import numpy as np
+np.random.seed(42)
+stock_df = pd.DataFrame({
+    'date': pd.date_range(start='2023-01-01', periods=100),
+    'ticker': np.random.choice(['AAPL', 'GOOGL', 'MSFT', 'AMZN'], 100),
+    'price': np.random.uniform(100, 1000, 100),
+    'volume': np.random.randint(1000, 1000000, 100),
+    'market_cap': ['$1.5T', '$800B', '$2.1T', '$1.2T'] * 25,
+    'sector': ['Tech', 'Tech', 'Tech', 'Consumer'] * 25,
+    'pe_ratio': np.random.uniform(10, 50, 100),
+    'dividend_yield': ['2.5%', '1.8%', None, '0%'] * 25
 })""", '']
 )

--- a/evals/requirements.txt
+++ b/evals/requirements.txt
@@ -3,3 +3,4 @@ types-setuptools
 openai>=1.0.0
 prettytable>=3.0.0
 pandas>=2.0.0
+matplotlib>=3.0.0

--- a/evals/test_cases/code_gen_tests/dataframe_transformation_tests.py
+++ b/evals/test_cases/code_gen_tests/dataframe_transformation_tests.py
@@ -200,7 +200,7 @@ NUMBER_OF_BMW_FORD_TOYOTA_FIRST_OWNER_FUNCTION = CodeGenTestCaseCore(
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-    tags=["function_declaration"],
+    tags=["function"],
 )
 
 ACTIVE_MONTHS_COLUMNS_3_TO_9 = CodeGenTestCaseCore(

--- a/evals/test_cases/code_gen_tests/function_tests.py
+++ b/evals/test_cases/code_gen_tests/function_tests.py
@@ -8,7 +8,7 @@ MY_SUM_FUNCTION = CodeGenTestCaseCore(
     
 sum_result = my_sum(1, 2)
 """,
-    tags=["function_declaration"],
+    tags=["function"],
 )
 
 
@@ -19,7 +19,7 @@ PALINDROME_FUNCTION = CodeGenTestCaseCore(
 
 is_palindrome_result = is_palindrome('racecar')
 """,
-    tags=["function_declaration"],
+    tags=["function"],
 )
 
 FIBONACCI_FUNCTION = CodeGenTestCaseCore(
@@ -40,7 +40,7 @@ FIBONACCI_FUNCTION = CodeGenTestCaseCore(
 x = fibonacci(10)
 y = sum(x)
 """,
-    tags=["function_declaration"],
+    tags=["function"],
 )
 
 FUNCTION_TESTS = [

--- a/evals/test_cases/smart_debug_tests/__init__.py
+++ b/evals/test_cases/smart_debug_tests/__init__.py
@@ -2,8 +2,14 @@ from typing import List
 from evals.eval_types import SmartDebugTestCase
 
 # Smart Debug Tests
-from evals.test_cases.smart_debug_tests.smart_debug_tests import SMART_DEBUG_TESTS
+from evals.test_cases.smart_debug_tests.smart_debug_tests import TESTS
+from evals.test_cases.smart_debug_tests.function_tests import FUNCTION_TESTS
+from evals.test_cases.smart_debug_tests.pandas_tests import PANDAS_TESTS
+from evals.test_cases.smart_debug_tests.import_tests import IMPORT_TESTS
 
 SMART_DEBUG_TESTS: List[SmartDebugTestCase] = [
-    *SMART_DEBUG_TESTS
+    *TESTS,
+    *FUNCTION_TESTS,
+    *PANDAS_TESTS,
+    *IMPORT_TESTS
 ]

--- a/evals/test_cases/smart_debug_tests/__init__.py
+++ b/evals/test_cases/smart_debug_tests/__init__.py
@@ -6,10 +6,12 @@ from evals.test_cases.smart_debug_tests.smart_debug_tests import TESTS
 from evals.test_cases.smart_debug_tests.function_tests import FUNCTION_TESTS
 from evals.test_cases.smart_debug_tests.pandas_tests import PANDAS_TESTS
 from evals.test_cases.smart_debug_tests.import_tests import IMPORT_TESTS
+from evals.test_cases.smart_debug_tests.matplotlib_tests import MATPLOTLIB_TESTS
 
 SMART_DEBUG_TESTS: List[SmartDebugTestCase] = [
     *TESTS,
     *FUNCTION_TESTS,
     *PANDAS_TESTS,
-    *IMPORT_TESTS
+    *IMPORT_TESTS,
+    *MATPLOTLIB_TESTS
 ]

--- a/evals/test_cases/smart_debug_tests/function_tests.py
+++ b/evals/test_cases/smart_debug_tests/function_tests.py
@@ -1,0 +1,147 @@
+from evals.eval_types import SmartDebugTestCase
+from evals.notebook_states import EMPTY_NOTEBOOK
+
+
+FUNCTION_TESTS = [
+    SmartDebugTestCase(
+        name="missing_colon_in_function_definition_simple",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code=""""
+def my_sum(x, y)
+    return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)""",
+        tags=['simple', 'function']
+    ),
+    SmartDebugTestCase(
+        name='function_indentation_error_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)
+""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)
+""",
+        tags=['simple', 'function']
+    ),
+    SmartDebugTestCase(
+        name='function_call_missing_parens_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum 1, 2
+""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum(1, 2)
+""",
+        tags=['simple', 'function']
+    ),
+    SmartDebugTestCase(
+        name='function_call_with_missing_arguments_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum(1)
+""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum(1, 2)
+""",
+        tags=['simple', 'function']
+    ),
+    SmartDebugTestCase(
+        name='function_call_with_extra_arguments_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+# Sum two numbers and return the result
+def sum_two_numbers(x, y):
+    return x + y
+
+x = sum_two_numbers(1, 2, 3)
+""",
+        correct_code="""
+def sum_two_numbers(x, y):
+    return x + y
+
+x = sum_two_numbers(1, 2)
+""",
+        tags=['simple', 'function']
+    ),
+    SmartDebugTestCase(
+        name='function_call_with_missing_return_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+    result = x + y
+
+def is_even(x):
+    if x % 2 == 0:
+        return True
+    else:
+        return False
+
+x = my_sum(1, 2)
+is_even(x)
+
+""",
+        correct_code="""
+def my_sum(x, y):
+    result = x + y
+    return result
+
+def is_even(x):
+    if x % 2 == 0:
+        return True
+    else:
+        return False
+
+x = my_sum(1, 2)
+is_even(x)
+""",
+        tags=['simple', 'function'],
+        variables_to_compare=['x']
+    ),
+    SmartDebugTestCase(
+        name='function_call_with_wrong_name_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def sum_two_numbers(x, y):
+    return x + y
+
+x = sum_two_number(1, 2)
+""",
+        correct_code="""
+def sum_two_numbers(x, y):
+    return x + y
+
+x = sum_two_numbers(1, 2)
+""",
+        tags=['simple', 'function'],
+        variables_to_compare=['x']
+    )
+
+]

--- a/evals/test_cases/smart_debug_tests/function_tests.py
+++ b/evals/test_cases/smart_debug_tests/function_tests.py
@@ -18,7 +18,7 @@ def my_sum(x, y):
 
 sum_one = my_sum(1, 2)
 sum_two = my_sum(3, 4)""",
-        tags=['simple', 'function']
+        tags=['simple', 'function', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name='function_indentation_error_simple',
@@ -37,7 +37,7 @@ def my_sum(x, y):
 sum_one = my_sum(1, 2)
 sum_two = my_sum(3, 4)
 """,
-        tags=['simple', 'function']
+        tags=['simple', 'function', 'IndentationError']
     ),
     SmartDebugTestCase(
         name='function_call_missing_parens_simple',
@@ -54,7 +54,7 @@ def my_sum(x, y):
 
 x = my_sum(1, 2)
 """,
-        tags=['simple', 'function']
+        tags=['simple', 'function', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name='function_call_with_missing_arguments_simple',
@@ -71,7 +71,7 @@ def my_sum(x, y):
 
 x = my_sum(1, 2)
 """,
-        tags=['simple', 'function']
+        tags=['simple', 'function', 'TypeError']
     ),
     SmartDebugTestCase(
         name='function_call_with_extra_arguments_simple',
@@ -89,7 +89,7 @@ def sum_two_numbers(x, y):
 
 x = sum_two_numbers(1, 2)
 """,
-        tags=['simple', 'function']
+        tags=['simple', 'function', 'TypeError']
     ),
     SmartDebugTestCase(
         name='function_call_with_missing_return_simple',
@@ -122,7 +122,7 @@ def is_even(x):
 x = my_sum(1, 2)
 is_even(x)
 """,
-        tags=['simple', 'function'],
+        tags=['simple', 'function', 'TypeError'],
         variables_to_compare=['x']
     ),
     SmartDebugTestCase(
@@ -140,7 +140,7 @@ def sum_two_numbers(x, y):
 
 x = sum_two_numbers(1, 2)
 """,
-        tags=['simple', 'function'],
+        tags=['simple', 'function', 'NameError'],
         variables_to_compare=['x']
     )
 

--- a/evals/test_cases/smart_debug_tests/import_tests.py
+++ b/evals/test_cases/smart_debug_tests/import_tests.py
@@ -13,7 +13,7 @@ today = datetime.today().strftime('%Y-%m-%d')
 from datetime import datetime
 today = datetime.today().strftime('%Y-%m-%d')
 """,
-        tags=['simple', 'import']
+        tags=['simple', 'import', 'NameError']
     ),
     SmartDebugTestCase(
         name="missing_pandas_import_simple",
@@ -25,7 +25,7 @@ df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 import pandas as pd
 df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
-        tags=['simple', 'import']
+        tags=['simple', 'import', 'NameError']
     ),
     SmartDebugTestCase(
         name="import_as_typo",
@@ -38,7 +38,7 @@ df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 import pandas as pd
 df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
-        tags=['import']
+        tags=['import', 'typo', 'NameError']
     ),
     SmartDebugTestCase(
         name="missing_multiple_imports_1",
@@ -90,7 +90,7 @@ def _generate_sample_data(days: int = 90) -> pd.DataFrame:
         
         return pd.DataFrame(data)
 """,
-        tags=['import']
+        tags=['import', 'NameError']
     ),
     SmartDebugTestCase(
         name="missing_multiple_imports_2",
@@ -142,6 +142,6 @@ def generate_fake_dataset(rows: int = 100) -> pd.DataFrame:
         
         return df
 """,
-        tags=['import']
+        tags=['import', 'NameError']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/import_tests.py
+++ b/evals/test_cases/smart_debug_tests/import_tests.py
@@ -28,6 +28,19 @@ df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
         tags=['simple', 'import']
     ),
     SmartDebugTestCase(
+        name="import_as_typo",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import pandas as ps
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        correct_code="""
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        tags=['import']
+    ),
+    SmartDebugTestCase(
         name="missing_multiple_imports_1",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""

--- a/evals/test_cases/smart_debug_tests/import_tests.py
+++ b/evals/test_cases/smart_debug_tests/import_tests.py
@@ -1,0 +1,134 @@
+from evals.eval_types import SmartDebugTestCase
+from evals.notebook_states import EMPTY_NOTEBOOK
+
+
+IMPORT_TESTS = [
+    SmartDebugTestCase(
+        name="missing_datetime_import_simple",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+today = datetime.today().strftime('%Y-%m-%d')
+""",
+        correct_code="""
+from datetime import datetime
+today = datetime.today().strftime('%Y-%m-%d')
+""",
+        tags=['simple', 'import']
+    ),
+    SmartDebugTestCase(
+        name="missing_pandas_import_simple",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        correct_code="""
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        tags=['simple', 'import']
+    ),
+    SmartDebugTestCase(
+        name="missing_multiple_imports_1",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def _generate_sample_data(days: int = 90) -> pd.DataFrame:
+        # Generate sample sales data with potential error triggers.
+        np.random.seed(42)
+        dates = [datetime.now() - timedelta(days=x) for x in range(days)]
+        products = ['A', 'B', 'C', 'D', None]  # None to trigger errors
+        
+        data = []
+        for date in dates:
+            for _ in range(np.random.randint(5, 15)):
+                row = {
+                    'date': date,
+                    'product': np.random.choice(products),
+                    'revenue': np.random.uniform(-100, 1000),  # Negative values to trigger errors
+                    'quantity': np.random.randint(0, 50),
+                    'customer_id': np.random.randint(1, 1000),
+                    'region': np.random.choice(['North', 'South', 'East', 'West', None])
+                }
+                data.append(row)
+        
+        return pd.DataFrame(data)
+""",
+        correct_code="""
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
+def _generate_sample_data(days: int = 90) -> pd.DataFrame:
+        # Generate sample sales data with potential error triggers.
+        np.random.seed(42)
+        dates = [datetime.now() - timedelta(days=x) for x in range(days)]
+        products = ['A', 'B', 'C', 'D', None]  # None to trigger errors
+        
+        data = []
+        for date in dates:
+            for _ in range(np.random.randint(5, 15)):
+                row = {
+                    'date': date,
+                    'product': np.random.choice(products),
+                    'revenue': np.random.uniform(-100, 1000),  # Negative values to trigger errors
+                    'quantity': np.random.randint(0, 50),
+                    'customer_id': np.random.randint(1, 1000),
+                    'region': np.random.choice(['North', 'South', 'East', 'West', None])
+                }
+                data.append(row)
+        
+        return pd.DataFrame(data)
+""",
+        tags=['import']
+    ),
+    SmartDebugTestCase(
+        name="missing_multiple_imports_2",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def generate_fake_dataset(rows: int = 100) -> pd.DataFrame:
+        # Generate sample sales data with potential error triggers.
+        np.random.seed(42)
+        
+        # Generate 100 rows of fake data
+        dates = [datetime.now() - timedelta(days=x) for x in range(rows)]
+        price = np.random.uniform(10, 100, rows)
+        quantity = np.random.randint(1, 10, rows)
+        customer_id = np.random.randint(1, 1000, rows)
+        region = np.random.choice(['North', 'South', 'East', 'West', None], rows)
+
+        df = pd.DataFrame({
+            'date': dates,
+            'price': price,
+            'quantity': quantity,
+            'customer_id': customer_id,
+            'region': region
+        })
+        
+        return df
+""",
+        correct_code="""
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
+def generate_fake_dataset(rows: int = 100) -> pd.DataFrame:
+        # Generate sample sales data with potential error triggers.
+        np.random.seed(42)
+        
+        # Generate 100 rows of fake data
+        dates = [datetime.now() - timedelta(days=x) for x in range(rows)]
+        price = np.random.uniform(10, 100, rows)
+        quantity = np.random.randint(1, 10, rows)
+        customer_id = np.random.randint(1, 1000, rows)
+        region = np.random.choice(['North', 'South', 'East', 'West', None], rows)
+
+        df = pd.DataFrame({
+            'date': dates,
+            'price': price,
+            'quantity': quantity,
+            'customer_id': customer_id,
+            'region': region
+        })
+        
+        return df
+""",
+        tags=['import']
+    )
+]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -1,0 +1,26 @@
+from evals.eval_types import SmartDebugTestCase
+from evals.notebook_states import EMPTY_NOTEBOOK, LOANS_DF_NOTEBOOK, MESSY_DATA_NOTEBOOK, STOCK_MARKET_DATA_NOTEBOOK, USED_CARS_DF_NOTEBOOK
+
+MATPLOTLIB_TESTS = [
+    SmartDebugTestCase(
+        name="axis_w_different_lengths",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+
+x = [1, 2, 3, 4, 5]
+y = [1, 2, 3, 4, 5, 6]
+
+plt.plot(x, y)
+""",
+        correct_code="""
+import matplotlib.pyplot as plt
+
+x = [1, 2, 3, 4, 5]
+y = [1, 2, 3, 4, 5]
+
+plt.plot(x, y)
+""",
+        tags=['simple', 'matplotlib']
+    ),
+]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -26,7 +26,7 @@ y = [1, 2, 3, 4, 5]
 
 plt.plot(x, y)
 """,
-        tags=['matplotlib', 'value_error']
+        tags=['matplotlib', 'ValueError']
     ),
     SmartDebugTestCase(
         name="bar_chart_missing_y_values",
@@ -53,7 +53,7 @@ plt.xlabel('Categories')
 plt.ylabel('Values')
 plt.title('Bar Chart')
 """,
-        tags=['matplotlib', 'argument_error']
+        tags=['matplotlib', 'TypeError']
     ),
     SmartDebugTestCase(
         name="incorrectly_applied_log_scale",
@@ -80,7 +80,7 @@ plt.yscale('log')
 plt.xlabel('X-axis')
 plt.ylabel('Y-axis (log scale)')
 """,
-        tags=['matplotlib', 'value_error']
+        tags=['matplotlib', 'ValueError']
     ),
     SmartDebugTestCase(
         name="minor_tick_locator_type_error",
@@ -108,7 +108,7 @@ plt.xticks([0.1, 0.2, 0.3], labels=[0.1, 0.2, 0.3])
 plt.minorticks_on()
 plt.gca().xaxis.set_minor_locator(MultipleLocator(0.05))
 """,
-        tags=['matplotlib', 'type_error']
+        tags=['matplotlib', 'TypeError']
     ),
     SmartDebugTestCase(
         name="scatter_colors_length_mismatch",
@@ -142,6 +142,6 @@ plt.ylabel('Y values')
 plt.title('Red Scatter Plot')
 """,
         variables_to_compare=['colors_length'],
-        tags=['matplotlib', 'value_error']
+        tags=['matplotlib', 'ValueError']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -109,5 +109,39 @@ plt.minorticks_on()
 plt.gca().xaxis.set_minor_locator(MultipleLocator(0.05))
 """,
         tags=['matplotlib', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name="scatter_colors_length_mismatch",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+import numpy as np
+
+x = np.random.rand(10)
+y = np.random.rand(10)
+colors = ['red', 'blue', 'green']  # Only 3 colors for 10 points
+colors_length = len(colors)
+
+plt.scatter(x, y, c=colors)
+plt.xlabel('X values')
+plt.ylabel('Y values')
+plt.title('Red Scatter Plot')
+""",
+        correct_code="""
+import matplotlib.pyplot as plt
+import numpy as np
+
+x = np.random.rand(10)
+y = np.random.rand(10)
+colors = ['red'] * 10  # One color for each point
+colors_length = len(colors)
+
+plt.scatter(x, y, c=colors)
+plt.xlabel('X values')
+plt.ylabel('Y values')
+plt.title('Red Scatter Plot')
+""",
+        variables_to_compare=['colors_length'],
+        tags=['matplotlib']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -1,6 +1,11 @@
 from evals.eval_types import SmartDebugTestCase
 from evals.notebook_states import EMPTY_NOTEBOOK, LOANS_DF_NOTEBOOK, MESSY_DATA_NOTEBOOK, STOCK_MARKET_DATA_NOTEBOOK, USED_CARS_DF_NOTEBOOK
 
+'''
+When writing tests for matplotlib, exclude `plt.show()` from the code.
+Displaying the plot will cause the test to pause until the user closes the plot window.
+'''
+
 MATPLOTLIB_TESTS = [
     SmartDebugTestCase(
         name="axis_w_different_lengths",
@@ -76,5 +81,33 @@ plt.xlabel('X-axis')
 plt.ylabel('Y-axis (log scale)')
 """,
         tags=['matplotlib']
+    ),
+    SmartDebugTestCase(
+        name="minor_tick_locator_type_error",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+
+x = [0.1, 0.2, 0.3, 0.4, 0.5]
+y = [1, 4, 9, 16, 25]
+
+plt.plot(x, y)
+plt.xticks([0.1, 0.2, 0.3], labels=[0.1, 0.2, 0.3])
+plt.minorticks_on()
+plt.gca().xaxis.set_minor_locator([0.15, 0.25, 0.35])
+""",
+        correct_code="""
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+
+x = [0.1, 0.2, 0.3, 0.4, 0.5]
+y = [1, 4, 9, 16, 25]
+
+plt.plot(x, y)
+plt.xticks([0.1, 0.2, 0.3], labels=[0.1, 0.2, 0.3])
+plt.minorticks_on()
+plt.gca().xaxis.set_minor_locator(MultipleLocator(0.05))
+""",
+        tags=['matplotlib', 'type_error']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -26,7 +26,7 @@ y = [1, 2, 3, 4, 5]
 
 plt.plot(x, y)
 """,
-        tags=['simple', 'matplotlib']
+        tags=['matplotlib', 'value_error']
     ),
     SmartDebugTestCase(
         name="bar_chart_missing_y_values",
@@ -53,7 +53,7 @@ plt.xlabel('Categories')
 plt.ylabel('Values')
 plt.title('Bar Chart')
 """,
-        tags=['simple', 'matplotlib']
+        tags=['matplotlib', 'argument_error']
     ),
     SmartDebugTestCase(
         name="incorrectly_applied_log_scale",
@@ -80,7 +80,7 @@ plt.yscale('log')
 plt.xlabel('X-axis')
 plt.ylabel('Y-axis (log scale)')
 """,
-        tags=['matplotlib']
+        tags=['matplotlib', 'value_error']
     ),
     SmartDebugTestCase(
         name="minor_tick_locator_type_error",
@@ -142,6 +142,6 @@ plt.ylabel('Y values')
 plt.title('Red Scatter Plot')
 """,
         variables_to_compare=['colors_length'],
-        tags=['matplotlib']
+        tags=['matplotlib', 'value_error']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -36,7 +36,6 @@ plt.bar(categories)
 plt.xlabel('Categories')
 plt.ylabel('Values')
 plt.title('Bar Chart')
-plt.show()
 """,
         correct_code="""
 import matplotlib.pyplot as plt
@@ -48,8 +47,34 @@ plt.bar(categories, values)
 plt.xlabel('Categories')
 plt.ylabel('Values')
 plt.title('Bar Chart')
-plt.show()
 """,
         tags=['simple', 'matplotlib']
+    ),
+    SmartDebugTestCase(
+        name="incorrectly_applied_log_scale",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+
+x = [1, 10, 100, 1000, 10000]
+y = [10, 100, 1000, 10000, 100000]
+
+plt.plot(x, y)
+plt.yscale('logarithmic')
+plt.xlabel('X-axis')
+plt.ylabel('Y-axis (log scale)')
+""",
+        correct_code="""
+import matplotlib.pyplot as plt
+
+x = [1, 10, 100, 1000, 10000]
+y = [10, 100, 1000, 10000, 100000]
+
+plt.plot(x, y)
+plt.yscale('log')
+plt.xlabel('X-axis')
+plt.ylabel('Y-axis (log scale)')
+""",
+        tags=['matplotlib']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/matplotlib_tests.py
+++ b/evals/test_cases/smart_debug_tests/matplotlib_tests.py
@@ -23,4 +23,33 @@ plt.plot(x, y)
 """,
         tags=['simple', 'matplotlib']
     ),
+    SmartDebugTestCase(
+        name="bar_chart_missing_y_values",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+
+categories = ['A', 'B', 'C']
+values = [5, 7, 3]
+
+plt.bar(categories)
+plt.xlabel('Categories')
+plt.ylabel('Values')
+plt.title('Bar Chart')
+plt.show()
+""",
+        correct_code="""
+import matplotlib.pyplot as plt
+
+categories = ['A', 'B', 'C']
+values = [5, 7, 3]
+
+plt.bar(categories, values)
+plt.xlabel('Categories')
+plt.ylabel('Values')
+plt.title('Bar Chart')
+plt.show()
+""",
+        tags=['simple', 'matplotlib']
+    )
 ]

--- a/evals/test_cases/smart_debug_tests/pandas_tests.py
+++ b/evals/test_cases/smart_debug_tests/pandas_tests.py
@@ -1,0 +1,64 @@
+from evals.eval_types import SmartDebugTestCase
+from evals.notebook_states import EMPTY_NOTEBOOK, MESSY_DATA_NOTEBOOK
+from evals.test_cases.code_gen_tests.dataframe_transformation_tests import CONVERT_CURRENCY_STRING_TO_FLOAT
+
+
+PANDAS_TESTS = [
+    SmartDebugTestCase(
+        name='create_dataframe_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        correct_code="""
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='datetime_conversion_required',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import pandas as pd
+df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': [4, 5, 6]})
+df['Year'] = df['A'].dt.year
+""",
+        correct_code="""
+import pandas as pd
+df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': [4, 5, 6]})
+df['A'] = pd.to_datetime(df['A'])
+df['Year'] = df['A'].dt.year
+""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name='must_handle_missing_values_in_type_conversion',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import pandas as pd
+df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': ['4', None, '6']})
+
+# Convert to an integer, ignoring missing values
+df['B'] = df['B'].astype(int)
+""",
+        correct_code="""
+import pandas as pd
+df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': ['4', None, '6']})
+
+# Convert to an integer, ignoring missing values
+df['B'] = df['B'].fillna(0).astype(int)
+""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name='convert_currency_to_float',
+        notebook_state=MESSY_DATA_NOTEBOOK,
+        invalid_code="""
+df['Transaction_Price'] = df['Transaction_Price'].astype(float)
+""",
+        correct_code="""df['Transaction_Price'] = df['Transaction_Price'].str[1:]
+df['Transaction_Price'] = df['Transaction_Price'].astype(float)""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+
+]

--- a/evals/test_cases/smart_debug_tests/pandas_tests.py
+++ b/evals/test_cases/smart_debug_tests/pandas_tests.py
@@ -189,6 +189,31 @@ loans_df_pivot = pivot_table.reset_index()""",
         tags=['simple', 'pandas']
     ),
     SmartDebugTestCase(
+        name='pivot_table_missing_multiple_columns',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+tmp_df = loans_df[['loan_amount', 'purpose']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    columns=['income_category'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()
+""",
+        correct_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income', 'income_category']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    columns=['income_category'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
         name='pivot_table_invalid_aggfunc_syntax',
         notebook_state=LOANS_DF_NOTEBOOK,
         invalid_code="""
@@ -209,6 +234,145 @@ pivot_table = tmp_df.pivot_table(
 loans_df_pivot = pivot_table.reset_index()""",
         tags=['simple', 'pandas']
     ),
+    SmartDebugTestCase(
+        name='pivot_table_incorrect_argument_rows',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income']].copy()
+pivot_table = tmp_df.pivot_table(
+    rows=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        correct_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='pivot_table_incorrect_argument_columns',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income', 'income_category']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    cols=['income_category'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        correct_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income', 'income_category']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    columns=['income_category'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='first_owner_function_wrong_arguments',
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""def get_number_of_first_owner_vehicles_by_brand(brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
 
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        correct_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
 
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='first_owner_function_wrong_column_name',
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        correct_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='first_owner_function_invalid_indentation',
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['owner'].str.contains('first', na=False, regex=False))]
+return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        correct_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase( 
+        # Should not use len around function return value
+        name='first_owner_function_incorrect_handling_return_value', 
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = len(get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW'))
+num_toyota = len(get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota'))
+num_ford = len(get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford'))""",
+        correct_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        # Missing 's' at end of last function call
+        name='first_owner_function_called_with_wrong_name', 
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return df
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicle_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        correct_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
+    return len(df)
+
+num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
+num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
+num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
+        tags=['simple', 'pandas']
+    ),
 ]

--- a/evals/test_cases/smart_debug_tests/pandas_tests.py
+++ b/evals/test_cases/smart_debug_tests/pandas_tests.py
@@ -5,17 +5,6 @@ from evals.test_cases.code_gen_tests.dataframe_transformation_tests import CONVE
 
 PANDAS_TESTS = [
     SmartDebugTestCase(
-        name='create_dataframe_simple',
-        notebook_state=EMPTY_NOTEBOOK,
-        invalid_code="""
-df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-""",
-        correct_code="""
-df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-""",
-        tags=['simple', 'pandas']
-    ),
-    SmartDebugTestCase(
         name='datetime_conversion_required',
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""

--- a/evals/test_cases/smart_debug_tests/pandas_tests.py
+++ b/evals/test_cases/smart_debug_tests/pandas_tests.py
@@ -18,7 +18,7 @@ df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': [4, 5, 6]})
 df['A'] = pd.to_datetime(df['A'])
 df['Year'] = df['A'].dt.year
 """,
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'AttributeError']
     ),
     SmartDebugTestCase(
         name='must_handle_missing_values_in_type_conversion',
@@ -37,7 +37,7 @@ df = pd.DataFrame({'A': ['1/2/24', '2/2/24', '3/2/24'], 'B': ['4', None, '6']})
 # Convert to an integer, ignoring missing values
 df['B'] = df['B'].fillna(0).astype(int)
 """,
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'TypeError']
     ),
     SmartDebugTestCase(
         name='convert_currency_to_float',
@@ -47,7 +47,7 @@ df['Transaction_Price'] = df['Transaction_Price'].astype(float)
 """,
         correct_code="""df['Transaction_Price'] = df['Transaction_Price'].str[1:]
 df['Transaction_Price'] = df['Transaction_Price'].astype(float)""",
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'ValueError']
     ),
     SmartDebugTestCase(
         name='convert_kilometers_drive_to_float',
@@ -60,7 +60,7 @@ used_cars_df['kmDriven'] = used_cars_df['kmDriven'].str[:-3]
 used_cars_df['kmDriven'] = used_cars_df['kmDriven'].replace({',': ''}, regex=True)
 used_cars_df['kmDriven'] = used_cars_df['kmDriven'].astype(float)
 """,
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'ValueError']
     ),
     SmartDebugTestCase(
         name='missing_quotes_in_column_name',
@@ -71,7 +71,7 @@ loans_df = loans_df[loans_df[annual_income] > 100000],
         correct_code="""
 loans_df = loans_df[loans_df['annual_income'] > 100000]
 """,
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'NameError']
     ),
     SmartDebugTestCase(
         name='wrong_combine_filter_condition_syntax',
@@ -82,7 +82,7 @@ loans_df = loans_df[(loans_df['annual_income'] > 100000) and (loans_df['loan_con
         correct_code="""
 loans_df = loans_df[(loans_df['annual_income'] > 100000) & (loans_df['loan_condition'] == 'Bad Loan')]
 """,
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name='date_format_missing_required_format',
@@ -93,7 +93,7 @@ used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'])
         correct_code="""
 used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='%b-%y')
 """,
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'OutOfBoundsDatetime']
     ),
     SmartDebugTestCase(
         name='invalid_date_format',
@@ -104,7 +104,7 @@ used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='
         correct_code="""
 used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='%b-%y')
 """,
-        tags=['simple', 'pandas', 'type_error']
+        tags=['simple', 'pandas', 'type_conversion', 'ValueError']
     ),
     SmartDebugTestCase(
         name='column_rename_missing_inplace',
@@ -117,7 +117,7 @@ loans_df['Year'] = loans_df['Date'].dt.year
 loans_df.rename(columns={'issue_date': 'Date'}, inplace=True)
 loans_df['Year'] = loans_df['Date'].dt.year
 """,
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'KeyError']
     ),
     SmartDebugTestCase(
         name='replace_with_invalid_regex',
@@ -147,7 +147,7 @@ pivot_table = tmp_df.pivot_table(
     aggfunc={'loan_amount': ['mean']}
 )
 loans_df_pivot = pivot_table.reset_index()""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'AttributeError']
     ),
     SmartDebugTestCase(
         name='pivot_table_missing_column',
@@ -166,7 +166,7 @@ pivot_table = tmp_df.pivot_table(
     aggfunc={'mean'}
 )
 loans_df_pivot = pivot_table.reset_index()""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'KeyError']
     ),
     SmartDebugTestCase(
         name='pivot_table_missing_multiple_columns',
@@ -191,7 +191,7 @@ pivot_table = tmp_df.pivot_table(
 )
 loans_df_pivot = pivot_table.reset_index()
 """,
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'KeyError']
     ),
     SmartDebugTestCase(
         name='pivot_table_invalid_aggfunc_syntax',
@@ -212,7 +212,7 @@ pivot_table = tmp_df.pivot_table(
     aggfunc=['mean']
 )
 loans_df_pivot = pivot_table.reset_index()""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         name='pivot_table_incorrect_argument_rows',
@@ -233,7 +233,7 @@ pivot_table = tmp_df.pivot_table(
     aggfunc=['mean']
 )
 loans_df_pivot = pivot_table.reset_index()""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         name='pivot_table_incorrect_argument_columns',
@@ -256,7 +256,7 @@ pivot_table = tmp_df.pivot_table(
     aggfunc=['mean']
 )
 loans_df_pivot = pivot_table.reset_index()""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         name='first_owner_function_wrong_arguments',
@@ -275,7 +275,7 @@ num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         name='first_owner_function_wrong_column_name',
@@ -294,13 +294,13 @@ num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'KeyError']
     ),
     SmartDebugTestCase(
         name='first_owner_function_invalid_indentation',
         notebook_state=USED_CARS_DF_NOTEBOOK,
         invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
-    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['owner'].str.contains('first', na=False, regex=False))]
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
 return len(df)
 
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
@@ -313,14 +313,14 @@ num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'SyntaxError']
     ),
     SmartDebugTestCase( 
         # Should not use len around function return value
         name='first_owner_function_incorrect_handling_return_value', 
         notebook_state=USED_CARS_DF_NOTEBOOK,
         invalid_code="""def get_number_of_first_owner_vehicles_by_brand(df, brand):
-    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['owner'].str.contains('first', na=False, regex=False))]
+    df = df[(df['Brand'].str.contains(brand, na=False, regex=False)) & (df['Owner'].str.contains('first', na=False, regex=False))]
     return len(df)
 
 num_bmw = len(get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW'))
@@ -333,7 +333,7 @@ num_ford = len(get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'TypeError'] # TODO: Make sure this is a TypeError
     ),
     SmartDebugTestCase(
         # Missing 's' at end of last function call
@@ -353,7 +353,7 @@ num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
 num_bmw = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'BMW')
 num_toyota = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Toyota')
 num_ford = get_number_of_first_owner_vehicles_by_brand(used_cars_df, 'Ford')""",
-        tags=['simple', 'pandas']
+        tags=['simple', 'pandas', 'NameError']
     ),
     SmartDebugTestCase(
         # ValueError: window must be an integer 0 or greater
@@ -371,7 +371,7 @@ stock_df = stock_df.sort_values('date')
 rolling_vol = stock_df.groupby('ticker')['volume'].rolling(5, min_periods=1).mean()
 stock_df['rolling_vol'] = rolling_vol.reset_index(level=0, drop=True)
 """,
-        tags=['pandas']
+        tags=['pandas', 'ValueError']
     ),
     SmartDebugTestCase(
         name='stock_market_convert_T_and_B_to_float',
@@ -384,7 +384,7 @@ stock_df['market_cap_numeric_billions'] = stock_df['market_cap_numeric_billions'
 stock_df['market_cap_numeric_billions'] = stock_df['market_cap'].str.replace('$', '').str.replace('T', '000').str.replace('B', '')
 stock_df['market_cap_numeric_billions'] = stock_df['market_cap_numeric_billions'].astype(float)
 """,
-        tags=['pandas']
+        tags=['pandas', 'type_conversion', 'ValueError']
     ),
     SmartDebugTestCase(
         # TypeError: agg function failed [how->mean,dtype->object]
@@ -397,7 +397,7 @@ sector_dividend = stock_df.groupby('sector')['dividend_yield'].mean()
 stock_df['dividend_numeric'] = stock_df['dividend_yield'].replace('0%', '0').str.rstrip('%').astype(float) / 100
 sector_dividend = stock_df.groupby('sector')['dividend_numeric'].mean()
 """,
-        tags=['pandas']
+        tags=['pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         # TypeError: incompatible index of inserted column with frame index
@@ -415,7 +415,7 @@ stock_df = stock_df.sort_values(['ticker', 'date'])
 stock_df['log_returns'] = np.log(stock_df.groupby('ticker')['price'].pct_change() + 1)
 stock_df['volatility'] = (stock_df.groupby('ticker')['log_returns'].rolling(window=20).std() * np.sqrt(252)).reset_index(level=0, drop=True)
 """,
-        tags=['pandas']
+        tags=['pandas', 'TypeError']
     ),
     SmartDebugTestCase(
         # ValueError: setting an array element with a sequence. 
@@ -436,7 +436,7 @@ stock_df['price_volume'] = stock_df['price'] * stock_df['volume']
 stock_df['vwap'] = (stock_df.groupby('ticker')['price_volume'].cumsum() / stock_df.groupby('ticker')['volume'].cumsum())
 stock_df.drop('price_volume', axis=1, inplace=True)
 """,
-        tags=['pandas']
+        tags=['pandas', 'ValueError']
     ),
     SmartDebugTestCase(
         name='rsi_calc_with_incompatible_index',
@@ -471,6 +471,6 @@ def calculate_rsi(data, periods=14):
 stock_df = stock_df.sort_values(['ticker', 'date'])
 stock_df['rsi'] = stock_df.groupby('ticker')['price'].transform(calculate_rsi)
 """,
-        tags=['logic_correction', 'pandas']
+        tags=['pandas', 'logic_correction','TypeError']
     )
 ]

--- a/evals/test_cases/smart_debug_tests/pandas_tests.py
+++ b/evals/test_cases/smart_debug_tests/pandas_tests.py
@@ -1,5 +1,5 @@
 from evals.eval_types import SmartDebugTestCase
-from evals.notebook_states import EMPTY_NOTEBOOK, MESSY_DATA_NOTEBOOK
+from evals.notebook_states import EMPTY_NOTEBOOK, LOANS_DF_NOTEBOOK, MESSY_DATA_NOTEBOOK, USED_CARS_DF_NOTEBOOK
 from evals.test_cases.code_gen_tests.dataframe_transformation_tests import CONVERT_CURRENCY_STRING_TO_FLOAT
 
 
@@ -60,5 +60,155 @@ df['Transaction_Price'] = df['Transaction_Price'].astype(float)
 df['Transaction_Price'] = df['Transaction_Price'].astype(float)""",
         tags=['simple', 'pandas', 'type_error']
     ),
+    SmartDebugTestCase(
+        name='convert_kilometers_drive_to_float',
+        notebook_state = USED_CARS_DF_NOTEBOOK,
+        invalid_code="""
+used_cars_df['kmDriven'] = used_cars_df['kmDriven'].astype(float)
+""",
+        correct_code="""
+used_cars_df['kmDriven'] = used_cars_df['kmDriven'].str[:-3]
+used_cars_df['kmDriven'] = used_cars_df['kmDriven'].replace({',': ''}, regex=True)
+used_cars_df['kmDriven'] = used_cars_df['kmDriven'].astype(float)
+""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name='missing_quotes_in_column_name',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+"loans_df = loans_df[loans_df[annual_income] > 100000]",
+""", 
+        correct_code="""
+loans_df = loans_df[loans_df['annual_income'] > 100000]
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='wrong_combine_filter_condition_syntax',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+loans_df = loans_df[(loans_df['annual_income'] > 100000) and (loans_df['loan_condition'] == 'Bad Loan')]",
+""",
+        correct_code="""
+loans_df = loans_df[(loans_df['annual_income'] > 100000) & (loans_df['loan_condition'] == 'Bad Loan')]
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='date_format_missing_required_format',
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""
+used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'])
+""",
+        correct_code="""
+used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='%b-%y')
+""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name='invalid_date_format',
+        notebook_state=USED_CARS_DF_NOTEBOOK,
+        invalid_code="""
+used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='%b')
+""",
+        correct_code="""
+used_cars_df['PostedDate'] = pd.to_datetime(used_cars_df['PostedDate'], format='%b-%y')
+""",
+        tags=['simple', 'pandas', 'type_error']
+    ),
+    SmartDebugTestCase(
+        name='column_rename_missing_inplace',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+loans_df.rename(columns={'issue_date': 'Date'})
+""",
+        correct_code="""
+loans_df.rename(columns={'issue_date': 'Date'}, inplace=True)
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='column_delete_missing_inplace',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+loans_df.drop(columns=['annual_income'])
+""",
+        correct_code="""
+loans_df.drop(columns=['annual_income'], inplace=True)
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='replace_with_invalid_regex',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+loans_df = loans_df.astype(str).replace("(?iLow", "Bottom Bucket", regex=True).astype(loans_df.dtypes.to_dict())
+""",
+        correct_code="""
+loans_df = loans_df.astype(str).replace("(?i)Low", "Bottom Bucket", regex=True).astype(loans_df.dtypes.to_dict())
+""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='pivot_table_invalid_aggfunc_average',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""tmp_df = loans_df[['loan_amount', 'purpose']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount'],
+    aggfunc={'loan_amount': ['average']}
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        correct_code="""tmp_df = loans_df[['loan_amount', 'purpose']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount'],
+    aggfunc={'loan_amount': ['mean']}
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='pivot_table_missing_column',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""tmp_df = loans_df[['loan_amount', 'purpose']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc={'loan_amount': ['mean']}
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        correct_code="""tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc={'mean'}
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        tags=['simple', 'pandas']
+    ),
+    SmartDebugTestCase(
+        name='pivot_table_invalid_aggfunc_syntax',
+        notebook_state=LOANS_DF_NOTEBOOK,
+        invalid_code="""
+tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=[{'mean'}]
+)
+loans_df_pivot = pivot_table.reset_index()
+        """,
+        correct_code="""tmp_df = loans_df[['loan_amount', 'purpose', 'annual_income']].copy()
+pivot_table = tmp_df.pivot_table(
+    index=['purpose'],
+    values=['loan_amount', 'annual_income'],
+    aggfunc=['mean']
+)
+loans_df_pivot = pivot_table.reset_index()""",
+        tags=['simple', 'pandas']
+    ),
+
 
 ]

--- a/evals/test_cases/smart_debug_tests/smart_debug_tests.py
+++ b/evals/test_cases/smart_debug_tests/smart_debug_tests.py
@@ -4,14 +4,14 @@ from evals.notebook_states import EMPTY_NOTEBOOK
 
 SMART_DEBUG_TESTS = [
     SmartDebugTestCase(
-        name="error_missing_quote",
+        name="error_missing_quote_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="x='aaron",
         correct_code="x='aaron'",
         tags=['simple']
     ),
     SmartDebugTestCase(
-        name="missing_colon_in_function_definition",
+        name="missing_colon_in_function_definition_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code=""""
 def my_sum(x, y)
@@ -28,7 +28,7 @@ sum_two = my_sum(3, 4)""",
         tags=['simple']
     ),
     SmartDebugTestCase(
-        name="single_equals_sign_in_if_statement",
+        name="single_equals_sign_in_if_statement_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""
 x = 1
@@ -47,14 +47,14 @@ else:
         tags=['simple']
     ),
     SmartDebugTestCase(
-        name="output_comparison",
+        name="output_comparison_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="print('hello world)",
         correct_code="print('hello world')",
         tags=['simple']
     ),
     SmartDebugTestCase(
-        name="missing_datetime_import",
+        name="missing_datetime_import_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""
 today = datetime.today().strftime('%Y-%m-%d')
@@ -62,6 +62,119 @@ today = datetime.today().strftime('%Y-%m-%d')
         correct_code="""
 from datetime import datetime
 today = datetime.today().strftime('%Y-%m-%d')
+""",
+        tags=['simple']
+    ),
+    SmartDebugTestCase(
+        name="variable_name_typo_simple",
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+aaron_age = 27
+aaron_age = Aaron_age + 1
+""",
+        correct_code="""
+aaron_age = 27
+aaron_age = aaron_age + 1
+""",
+        tags=['simple']
+    ),
+    SmartDebugTestCase(
+        name='function_indentation_error_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)
+""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+sum_one = my_sum(1, 2)
+sum_two = my_sum(3, 4)
+""",
+        tags=['simple']
+    ),
+    SmartDebugTestCase(
+        name='string_integer_operations_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+y = '5'
+x = y + 27
+""",
+        correct_code="""
+y = 5
+x = y + 27
+""",
+        tags=['simple'],
+        variables_to_compare=['x']
+    ),
+    SmartDebugTestCase(
+        name='incorrect_function_call_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum 1, 2
+""",
+        correct_code="""
+def my_sum(x, y):
+    return x + y
+
+x = my_sum(1, 2)
+""",
+        tags=['simple']
+    ),
+    SmartDebugTestCase(
+        name='missing_package_installation_simple',
+        notebook_state=EMPTY_NOTEBOOK,
+        invalid_code="""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# make data
+x = np.linspace(0, 10, 100)
+y = 4 + 1 * np.sin(2 * x)
+x2 = np.linspace(0, 10, 25)
+y2 = 4 + 1 * np.sin(2 * x2)
+
+# plot
+fig, ax = plt.subplots()
+
+ax.plot(x2, y2 + 2.5, 'x', markeredgewidth=2)
+ax.plot(x, y, linewidth=2.0)
+ax.plot(x2, y2 - 2.5, 'o-', linewidth=2)
+
+ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
+       ylim=(0, 8), yticks=np.arange(1, 8))
+""",
+        correct_code="""
+!pip install matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# make data
+x = np.linspace(0, 10, 100)
+y = 4 + 1 * np.sin(2 * x)
+x2 = np.linspace(0, 10, 25)
+y2 = 4 + 1 * np.sin(2 * x2)
+
+# plot
+fig, ax = plt.subplots()
+
+ax.plot(x2, y2 + 2.5, 'x', markeredgewidth=2)
+ax.plot(x, y, linewidth=2.0)
+ax.plot(x2, y2 - 2.5, 'o-', linewidth=2)
+
+ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
+       ylim=(0, 8), yticks=np.arange(1, 8))
 """,
         tags=['simple']
     )

--- a/evals/test_cases/smart_debug_tests/smart_debug_tests.py
+++ b/evals/test_cases/smart_debug_tests/smart_debug_tests.py
@@ -77,4 +77,5 @@ df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
         tags=['simple', 'typo']
     )
+
 ]

--- a/evals/test_cases/smart_debug_tests/smart_debug_tests.py
+++ b/evals/test_cases/smart_debug_tests/smart_debug_tests.py
@@ -8,7 +8,7 @@ TESTS = [
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="x='aaron",
         correct_code="x='aaron'",
-        tags=['simple']
+        tags=['simple', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name="single_equals_sign_in_if_statement_simple",
@@ -27,14 +27,14 @@ if x == 1:
 else:
     print("x is not 1")
 """,
-        tags=['simple']
+        tags=['simple', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name="output_comparison_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="print('hello world)",
         correct_code="print('hello world')",
-        tags=['simple']
+        tags=['simple', 'SyntaxError']
     ),
     SmartDebugTestCase(
         name="variable_name_typo_simple",
@@ -47,7 +47,7 @@ aaron_age = Aaron_age + 1
 aaron_age = 27
 aaron_age = aaron_age + 1
 """,
-        tags=['simple']
+        tags=['simple', 'NameError']
     ),
     SmartDebugTestCase(
         name='string_integer_operations_simple',
@@ -60,7 +60,7 @@ x = y + 27
 y = 5
 x = y + 27
 """,
-        tags=['simple'],
+        tags=['simple', 'TypeError'],
         variables_to_compare=['x']
     ),
     SmartDebugTestCase(
@@ -75,7 +75,7 @@ df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 import pandas as pd
 df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
-        tags=['simple', 'typo']
+        tags=['simple', 'typo', 'NameError']
     )
 
 ]

--- a/evals/test_cases/smart_debug_tests/smart_debug_tests.py
+++ b/evals/test_cases/smart_debug_tests/smart_debug_tests.py
@@ -2,29 +2,12 @@ from evals.eval_types import CodeGenTestCase, CodeGenTestCaseCore, SmartDebugTes
 from evals.notebook_states import EMPTY_NOTEBOOK
 
 
-SMART_DEBUG_TESTS = [
+TESTS = [
     SmartDebugTestCase(
         name="error_missing_quote_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="x='aaron",
         correct_code="x='aaron'",
-        tags=['simple']
-    ),
-    SmartDebugTestCase(
-        name="missing_colon_in_function_definition_simple",
-        notebook_state=EMPTY_NOTEBOOK,
-        invalid_code=""""
-def my_sum(x, y)
-    return x + y
-
-sum_one = my_sum(1, 2)
-sum_two = my_sum(3, 4)""",
-        correct_code="""
-def my_sum(x, y):
-    return x + y
-
-sum_one = my_sum(1, 2)
-sum_two = my_sum(3, 4)""",
         tags=['simple']
     ),
     SmartDebugTestCase(
@@ -54,18 +37,6 @@ else:
         tags=['simple']
     ),
     SmartDebugTestCase(
-        name="missing_datetime_import_simple",
-        notebook_state=EMPTY_NOTEBOOK,
-        invalid_code="""
-today = datetime.today().strftime('%Y-%m-%d')
-""",
-        correct_code="""
-from datetime import datetime
-today = datetime.today().strftime('%Y-%m-%d')
-""",
-        tags=['simple']
-    ),
-    SmartDebugTestCase(
         name="variable_name_typo_simple",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""
@@ -75,25 +46,6 @@ aaron_age = Aaron_age + 1
         correct_code="""
 aaron_age = 27
 aaron_age = aaron_age + 1
-""",
-        tags=['simple']
-    ),
-    SmartDebugTestCase(
-        name='function_indentation_error_simple',
-        notebook_state=EMPTY_NOTEBOOK,
-        invalid_code="""
-def my_sum(x, y):
-return x + y
-
-sum_one = my_sum(1, 2)
-sum_two = my_sum(3, 4)
-""",
-        correct_code="""
-def my_sum(x, y):
-    return x + y
-
-sum_one = my_sum(1, 2)
-sum_two = my_sum(3, 4)
 """,
         tags=['simple']
     ),
@@ -112,70 +64,17 @@ x = y + 27
         variables_to_compare=['x']
     ),
     SmartDebugTestCase(
-        name='incorrect_function_call_simple',
+        name="typo_adding_code_cell_below",
         notebook_state=EMPTY_NOTEBOOK,
         invalid_code="""
-def my_sum(x, y):
-    return x + y
-
-x = my_sum 1, 2
+bb
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
         correct_code="""
-def my_sum(x, y):
-    return x + y
-
-x = my_sum(1, 2)
+import pandas as pd
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 """,
-        tags=['simple']
-    ),
-    SmartDebugTestCase(
-        name='missing_package_installation_simple',
-        notebook_state=EMPTY_NOTEBOOK,
-        invalid_code="""
-import matplotlib.pyplot as plt
-import numpy as np
-
-plt.style.use('_mpl-gallery')
-
-# make data
-x = np.linspace(0, 10, 100)
-y = 4 + 1 * np.sin(2 * x)
-x2 = np.linspace(0, 10, 25)
-y2 = 4 + 1 * np.sin(2 * x2)
-
-# plot
-fig, ax = plt.subplots()
-
-ax.plot(x2, y2 + 2.5, 'x', markeredgewidth=2)
-ax.plot(x, y, linewidth=2.0)
-ax.plot(x2, y2 - 2.5, 'o-', linewidth=2)
-
-ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
-       ylim=(0, 8), yticks=np.arange(1, 8))
-""",
-        correct_code="""
-!pip install matplotlib
-import matplotlib.pyplot as plt
-import numpy as np
-
-plt.style.use('_mpl-gallery')
-
-# make data
-x = np.linspace(0, 10, 100)
-y = 4 + 1 * np.sin(2 * x)
-x2 = np.linspace(0, 10, 25)
-y2 = 4 + 1 * np.sin(2 * x2)
-
-# plot
-fig, ax = plt.subplots()
-
-ax.plot(x2, y2 + 2.5, 'x', markeredgewidth=2)
-ax.plot(x, y, linewidth=2.0)
-ax.plot(x2, y2 - 2.5, 'o-', linewidth=2)
-
-ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
-       ylim=(0, 8), yticks=np.arange(1, 8))
-""",
-        tags=['simple']
+        tags=['simple', 'typo']
     )
 ]

--- a/evals/test_runners/smart_debugger_test_runner.py
+++ b/evals/test_runners/smart_debugger_test_runner.py
@@ -90,22 +90,22 @@ def run_smart_debug_test(test: SmartDebugTestCase, prompt_generator: DebugPrompt
         actual_globals, actual_output = exec_code_and_get_globals_and_output(actual_code)
     except Exception as e:
         # Fail early if we can't execute the code
-        # print(f"Failed to execute code with error: {e}")
+        print(f"Failed to execute code with error: {e}")
         return TestCaseResult(test=test, passed=False)
 
     equal_globals = assert_equal_globals(expected_globals, actual_globals, test.variables_to_compare)
     equal_outputs = assert_equal_outputs(expected_output, actual_output)
 
-    # if not equal_globals:
-    #     print("Globals are not equal")
-    #     print(f"Expected globals: {get_globals_to_compare(expected_globals, test.variables_to_compare)}")
-    #     print(f"Actual globals: {get_globals_to_compare(actual_globals, test.variables_to_compare)}")
-    #     print(f"Variables to compare: {test.variables_to_compare}")
+    if not equal_globals:
+        print("Globals are not equal")
+        print(f"Expected globals: {get_globals_to_compare(expected_globals, test.variables_to_compare)}")
+        print(f"Actual globals: {get_globals_to_compare(actual_globals, test.variables_to_compare)}")
+        print(f"Variables to compare: {test.variables_to_compare}")
 
-    # if not equal_outputs:
-    #     print("Outputs are not equal")
-    #     print(f"Expected output: {expected_output}")
-    #     print(f"Actual output: {actual_output}")
+    if not equal_outputs:
+        print("Outputs are not equal")
+        print(f"Expected output: {expected_output}")
+        print(f"Actual output: {actual_output}")
 
     passed = equal_globals and equal_outputs
 

--- a/evals/test_runners/smart_debugger_test_runner.py
+++ b/evals/test_runners/smart_debugger_test_runner.py
@@ -68,7 +68,8 @@ def run_smart_debug_test(test: SmartDebugTestCase, prompt_generator: DebugPrompt
     try:
         exec(invalid_code_cells_script, {})
     except Exception as e:
-        error_message = str(e)
+        error_type = e.__class__.__name__
+        error_message = f"{error_type}: {str(e)}"
 
     print(f"Error message: {error_message}")
     if error_message is None:
@@ -89,25 +90,22 @@ def run_smart_debug_test(test: SmartDebugTestCase, prompt_generator: DebugPrompt
         actual_globals, actual_output = exec_code_and_get_globals_and_output(actual_code)
     except Exception as e:
         # Fail early if we can't execute the code
-        print(f"Failed to execute code with error: {e}")
+        # print(f"Failed to execute code with error: {e}")
         return TestCaseResult(test=test, passed=False)
-    
-    print(f"expected_code: {expected_code}")
-    print(f"actual_code: {actual_code}")
 
     equal_globals = assert_equal_globals(expected_globals, actual_globals, test.variables_to_compare)
     equal_outputs = assert_equal_outputs(expected_output, actual_output)
 
-    if not equal_globals:
-        print("Globals are not equal")
-        print(f"Expected globals: {get_globals_to_compare(expected_globals, test.variables_to_compare)}")
-        print(f"Actual globals: {get_globals_to_compare(actual_globals, test.variables_to_compare)}")
-        print(f"Variables to compare: {test.variables_to_compare}")
+    # if not equal_globals:
+    #     print("Globals are not equal")
+    #     print(f"Expected globals: {get_globals_to_compare(expected_globals, test.variables_to_compare)}")
+    #     print(f"Actual globals: {get_globals_to_compare(actual_globals, test.variables_to_compare)}")
+    #     print(f"Variables to compare: {test.variables_to_compare}")
 
-    if not equal_outputs:
-        print("Outputs are not equal")
-        print(f"Expected output: {expected_output}")
-        print(f"Actual output: {actual_output}")
+    # if not equal_outputs:
+    #     print("Outputs are not equal")
+    #     print(f"Expected output: {expected_output}")
+    #     print(f"Actual output: {actual_output}")
 
     passed = equal_globals and equal_outputs
 

--- a/evals/test_runners/smart_debugger_test_runner.py
+++ b/evals/test_runners/smart_debugger_test_runner.py
@@ -1,11 +1,11 @@
 import copy
 from typing import Dict, List, Optional
 from evals.ai_api_calls.get_open_ai_completion import get_open_ai_completion
-from evals.asserts.equal_globals import assert_equal_globals
+from evals.asserts.equal_globals import assert_equal_globals, get_globals_to_compare
 from evals.asserts.equal_outputs import assert_equal_outputs
 from evals.eval_types import ChatPromptGenerator, CodeGenTestCase, DebugPromptGenerator, SmartDebugTestCase, TestCaseResult
 from evals.prompts.smart_debug_prompts import SMART_DEBUG_PROMPT_GENERATORS
-from evals.test_cases.smart_debug_tests.smart_debug_tests import SMART_DEBUG_TESTS
+from evals.test_cases.smart_debug_tests import SMART_DEBUG_TESTS
 from evals.test_runners.utils import exec_code_and_get_globals_and_output
 from evals.utils import get_script_from_cells, print_test_case_result_tables
 
@@ -91,9 +91,24 @@ def run_smart_debug_test(test: SmartDebugTestCase, prompt_generator: DebugPrompt
         # Fail early if we can't execute the code
         print(f"Failed to execute code with error: {e}")
         return TestCaseResult(test=test, passed=False)
+    
+    print(f"expected_code: {expected_code}")
+    print(f"actual_code: {actual_code}")
 
     equal_globals = assert_equal_globals(expected_globals, actual_globals, test.variables_to_compare)
     equal_outputs = assert_equal_outputs(expected_output, actual_output)
+
+    if not equal_globals:
+        print("Globals are not equal")
+        print(f"Expected globals: {get_globals_to_compare(expected_globals, test.variables_to_compare)}")
+        print(f"Actual globals: {get_globals_to_compare(actual_globals, test.variables_to_compare)}")
+        print(f"Variables to compare: {test.variables_to_compare}")
+
+    if not equal_outputs:
+        print("Outputs are not equal")
+        print(f"Expected output: {expected_output}")
+        print(f"Actual output: {actual_output}")
+
     passed = equal_globals and equal_outputs
 
     return TestCaseResult(test=test, passed=passed)


### PR DESCRIPTION
# Description

First 45 smart debugger tests

- [ ] When the user overwrites the print function, the response should give back the correct code and also contain the text 'restart" "kernel"

### Testing Package Installation

I tried for a while to support testing package installations and ran into a few problems. Primarily:
1. In order to run package installation commands like `!pip install matplotlib`, we need to be inside of a ipython kernel. This is doable and maybe we should move to this anyways because it more closely mirrors Jupyter. 
2. But, `!pip install` commands are not an in-memory operation—it’s a file system operation. Running it places files into the environment’s site-packages. That means, when we run a  `!pip install` command for the expected code, it ends up storing that package forever. This means successive runs of our test suite won't actually test if the Ai generated the right code without first resetting the environment. 

For now, let's not test package installs to avoid this added complexity. There's still a lot of smart debugging tests that we can write for other sorts of debugging! 


### Evals that we should create later. These are more complicated. 
1. Jupyter specific issues that arise from running cells in the wrong order. Often, this is a variable undefined error. 
2. Installing packages. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.