### PR TITLE
Fix frontend tests

### DIFF
--- a/mito-ai/src/Extensions/emptyCell/EmptyCellPlugin.ts
+++ b/mito-ai/src/Extensions/emptyCell/EmptyCellPlugin.ts
@@ -14,8 +14,8 @@ import { COMMAND_MITO_AI_OPEN_CHAT } from '../../commands';
 import { IChatTracker } from '../AiChat/token';
 import { advicePlugin } from './emptyCell';
 
-export const localPrompt: JupyterFrontEndPlugin<void> = {
-  id: 'mito-ai:empty-editor-advice',
+export const emptyCellPlaceholder: JupyterFrontEndPlugin<void> = {
+  id: 'mito-ai:empty-cell-placeholder',
   description: 'Display a default message in an empty code cell.',
   autoStart: true,
   requires: [IChatTracker, IEditorExtensionRegistry],

--- a/mito-ai/src/index.ts
+++ b/mito-ai/src/index.ts
@@ -2,7 +2,7 @@ import AiChatPlugin from './Extensions/AiChat/AiChatPlugin';
 import VariableManagerPlugin from './Extensions/VariableManager/VariableManagerPlugin';
 import ErrorMimeRendererPlugin from './Extensions/ErrorMimeRenderer/ErrorMimeRendererPlugin';
 import CellToolbarButtonsPlugin from './Extensions/CellToolbarButtons/CellToolbarButtonsPlugin';
-import { localPrompt } from './Extensions/emptyCell/EmptyCellPlugin';
+import { emptyCellPlaceholder } from './Extensions/emptyCell/EmptyCellPlugin';
 import { completionPlugin } from './Extensions/InlineCompleter';
 import { statusItem } from './Extensions/status';
 
@@ -13,7 +13,7 @@ export default [
   ErrorMimeRendererPlugin,
   VariableManagerPlugin,
   CellToolbarButtonsPlugin,
-  localPrompt,
+  emptyCellPlaceholder,
   completionPlugin,
   statusItem
 ];

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -1,4 +1,4 @@
-import { expect, IJupyterLabPageFixture } from "@jupyterlab/galata";
+import { IJupyterLabPageFixture } from "@jupyterlab/galata";
 
 export const runCell = async (page: IJupyterLabPageFixture, cellIndex: number) => {
     await page.notebook.runCell(cellIndex);
@@ -24,85 +24,10 @@ export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture
         await page.waitForTimeout(100);
 
         await page.keyboard.type(cellContents[i], {delay: 50});
-
         await page.notebook.leaveCellEditingMode(i);
-
         await page.notebook.runCell(i);
     }
     await waitForIdle(page)
-}
-
-// export const createAndRunNotebookWithCells = async (
-//     page: IJupyterLabPageFixture, 
-//     cellContents: string[],
-// ) => {
-//     const randomFileName = `$test_file_${Math.random().toString(36).substring(2, 15)}.ipynb`;
-//     await page.notebook.createNew(randomFileName);
-
-//     await page.waitForTimeout(3000);
-
-//     // Wait for the kernel to be ready before setting cells
-//     await waitForIdle(page);
-
-//     for (let i = 0; i < cellContents.length; i++) {
-
-
-//         await page.notebook.addCell('code', '');
-//         await mitoSetCell(page, i, cellContents[i]);
-
-//         // await page.notebook.enterCellEditingMode(i);
-//         // // timeout for 100ms 
-//         // await page.waitForTimeout(100);
-
-//         // The setCell utility isn't working for some reason. The workaround was 
-//         // to add a \n in front of the cell contents, however, just typing the cell 
-//         // contents also works and doesn't require the \n which is an extra burden on 
-//         // expecting the cell contents. There is some discussion of a similar issue here: 
-//         // https://github.com/jupyterlab/jupyterlab/issues/15252
-//         // await page.keyboard.type(cellContents[i]);
-
-//         //Check if the cell now contains the cell contents
-//         // const cellInput = await page.notebook.getCellTextInput(i);
-
-//         // Sometimes the cell input doesn't get updated.
-//         // If that happens, try again.
-//         // if (cellInput !== cellContents[i]) {
-//         //     await page.notebook.enterCellEditingMode(i);
-//         //     await page.keyboard.type("\n\n");
-//         //     await page.keyboard.press('Backspace');
-//         //     await page.keyboard.press('Backspace');
-//         //     await page.keyboard.type(cellContents[i]);
-//         // }
-
-//         // await leaveCellEditingMode(cellIndex);
-//     }
-
-//     await page.notebook.runCellByCell();
-//     await waitForIdle(page)
-// }
-
-export const mitoSetCell = async (
-    page: IJupyterLabPageFixture,
-    cellIndex: number,
-    source: string
-  ): Promise<boolean> => {
-
-    const cell = await page.notebook.getCell(cellIndex);
-    await cell?.dblclick();
-    await page.notebook.enterCellEditingMode(cellIndex);
-
-    await page.keyboard.press('Control+A');
-    // give CodeMirror time to style properly
-
-    // Type slower like a user would
-    await page.keyboard.type(source, {delay: 200}) 
-
-    await page.notebook.leaveCellEditingMode(cellIndex);
-
-    // give CodeMirror time to style properly
-    await page.waitForTimeout(500);
-
-    return true;
 }
 
 export const waitForIdle = async (page: IJupyterLabPageFixture) => {

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -21,7 +21,7 @@ export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture
 
         // Give the cell a chance to enter editing mode and be ready for typing. 
         // This is a crucial step that prevents the typing from not registering!
-        await page.waitForTimeout(100);
+        await page.waitForTimeout(500);
 
         await page.keyboard.type(cellContents[i], {delay: 50});
         await page.notebook.leaveCellEditingMode(i);

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -23,6 +23,11 @@ export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture
         // This is a crucial step that prevents the typing from not registering!
         await page.waitForTimeout(500);
 
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+
         await page.keyboard.type(cellContents[i], {delay: 50});
         await page.notebook.leaveCellEditingMode(i);
         await page.notebook.runCell(i);

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -23,6 +23,8 @@ export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture
         // This is a crucial step that prevents the typing from not registering!
         await page.waitForTimeout(500);
 
+        // Even after waiting, sometimes the cell is not ready for typing, but
+        // it does accept the Enter 
         await page.keyboard.press('Enter');
         await page.keyboard.press('Enter');
         await page.keyboard.press('Backspace');

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -5,10 +5,7 @@ export const runCell = async (page: IJupyterLabPageFixture, cellIndex: number) =
     await waitForIdle(page);
 }
 
-export const createAndRunNotebookWithCells = async (
-    page: IJupyterLabPageFixture, 
-    cellContents: string[],
-) => {
+export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture, cellContents: string[]) => {
     const randomFileName = `$test_file_${Math.random().toString(36).substring(2, 15)}.ipynb`;
     await page.notebook.createNew(randomFileName);
 
@@ -16,41 +13,73 @@ export const createAndRunNotebookWithCells = async (
     await waitForIdle(page);
 
     for (let i = 0; i < cellContents.length; i++) {
+        // Add a short delay to ensure that the cell is created and the decoration placeholder extension
+        // has a chance to process
+        await page.waitForTimeout(100);
 
+        await page.notebook.enterCellEditingMode(i);
 
-        await page.notebook.addCell('code', cellContents[i]);
-        await mitoSetCell(page, i, cellContents[i]);
+        // Give the cell a chance to enter editing mode and be ready for typing. 
+        // This is a crucial step that prevents the typing from not registering!
+        await page.waitForTimeout(100);
 
-        // await page.notebook.enterCellEditingMode(i);
-        // // timeout for 100ms 
-        // await page.waitForTimeout(100);
+        await page.keyboard.type(cellContents[i], {delay: 50});
 
-        // The setCell utility isn't working for some reason. The workaround was 
-        // to add a \n in front of the cell contents, however, just typing the cell 
-        // contents also works and doesn't require the \n which is an extra burden on 
-        // expecting the cell contents. There is some discussion of a similar issue here: 
-        // https://github.com/jupyterlab/jupyterlab/issues/15252
-        // await page.keyboard.type(cellContents[i]);
+        await page.notebook.leaveCellEditingMode(i);
 
-        //Check if the cell now contains the cell contents
-        // const cellInput = await page.notebook.getCellTextInput(i);
-
-        // Sometimes the cell input doesn't get updated.
-        // If that happens, try again.
-        // if (cellInput !== cellContents[i]) {
-        //     await page.notebook.enterCellEditingMode(i);
-        //     await page.keyboard.type("\n\n");
-        //     await page.keyboard.press('Backspace');
-        //     await page.keyboard.press('Backspace');
-        //     await page.keyboard.type(cellContents[i]);
-        // }
-
-        // await leaveCellEditingMode(cellIndex);
+        await page.notebook.runCell(i);
     }
-
-    await page.notebook.runCellByCell();
     await waitForIdle(page)
 }
+
+// export const createAndRunNotebookWithCells = async (
+//     page: IJupyterLabPageFixture, 
+//     cellContents: string[],
+// ) => {
+//     const randomFileName = `$test_file_${Math.random().toString(36).substring(2, 15)}.ipynb`;
+//     await page.notebook.createNew(randomFileName);
+
+//     await page.waitForTimeout(3000);
+
+//     // Wait for the kernel to be ready before setting cells
+//     await waitForIdle(page);
+
+//     for (let i = 0; i < cellContents.length; i++) {
+
+
+//         await page.notebook.addCell('code', '');
+//         await mitoSetCell(page, i, cellContents[i]);
+
+//         // await page.notebook.enterCellEditingMode(i);
+//         // // timeout for 100ms 
+//         // await page.waitForTimeout(100);
+
+//         // The setCell utility isn't working for some reason. The workaround was 
+//         // to add a \n in front of the cell contents, however, just typing the cell 
+//         // contents also works and doesn't require the \n which is an extra burden on 
+//         // expecting the cell contents. There is some discussion of a similar issue here: 
+//         // https://github.com/jupyterlab/jupyterlab/issues/15252
+//         // await page.keyboard.type(cellContents[i]);
+
+//         //Check if the cell now contains the cell contents
+//         // const cellInput = await page.notebook.getCellTextInput(i);
+
+//         // Sometimes the cell input doesn't get updated.
+//         // If that happens, try again.
+//         // if (cellInput !== cellContents[i]) {
+//         //     await page.notebook.enterCellEditingMode(i);
+//         //     await page.keyboard.type("\n\n");
+//         //     await page.keyboard.press('Backspace');
+//         //     await page.keyboard.press('Backspace');
+//         //     await page.keyboard.type(cellContents[i]);
+//         // }
+
+//         // await leaveCellEditingMode(cellIndex);
+//     }
+
+//     await page.notebook.runCellByCell();
+//     await waitForIdle(page)
+// }
 
 export const mitoSetCell = async (
     page: IJupyterLabPageFixture,

--- a/tests/jupyter_utils/jupyterlab_utils.ts
+++ b/tests/jupyter_utils/jupyterlab_utils.ts
@@ -26,6 +26,7 @@ export const createAndRunNotebookWithCells = async (page: IJupyterLabPageFixture
         await page.keyboard.type(cellContents[i], {delay: 50});
         await page.notebook.leaveCellEditingMode(i);
         await page.notebook.runCell(i);
+        await waitForIdle(page)
     }
     await waitForIdle(page)
 }

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -185,23 +185,6 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Test fix error button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(3']);
-    await waitForIdle(page);
-
-    await page.getByRole('button', { name: 'Fix Error in AI Chat' }).click();
-    await waitForIdle(page);
-    await expect(page.locator('.message-assistant')).toHaveCount(1);
-  });
-
-  test('Test no fix error button for warnings', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['import warnings', 'warnings.warn("This is a warning")']);
-    await waitForIdle(page);
-
-    // Ensure that the "Fix Error in AI Chat" button is not visible
-    expect(page.getByRole('button', { name: 'Fix Error in AI Chat' })).not.toBeVisible();
-  });
-
-  test('Errors have fix with AI button', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['print(1']);
     await waitForIdle(page);
 
