### PR TITLE
Fix: Variable Types Truncated 

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
@@ -62,9 +62,16 @@ const ChatDropdown: React.FC<ChatDropdownProps> = ({
     }, [filteredOptions, selectedIndex]);
 
     const getShortType = (type: string) => {
-        return type.includes("DataFrame") ? "df"
-            : type.includes("<class '") ? type.split("'")[1]
-                : type;
+        if (type.includes("DataFrame")) {
+            return "df";
+        }
+        if (type.includes("Series")) {
+            return "s";
+        }
+        if (type.includes("<class '")) {
+            return type.split("'")[1];
+        }
+        return type;
     }
 
     return (

--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -179,7 +179,10 @@
     color: var(--muted-text-color);
     font-family: var(--jp-code-font-family);
     min-width: 35px;
-    /* Fixed width for type column */
+    width: 35px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .chat-dropdown-item-name {


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1383

# Testing

Create a variable with a really exotic type, and then try to access it using `@variable_name_here`. The type should be truncated. 

As an example, try:

```python
import numpy as np

array_int = np.array([1, 2, 3])
array_float = np.array([1.0, 2.0, 3.0])
```

# Documentation

N/A