### PR TITLE
.github: bump workflows to 3.12

### DIFF
--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.12']
         use-mito-ai-server: [true, false]
       fail-fast: false
 

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -28,6 +28,24 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v2
+    
+    # Install system dependencies required by Playwright browser automation
+    # These dependencies are specifically needed for Python 3.12 due to changes
+    # in how it handles browser automation and system-level libraries
+    - name: Install system dependencies
+      if: matrix.python-version == '3.12'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libwoff1 \
+                               libopus0 \
+                               libwebpdemux2 \
+                               libharfbuzz-icu0 \
+                               libhyphen0 \
+                               libegl1 \
+                               libevdev2 \
+                               libgles2 \
+                               gstreamer1.0-libav
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -41,6 +41,9 @@ jobs:
         node-version: 18
         cache: 'npm'
         cache-dependency-path: mito-ai/package-lock.json
+    - name: Upgrade pip
+      run: |
+        python -m pip install --upgrade pip
     - name: Install dependencies
       run: |
         cd tests

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -44,14 +44,11 @@ jobs:
     - name: Install dependencies
       run: |
         cd tests
+        # For Python 3.12, upgrade setuptools first
+        if [ "${{ matrix.python-version }}" = "3.12" ]; then
+          python -m pip install --upgrade pip setuptools>=68.0.0
+        fi
         bash mac-setup.sh
-    - name: Install Playwright dependencies for Python 3.12
-      if: matrix.python-version == '3.12'
-      run: |
-        cd tests
-        source venv/bin/activate
-        npx playwright install-deps
-        npx playwright install
     - name: Setup JupyterLab
       run: |
         cd tests

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -28,24 +28,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v2
-    
-    # Install system dependencies required by Playwright browser automation
-    # These dependencies are specifically needed for Python 3.12 due to changes
-    # in how it handles browser automation and system-level libraries
-    - name: Install system dependencies
-      if: matrix.python-version == '3.12'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libwoff1 \
-                               libopus0 \
-                               libwebpdemux2 \
-                               libharfbuzz-icu0 \
-                               libhyphen0 \
-                               libegl1 \
-                               libevdev2 \
-                               libgles2 \
-                               gstreamer1.0-libav
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -63,6 +45,13 @@ jobs:
       run: |
         cd tests
         bash mac-setup.sh
+    - name: Install Playwright dependencies for Python 3.12
+      if: matrix.python-version == '3.12'
+      run: |
+        cd tests
+        source venv/bin/activate
+        npx playwright install-deps
+        npx playwright install
     - name: Setup JupyterLab
       run: |
         cd tests

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'mito-ai/**'
       - 'tests/mitoai_ui_tests/**'
+      - '.github/workflows/test-mito-ai.yml'
   pull_request:
     paths:
       - 'mito-ai/**'
       - 'tests/mitoai_ui_tests/**'
+      - '.github/workflows/test-mito-ai.yml'
 jobs:
   test-mitoai-frontend-jupyterlab:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.12']
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.12']
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
+      - '.github/workflows/test-mitosheet-frontend.yml'
       - '!tests/mitoai_ui_tests/**'
   pull_request:
     paths:
       - 'mitosheet/**'
       - 'tests/**'
+      - '.github/workflows/test-mitosheet-frontend.yml'
       - '!tests/mitoai_ui_tests/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -5,9 +5,11 @@ on:
     branches: [ dev ]
     paths:
       - 'mitosheet/**'
+      - '.github/workflows/test-mitosheet-python.yml'
   pull_request:
     paths:
       - 'mitosheet/**'
+      - '.github/workflows/test-mitosheet-python.yml'
 
 jobs:
   test-mitosheet-python:

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
         pandas-version: ['0.24.2', '1.1.5', '1.3.5']
         optional_feature_dependencies: [False, True] 
         exclude:
           - python-version: 3.8
             pandas-version: '0.24.2'
-          - python-version: 3.11
+          - python-version: 3.12
             pandas-version: '0.24.2'
-          - python-version: 3.11
+          - python-version: 3.12
             pandas-version: '1.1.5'
-          - python-version: 3.11
+          - python-version: 3.12
             pandas-version: '1.3.5'
             
     steps:

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "jupyterlab>=4.0.0,<5"]
+requires = ["setuptools>=69.0.0", "wheel", "jupyterlab>=4.0.0,<5"]
 build-backend = "setuptools.build_meta"

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=69.0.0", "wheel", "jupyterlab>=4.0.0,<5"]
+requires = ["setuptools", "wheel", "jupyterlab>=4.0.0,<5"]
 build-backend = "setuptools.build_meta"

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -96,7 +96,7 @@ setup(
         'deploy': [
             'wheel==0.42.0', 
             'twine==5.1.1',
-            "setuptools==56.0.0"
+            'setuptools>=61.0.0,<70.0.0'
         ],
     },
     keywords=["AI", "Jupyter", "Mito"],

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -96,7 +96,8 @@ setup(
         'deploy': [
             'wheel==0.42.0', 
             'twine==5.1.1',
-            'setuptools>=61.0.0,<70.0.0'
+            'setuptools==68.0.0'
+            
         ],
     },
     keywords=["AI", "Jupyter", "Mito"],

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -101,7 +101,7 @@ setup_args = dict(
         'deploy': [
             'wheel==0.42.0', 
             'twine==5.1.1',
-            "setuptools==56.0.0"
+            'setuptools>=61.0.0,<70.0.0'
         ],
         'streamlit': [
             'streamlit>=1.24,<1.32',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -101,7 +101,7 @@ setup_args = dict(
         'deploy': [
             'wheel==0.42.0', 
             'twine==5.1.1',
-            'setuptools>=61.0.0,<70.0.0'
+            'setuptools==68.0.0'
         ],
         'streamlit': [
             'streamlit>=1.24,<1.32',


### PR DESCRIPTION
# Description

- Bumping workflows to 3.12 to make sure Mito is compatible with latest Python releases. 
- Run workflows when workflow files are changed

# Testing

See tests. 

# Documentation

Note if any new documentation needs to addressed or reviewed.