### PR TITLE
Renamed Apply Button to Preview

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -26,7 +26,7 @@ interface IChatMessageProps {
     isLastAiMessage: boolean
     operatingSystem: OperatingSystem
     setDisplayCodeDiff: React.Dispatch<React.SetStateAction<UnifiedDiffLine[] | undefined>>;
-    applyAICode: () => void
+    previewAICode: () => void
     acceptAICode: () => void
     rejectAICode: () => void
     onUpdateMessage: (messageIndex: number, newContent: string) => void
@@ -45,7 +45,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
     isLastAiMessage,
     operatingSystem,
     setDisplayCodeDiff,
-    applyAICode,
+    previewAICode,
     acceptAICode,
     rejectAICode,
     onUpdateMessage,
@@ -114,7 +114,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                 isLastAiMessage={isLastAiMessage}
                                 operatingSystem={operatingSystem}
                                 setDisplayCodeDiff={setDisplayCodeDiff}
-                                applyAICode={applyAICode}
+                                previewAICode={previewAICode}
                                 acceptAICode={acceptAICode}
                                 rejectAICode={rejectAICode}
                                 codeReviewStatus={codeReviewStatus}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
@@ -70,7 +70,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
                     {isLastAiMessage && codeCellID !== undefined && (
                         <>
                             {codeReviewStatus === 'chatPreview' && (
-                                <button onClick={() => { previewAICode() }}>Preview</button>
+                                <button onClick={() => { previewAICode() }}>Preview Code in Notebook</button>
                             )}
 
                             {codeReviewStatus === 'codeCellPreview' && (

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
@@ -21,7 +21,7 @@ interface ICodeBlockProps {
     isLastAiMessage: boolean,
     operatingSystem: OperatingSystem,
     setDisplayCodeDiff: React.Dispatch<React.SetStateAction<UnifiedDiffLine[] | undefined>>;
-    applyAICode: () => void,
+    previewAICode: () => void,
     acceptAICode: (codeCellID: string) => void,
     rejectAICode: (codeCellID: string) => void,
     codeReviewStatus: CodeReviewStatus
@@ -37,7 +37,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
     isLastAiMessage,
     operatingSystem,
     setDisplayCodeDiff,
-    applyAICode,
+    previewAICode,
     acceptAICode,
     rejectAICode,
     codeReviewStatus
@@ -70,7 +70,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
                     {isLastAiMessage && codeCellID !== undefined && (
                         <>
                             {codeReviewStatus === 'chatPreview' && (
-                                <button onClick={() => { applyAICode() }}>Apply</button>
+                                <button onClick={() => { previewAICode() }}>Preview</button>
                             )}
 
                             {codeReviewStatus === 'codeCellPreview' && (

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -216,7 +216,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
 
     const displayOptimizedChatHistory = chatHistoryManager.getDisplayOptimizedHistory()
 
-    const applyAICode = () => {
+    const previewAICode = () => {
         setCodeReviewStatus('codeCellPreview')
         updateCodeDiffStripes(chatHistoryManager.getLastAIMessage()?.message)
     }
@@ -412,7 +412,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                             isLastAiMessage={index === lastAIMessagesIndex}
                             operatingSystem={operatingSystem}
                             setDisplayCodeDiff={setUnifiedDiffLines}
-                            applyAICode={applyAICode}
+                            previewAICode={previewAICode}
                             acceptAICode={acceptAICode}
                             rejectAICode={rejectAICode}
                             onUpdateMessage={handleUpdateMessage}

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -11,18 +11,22 @@ test.describe.configure({ mode: 'parallel' });
 
 test.describe('Mito AI Chat', () => {
 
-  test('Apply and Accept AI Generated Code', async ({ page }) => {
+  test.only('Preview and Accept AI Generated Code', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
-    // No code diffs should be visible before the user clicks apply
+    // No code diffs should be visible before the user clicks preview
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 
     await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
+
+    // Code diffs should be visible after the user clicks preview
+    await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
+    await expect(page.locator('.cm-codeDiffInsertedStripe')).toBeVisible();
 
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
@@ -84,19 +88,6 @@ test.describe('Mito AI Chat', () => {
     await expect(page.locator('.message-assistant .message-edit-button')).not.toBeVisible();
     await page.locator('.message-assistant p').last().dblclick();
     await expect(page.locator('.message-assistant').getByRole('button', { name: 'Save' })).not.toBeVisible();
-  });
-
-  test('Code Diffs are applied after clicking apply', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1)']);
-    await waitForIdle(page);
-
-    await sendMessageToMitoAI(page, 'Remove the code print(1) and add the code print(2)', 0);
-
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
-
-    await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
-    await expect(page.locator('.cm-codeDiffInsertedStripe')).toBeVisible();
   });
 
   test('Code diffs are automatically rejected before new messages are sent', async ({ page }) => {
@@ -209,7 +200,7 @@ test.describe('Mito AI Chat', () => {
 
     await waitForMitoAILoadingToDisappear(page);
 
-    // No code diffs should be visible before the user clicks apply
+    // No code diffs should be visible before the user clicks preview
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -21,7 +21,7 @@ test.describe('Mito AI Chat', () => {
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
 
     await page.locator(acceptButtonSelector).click();
@@ -37,7 +37,7 @@ test.describe('Mito AI Chat', () => {
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
 
     await page.locator(denyButtonSelector).click();
@@ -54,21 +54,21 @@ test.describe('Mito AI Chat', () => {
 
     // Send the first message
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
     // Send the second message
     await sendMessageToMitoAI(page, 'Write the code df["D"] = [10, 11, 12]');
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
     // Edit the first message
     await editMitoAIMessage(page, 'Write the code df["C_edited"] = [7, 8, 9]', 0);
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
@@ -92,7 +92,7 @@ test.describe('Mito AI Chat', () => {
 
     await sendMessageToMitoAI(page, 'Remove the code print(1) and add the code print(2)', 0);
 
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
 
     await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
@@ -111,7 +111,7 @@ test.describe('Mito AI Chat', () => {
 
     // Send a second message in cell 2
     await sendMessageToMitoAI(page, 'Write the code x = 2');
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
@@ -139,7 +139,7 @@ test.describe('Mito AI Chat', () => {
     await typeInNotebookCell(page, 2, '# this should not be overwritten', true);
 
     // Accept the first message
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
@@ -166,7 +166,7 @@ test.describe('Mito AI Chat', () => {
     await typeInNotebookCell(page, 2, '# this should not be overwritten', true);
 
     // Reject the first message
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
     await page.locator(denyButtonSelector).click();
     await waitForIdle(page);
@@ -213,7 +213,7 @@ test.describe('Mito AI Chat', () => {
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByRole('button', { name: 'Preview' }).click();
     await waitForIdle(page);
 
     await page.locator(acceptButtonSelector).click();

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jupyterlab/galata';
 import { createAndRunNotebookWithCells, getCodeFromCell, runCell, selectCell, typeInNotebookCell, waitForIdle, addNewCell } from '../jupyter_utils/jupyterlab_utils';
 import { updateCellValue } from '../jupyter_utils/mitosheet_utils';
-import { clearMitoAIChatInput, clickOnMitoAIChatTab, editMitoAIMessage, sendMessageToMitoAI, waitForMitoAILoadingToDisappear } from './utils';
+import { clearMitoAIChatInput, clickOnMitoAIChatTab, clickPreviewButton, editMitoAIMessage, sendMessageToMitoAI, waitForMitoAILoadingToDisappear } from './utils';
 
 const placeholderCellText = '# Empty code cell';
 const acceptButtonSelector = '[class="code-block-accept-button"]';
@@ -21,9 +21,7 @@ test.describe('Mito AI Chat', () => {
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
-
+    await clickPreviewButton(page);
     // Code diffs should be visible after the user clicks preview
     await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).toBeVisible();
@@ -41,8 +39,7 @@ test.describe('Mito AI Chat', () => {
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
 
     await page.locator(denyButtonSelector).click();
     await waitForIdle(page);
@@ -58,22 +55,20 @@ test.describe('Mito AI Chat', () => {
 
     // Send the first message
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+
+    await clickPreviewButton(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
     // Send the second message
     await sendMessageToMitoAI(page, 'Write the code df["D"] = [10, 11, 12]');
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
     // Edit the first message
     await editMitoAIMessage(page, 'Write the code df["C_edited"] = [7, 8, 9]', 0);
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
@@ -102,8 +97,7 @@ test.describe('Mito AI Chat', () => {
 
     // Send a second message in cell 2
     await sendMessageToMitoAI(page, 'Write the code x = 2');
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
@@ -130,8 +124,7 @@ test.describe('Mito AI Chat', () => {
     await typeInNotebookCell(page, 2, '# this should not be overwritten', true);
 
     // Accept the first message
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);
 
@@ -157,8 +150,7 @@ test.describe('Mito AI Chat', () => {
     await typeInNotebookCell(page, 2, '# this should not be overwritten', true);
 
     // Reject the first message
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
     await page.locator(denyButtonSelector).click();
     await waitForIdle(page);
 
@@ -204,8 +196,7 @@ test.describe('Mito AI Chat', () => {
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
     await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
 
-    await page.getByRole('button', { name: 'Preview' }).click();
-    await waitForIdle(page);
+    await clickPreviewButton(page);
 
     await page.locator(acceptButtonSelector).click();
     await waitForIdle(page);

--- a/tests/mitoai_ui_tests/utils.ts
+++ b/tests/mitoai_ui_tests/utils.ts
@@ -1,5 +1,5 @@
 import { IJupyterLabPageFixture } from "@jupyterlab/galata";
-import { selectCell } from "../jupyter_utils/jupyterlab_utils";
+import { selectCell, waitForIdle } from "../jupyter_utils/jupyterlab_utils";
 
 export const waitForMitoAILoadingToDisappear = async (page: IJupyterLabPageFixture) => {
     const mitoAILoadingLocator = page.locator('.chat-loading-message');
@@ -48,4 +48,9 @@ export const editMitoAIMessage = async (
     await page.getByPlaceholder('Edit your message').fill(message);
     await page.keyboard.press('Enter');
     await waitForMitoAILoadingToDisappear(page);
+}
+
+export const clickPreviewButton = async (page: IJupyterLabPageFixture) => {
+    await page.getByRole('button', { name: 'Preview Code in Notebook' }).click();
+    await waitForIdle(page);
 }


### PR DESCRIPTION
# Description

Renamed the _Apply_ button to _Preview_. Hopefully this makes it clearer to users. 

# Testing

Test a basic Mito AI workflow. Nothing should have changed, except the button names. 

# Documentation

Update this page on next release: https://docs.trymito.io/mito-ai/chat