### PR TITLE
Fixed Incorrectly Configured paths-ignore

### DIFF
--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
-    paths-ignore:
-      - 'tests/mitoai_ui_tests/**'
+      - '!tests/mitoai_ui_tests/**'
   pull_request:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
-    paths-ignore:
-      - 'tests/mitoai_ui_tests/**'
+      - '!tests/mitoai_ui_tests/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Description

The goal of #1409 was to not run mitosheet tests when changes were mad to mito-ai. However, I did not realize that when using `paths-ignore` you could only have one path and one ignored path listed. This would not have worked, since `paths` has two dirs listed. 

The solution was to remove `paths-ignore`, and use a `!` in `paths`.   

Screenshot of error:
<img width="769" alt="Screenshot 2024-12-12 at 10 19 29 AM" src="https://github.com/user-attachments/assets/3db2bd2a-e6a7-43f2-b92c-e9d04c97b68b" />

# Testing

Trigger Github actions, or wait for next PR and monitor. 

# Documentation

N/A