### PR TITLE
Expanded logging for server key users

### DIFF
--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -130,12 +130,12 @@ def get_open_ai_completion(
             set_user_field(UJ_AI_MITO_API_NUM_USAGES, __num_usages)
 
             # Log the successful completion
-            log(
-                MITO_AI_COMPLETION_SUCCESS,
-                params={
-                    KEY_TYPE_PARAM: MITO_SERVER_KEY,
-                    MITO_SERVER_NUM_USAGES: __num_usages,
-                },
+            log_ai_completion_success(
+                MITO_SERVER_KEY,
+                prompt_type,
+                last_message_content,
+                response,
+                __num_usages,
             )
             return response
         else:

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -1,7 +1,5 @@
-import os
 import json
 from typing import Any, Dict, Optional
-import requests
 from .version_utils import MITOSHEET_HELPER_PRIVATE, is_pro
 from .schema import UJ_MITOSHEET_TELEMETRY, UJ_STATIC_USER_ID, UJ_USER_EMAIL, UJ_FEEDBACKS_V2
 from .db import get_user_field
@@ -159,6 +157,7 @@ def log_ai_completion_success(
     prompt_type: str,
     last_message_content: str,
     response: Dict[str, Any],
+    num_usages: Optional[int] = None
 ) -> None:
     """
     Logs AI completion success based on the input location.
@@ -192,6 +191,10 @@ def log_ai_completion_success(
 
     for chunk_key, chunk_value in response_chunks.items():
         base_params[chunk_key] = chunk_value
+
+    # Log number of usages (for mito server)
+    if num_usages is not None:
+        base_params[MITO_SERVER_NUM_USAGES] = str(num_usages)
 
     if prompt_type == "smartDebug":
         error_message = (

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -184,9 +184,13 @@ def log_ai_completion_success(
 
     # Chunk certain params to work around mixpanel's 255 character limit
     code_cell_input_chunks = chunk_param(code_cell_input, "code_cell_input")
+    full_prompt_chunks = chunk_param(last_message_content, "full_prompt")
     response_chunks = chunk_param(response["completion"], "response")
 
     for chunk_key, chunk_value in code_cell_input_chunks.items():
+        base_params[chunk_key] = chunk_value
+
+    for chunk_key, chunk_value in full_prompt_chunks.items():
         base_params[chunk_key] = chunk_value
 
     for chunk_key, chunk_value in response_chunks.items():

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -219,7 +219,13 @@ def log_ai_completion_success(
         log("mito_ai_code_explain_success", params=final_params)
     elif prompt_type == "chat":
         final_params = base_params
-        final_params["user_input"] = last_message_content.split("Your task: ")[-1]
+
+        # Chunk the user input
+        user_input = last_message_content.split("Your task: ")[-1]
+        user_input_chunks = chunk_param(user_input, "user_input")
+        
+        for chunk_key, chunk_value in user_input_chunks.items():
+            final_params[chunk_key] = chunk_value
 
         log("mito_ai_chat_success", params=final_params)
     else:


### PR DESCRIPTION
# Description

Expanded logging for server key users. Additionally, we're now tracking the full prompt. 

# Testing

Comment out `OPENAI_API_KEY` from your env vars, and send a few messages, use code explain and Start Debug. Then look in Mixpanel for the logs.  

# Documentation

N/A