@@ -223,21 +206,19 @@ test.describe('Mito AI Chat', () => {
     expect(code).toContain('print(1)');
   });
 
-  test('Code cells have Explain Code button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1)']);
+  test('Test no fix error button for warnings', async ({ page }) => {
+    await createAndRunNotebookWithCells(page, ['import warnings', 'warnings.warn("This is a warning")']);
     await waitForIdle(page);
 
-    await selectCell(page, 0);
-    await page.getByRole('button', { name: 'Explain code in AI Chat' }).click();
-
-    // Check that the message "Explain this code" exists in the AI chat
-    await expect(page.getByText('Explain this code')).toBeVisible();
-
+    // Ensure that the "Fix Error in AI Chat" button is not visible
+    expect(page.getByRole('button', { name: 'Fix Error in AI Chat' })).not.toBeVisible();
   });
 
   test('Test explain code button', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['print(1)']);
     await waitForIdle(page);
+
+    await selectCell(page, 0);
 
     await page.getByRole('button', { name: 'Explain code in AI Chat' }).click();
     await waitForIdle(page);

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -26,7 +26,7 @@ test.describe.configure({ mode: 'parallel' });
 test.describe('Mito AI Chat', () => {
 
   test('Preview and Accept AI Generated Code', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})'], true);
+    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
@@ -48,7 +48,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Reject AI Generated Code', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})'], true);
+    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
@@ -63,7 +63,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Edit Message', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})'], true);
+    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     // Send the first message
@@ -99,7 +99,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Code diffs are automatically rejected before new messages are sent', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print("cell 0")'], true);
+    await createAndRunNotebookWithCells(page, ['print("cell 0")']);
     await waitForIdle(page);
 
     // Send a first message in cell 1
