### PR TITLE
Ignoring mitosheet Tests 

### DIFF
--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
+    paths-ignore:
+      - 'tests/mitoai_ui_tests/**'
   pull_request:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
+    paths-ignore:
+      - 'tests/mitoai_ui_tests/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Description

Changes made in `mitoai_ui_tests` should no longer trigger mitosheet tests. This should speed up PR, getting rid of irrelevant tests. Currently, there are 59 tests that run when making a change in `mitoai_ui_tests`, most of which are mitosheet related, and unaffected. 

# Testing

You could simulate Github actions locally, but for this it's probably best to keep an eye on the next PR. Any changes made to the `mitoai_ui_tests` dir should only trigger tests related to Mito AI.   

# Documentation

N/A