### PR TITLE
Added Preview Code Shortcut

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -10,7 +10,13 @@ import { IVariableManager } from '../VariableManager/VariableManagerPlugin';
 import LoadingDots from '../../components/LoadingDots';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { getCodeBlockFromMessage, removeMarkdownCodeFormatting } from '../../utils/strings';
-import { COMMAND_MITO_AI_APPLY_LATEST_CODE, COMMAND_MITO_AI_REJECT_LATEST_CODE, COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE } from '../../commands';
+import { 
+    COMMAND_MITO_AI_PREVIEW_LATEST_CODE, 
+    COMMAND_MITO_AI_APPLY_LATEST_CODE, 
+    COMMAND_MITO_AI_REJECT_LATEST_CODE, 
+    COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, 
+    COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE 
+} from '../../commands';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import ResetIcon from '../../icons/ResetIcon';
 import IconButton from '../../components/IconButton';
@@ -277,34 +283,22 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     }
 
     useEffect(() => {
-        /* 
-            Add a new command to the JupyterLab command registry that applies the latest AI generated code
-            to the active code cell. Do this inside of the useEffect so that we only register the command
-            the first time we create the chat. Registering the command when it is already created causes
-            errors.
-        */
+        app.commands.addCommand(COMMAND_MITO_AI_PREVIEW_LATEST_CODE, {
+            execute: () => {
+                previewAICode()
+            }
+        });
+
         app.commands.addCommand(COMMAND_MITO_AI_APPLY_LATEST_CODE, {
             execute: () => {
                 acceptAICode()
             }
-        })
+        });
 
         app.commands.addCommand(COMMAND_MITO_AI_REJECT_LATEST_CODE, {
             execute: () => {
                 rejectAICode()
             }
-        })
-
-        app.commands.addKeyBinding({
-            command: COMMAND_MITO_AI_APPLY_LATEST_CODE,
-            keys: ['Accel Y'],
-            selector: 'body',
-        });
-
-        app.commands.addKeyBinding({
-            command: COMMAND_MITO_AI_REJECT_LATEST_CODE,
-            keys: ['Accel D'],
-            selector: 'body',
         });
 
         /* 
@@ -317,14 +311,38 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     sendDebugErrorMessage(args.input.toString())
                 }
             }
-        })
+        });
 
         app.commands.addCommand(COMMAND_MITO_AI_SEND_EXPLAIN_CODE_MESSAGE, {
             execute: () => {
                 sendExplainCodeMessage()
             }
-        })
-    }, [])
+        });
+    }, []);
+
+    useEffect(() => {
+        // Register keyboard shortcuts 
+        const accelYDisposable = app.commands.addKeyBinding({
+            command: codeReviewStatus === 'chatPreview' ? 
+                COMMAND_MITO_AI_PREVIEW_LATEST_CODE : 
+                COMMAND_MITO_AI_APPLY_LATEST_CODE,
+            keys: ['Accel Y'],
+            selector: 'body',
+        });
+
+        const accelDDisposable = app.commands.addKeyBinding({
+            command: COMMAND_MITO_AI_REJECT_LATEST_CODE,
+            keys: ['Accel D'],
+            selector: 'body',
+        });
+
+        // Clean up the key bindings when the component unmounts or when codeReviewStatus changes
+        // This prevents keyboard shortcuts from persisting when they shouldn't.
+        return () => {
+            accelYDisposable.dispose();
+            accelDDisposable.dispose();
+        };
+    }, [codeReviewStatus]);
 
     // Create a WeakMap to store compartments per code cell
     const codeDiffStripesCompartments = React.useRef(new WeakMap<CodeCell, Compartment>());

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -283,6 +283,12 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     }
 
     useEffect(() => {
+        /* 
+            Add a new command to the JupyterLab command registry that applies the latest AI generated code
+            to the active code cell. Do this inside of the useEffect so that we only register the command
+            the first time we create the chat. Registering the command when it is already created causes
+            errors.
+        */        
         app.commands.addCommand(COMMAND_MITO_AI_PREVIEW_LATEST_CODE, {
             execute: () => {
                 previewAICode()

--- a/mito-ai/src/commands.tsx
+++ b/mito-ai/src/commands.tsx
@@ -1,6 +1,7 @@
 const MITO_AI = 'mito_ai'
 
 export const COMMAND_MITO_AI_OPEN_CHAT = `${MITO_AI}:open-chat`
+export const COMMAND_MITO_AI_PREVIEW_LATEST_CODE = `${MITO_AI}:preview-latest-code`
 export const COMMAND_MITO_AI_APPLY_LATEST_CODE = `${MITO_AI}:apply-latest-code`
 export const COMMAND_MITO_AI_REJECT_LATEST_CODE = `${MITO_AI}:reject-latest-code`
 export const COMMAND_MITO_AI_SEND_MESSAGE = `${MITO_AI}:send-message`

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -1,7 +1,21 @@
 import { expect, test } from '@jupyterlab/galata';
-import { createAndRunNotebookWithCells, getCodeFromCell, runCell, selectCell, typeInNotebookCell, waitForIdle, addNewCell } from '../jupyter_utils/jupyterlab_utils';
-import { updateCellValue } from '../jupyter_utils/mitosheet_utils';
-import { clearMitoAIChatInput, clickOnMitoAIChatTab, clickPreviewButton, editMitoAIMessage, sendMessageToMitoAI, waitForMitoAILoadingToDisappear } from './utils';
+import { 
+  createAndRunNotebookWithCells, 
+  getCodeFromCell, 
+  runCell, 
+  selectCell, 
+  typeInNotebookCell, 
+  waitForIdle, 
+  addNewCell 
+} from '../jupyter_utils/jupyterlab_utils';
+import { 
+  clearMitoAIChatInput, 
+  clickOnMitoAIChatTab, 
+  clickPreviewButton, 
+  editMitoAIMessage, 
+  sendMessageToMitoAI, 
+  waitForMitoAILoadingToDisappear 
+} from './utils';
 
 const placeholderCellText = '# Empty code cell';
 const acceptButtonSelector = '[class="code-block-accept-button"]';
@@ -271,13 +285,6 @@ test.describe('Mito AI Chat', () => {
 
     await page.keyboard.type("@none_type_col_A");
     await expect(page.locator('.chat-dropdown-item-name').filter({ hasText: 'none_type_col_A' })).toBeVisible();
-  });
-
-  test('Keyboard shortcut opens the AI chat', async ({ page, browserName }) => {
-    const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
-    await page.keyboard.press(`${modifierKey}+B`); // Close the sidebar
-    await page.keyboard.press(`${modifierKey}+E`);
-    await expect(page.locator('.chat-input')).toBeVisible();
   });
 });
 

--- a/tests/mitoai_ui_tests/shortcuts.spec.ts
+++ b/tests/mitoai_ui_tests/shortcuts.spec.ts
@@ -15,13 +15,13 @@ test.describe('Mito AI Shortcuts', () => {
         await waitForIdle(page);
     });
     
-    test.only('Open the AI chat pane', async ({ page }) => {
+    test('Open the AI chat pane', async ({ page }) => {
         await page.keyboard.press(`${modifierKey}+B`); // Close the sidebar
         await page.keyboard.press(`${modifierKey}+E`);
         await expect(page.locator('.chat-input')).toBeVisible();
     });
 
-    test.only('Preview AI generated code', async ({ page }) => {
+    test('Accept AI generated code', async ({ page }) => {
         await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
         // Preview the code
@@ -30,13 +30,6 @@ test.describe('Mito AI Shortcuts', () => {
         // Code diffs should be visible after the user clicks preview
         await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
         await expect(page.locator('.cm-codeDiffInsertedStripe')).toBeVisible();
-    });
-
-    test.only('Accept AI generated code', async ({ page }) => {
-        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-
-        // Preview the code
-        await page.keyboard.press(`${modifierKey}+Y`);
 
         // Accept the code
         await page.keyboard.press(`${modifierKey}+Y`);
@@ -49,7 +42,7 @@ test.describe('Mito AI Shortcuts', () => {
         expect(code).toContain('df["C"] = [7, 8, 9]');
     });
 
-    test.only('Reject AI generated code', async ({ page }) => {
+    test('Reject AI generated code', async ({ page }) => {
         await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
         // Preview the code

--- a/tests/mitoai_ui_tests/shortcuts.spec.ts
+++ b/tests/mitoai_ui_tests/shortcuts.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@jupyterlab/galata';
+import {
+    createAndRunNotebookWithCells,
+    getCodeFromCell,
+    waitForIdle,
+} from '../jupyter_utils/jupyterlab_utils';
+import { sendMessageToMitoAI } from './utils';
+
+const modifierKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+test.describe('Mito AI Shortcuts', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
+        await waitForIdle(page);
+    });
+    
+    test.only('Open the AI chat pane', async ({ page }) => {
+        await page.keyboard.press(`${modifierKey}+B`); // Close the sidebar
+        await page.keyboard.press(`${modifierKey}+E`);
+        await expect(page.locator('.chat-input')).toBeVisible();
+    });
+
+    test.only('Preview AI generated code', async ({ page }) => {
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+
+        // Preview the code
+        await page.keyboard.press(`${modifierKey}+Y`);
+
+        // Code diffs should be visible after the user clicks preview
+        await expect(page.locator('.cm-codeDiffRemovedStripe')).toBeVisible();
+        await expect(page.locator('.cm-codeDiffInsertedStripe')).toBeVisible();
+    });
+
+    test.only('Accept AI generated code', async ({ page }) => {
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+
+        // Preview the code
+        await page.keyboard.press(`${modifierKey}+Y`);
+
+        // Accept the code
+        await page.keyboard.press(`${modifierKey}+Y`);
+
+        // Code diffs should not longer be visible after the user accepts 
+        await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
+        await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
+
+        const code = await getCodeFromCell(page, 1);
+        expect(code).toContain('df["C"] = [7, 8, 9]');
+    });
+
+    test.only('Reject AI generated code', async ({ page }) => {
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+
+        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
+
+        // Preview the code
+        await page.keyboard.press(`${modifierKey}+Y`);
+
+        // Reject the code
+        await page.keyboard.press(`${modifierKey}+D`);
+
+        // Code diffs should not longer be visible after the user rejects 
+        await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
+        await expect(page.locator('.cm-codeDiffInsertedStripe')).not.toBeVisible();
+
+        const code = await getCodeFromCell(page, 1);
+        expect(code).not.toContain('df["C"] = [7, 8, 9]');
+    });
+});

--- a/tests/mitoai_ui_tests/shortcuts.spec.ts
+++ b/tests/mitoai_ui_tests/shortcuts.spec.ts
@@ -23,7 +23,6 @@ test.describe('Mito AI Shortcuts', () => {
 
     test.only('Preview AI generated code', async ({ page }) => {
         await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
         // Preview the code
         await page.keyboard.press(`${modifierKey}+Y`);
@@ -34,7 +33,6 @@ test.describe('Mito AI Shortcuts', () => {
     });
 
     test.only('Accept AI generated code', async ({ page }) => {
-        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
         await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
         // Preview the code
@@ -52,9 +50,6 @@ test.describe('Mito AI Shortcuts', () => {
     });
 
     test.only('Reject AI generated code', async ({ page }) => {
-        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-        await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
-
         await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
         // Preview the code


### PR DESCRIPTION
# Description

CMD+Y now triggers preview, when appropriate. Also, moved shortcut tests to their own file. 

Note that the way key bindings are registered have been changed. We are now disposing bindings every time `codeReviewStatus` is updated. Here's a quick Claude explanation of why this is best practice:

1. Memory Leaks: Without disposing of key bindings, each time the useEffect runs (whenever codeReviewStatus changes), new key bindings are added without removing the old ones. This can lead to memory leaks and multiple bindings for the same keys.
2. Duplicate Handlers: Multiple active bindings for the same key combination can cause unexpected behavior, with multiple handlers firing for a single keystroke.
3. Cleanup Best Practices: React's useEffect cleanup function (returned function) is the proper way to clean up side effects when a component unmounts or when dependencies change.


# Testing

Send some messages, try the shortcuts. 

# Documentation

Yes, not now, but after the next release we should update this page: https://docs.trymito.io/mito-ai/chat