@@ -173,7 +173,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('No Code blocks are displayed when active cell is empty', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, [], true);
+    await createAndRunNotebookWithCells(page, []);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Add print (1)');
@@ -185,7 +185,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Test fix error button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(3'], true);
+    await createAndRunNotebookWithCells(page, ['print(3']);
     await waitForIdle(page);
 
     await page.getByRole('button', { name: 'Fix Error in AI Chat' }).click();
@@ -202,7 +202,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Errors have fix with AI button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1'], true);
+    await createAndRunNotebookWithCells(page, ['print(1']);
     await waitForIdle(page);
 
     await page.getByRole('button', { name: 'Fix Error in AI Chat' }).click();
@@ -224,7 +224,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Code cells have Explain Code button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1)'], true);
+    await createAndRunNotebookWithCells(page, ['print(1)']);
     await waitForIdle(page);
 
     await selectCell(page, 0);
@@ -236,7 +236,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Test explain code button', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1)'], true);
+    await createAndRunNotebookWithCells(page, ['print(1)']);
     await waitForIdle(page);
 
     await page.getByRole('button', { name: 'Explain code in AI Chat' }).click();
@@ -245,7 +245,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Variable dropdown shows correct variables', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"Apples": [1, 2, 3], "Bananas": [4, 5, 6]})'], true);
+    await createAndRunNotebookWithCells(page, ['import pandas as pd\ndf=pd.DataFrame({"Apples": [1, 2, 3], "Bananas": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await clickOnMitoAIChatTab(page);
@@ -265,8 +265,7 @@ test.describe('Mito AI Chat', () => {
         'import pandas as pd',
         'timestamp_df = pd.DataFrame({"timestamp_col_A": [pd.to_datetime("2020-01-01"), pd.to_datetime("2020-01-02"), pd.to_datetime("2020-01-03")]}, dtype=object)',
         'none_type_df = pd.DataFrame({"none_type_col_A": [None, None, None]})'
-      ],
-      true
+      ]
     );
 
     await waitForIdle(page);
@@ -293,7 +292,7 @@ test.describe('Mito AI Chat', () => {
   });
 
   test('Active cell preview is displayed and updated when active cell changes', async ({ page }) => {
-    await createAndRunNotebookWithCells(page, ['print(1)', 'print(2)'], true);
+    await createAndRunNotebookWithCells(page, ['print(1)', 'print(2)']);
     await waitForIdle(page);
 
     await selectCell(page, 0);

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -230,10 +230,10 @@ test.describe('Mito AI Chat', () => {
     await waitForIdle(page);
 
     await clickOnMitoAIChatTab(page);
+    await page.locator('.chat-input').click();
 
     // The fill() command doesn't trigger input events that the dropdown relies on
     // So we need to type it character by character instead
-    await page.locator('.chat-input').click();
     await page.keyboard.type("Edit column @ap");
     await expect.soft(page.locator('.chat-dropdown-item-name').filter({ hasText: 'Apples' })).toBeVisible();
     await expect(page.locator('.chat-dropdown-item-name').filter({ hasText: 'Bananas' })).not.toBeVisible();

--- a/tests/mitoai_ui_tests/utils.ts
+++ b/tests/mitoai_ui_tests/utils.ts
@@ -7,12 +7,15 @@ export const waitForMitoAILoadingToDisappear = async (page: IJupyterLabPageFixtu
 }
 
 export const clickOnMitoAIChatTab = async (page: IJupyterLabPageFixture) => {
+    await page.waitForTimeout(1000);
+
     // Click the AI Chat tab if it's not already selected
     const aiChatTab = await page.getByRole('tab', { name: 'AI Chat for your JupyterLab' });
     const isSelected = await aiChatTab.getAttribute('aria-selected');
     if (isSelected !== 'true') {
         await aiChatTab.getByRole('img').click();
     }
+    await page.waitForTimeout(1000);
 }
 
 export const clearMitoAIChatInput = async (page: IJupyterLabPageFixture) => {


### PR DESCRIPTION
# Description

Improves the robustness of our tests by adding a short timeout in between entering cell editing mode and beginning to type. This short timeout ensures that the cell is ready to accept user input. Prior to this, we would type and nothing would appear in the cell. 

The tests are all now passing locally, but not on the CI.. 


# Testing


# Documentation

Nope