### PR TITLE
Grey overwrite button

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -115,14 +115,14 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                             text={'Overwrite Active Cell'}
                                             icon={PlayButtonIcon}
                                             title={'Write the Ai generated code to the active cell in the jupyter notebook, replacing the current code.'}
-                                            variant='green'
+                                            variant='gray'
                                         />
                                         <TextAndIconButton 
                                             onClick={() => {copyToClipboard(messagePart)}}
                                             text={'Copy'}
                                             icon={CopyIcon}
                                             title={'Copy the Ai generated code to your clipboard'}
-                                            variant='green'
+                                            variant='gray'
                                         />
                                     </div>
                                 }

--- a/mito-ai/src/components/TextButton.tsx
+++ b/mito-ai/src/components/TextButton.tsx
@@ -7,7 +7,7 @@ export interface ButtonProps {
     text: string;
     onClick: () => void;
     title: string;
-    variant: 'green' | 'red';
+    variant: 'green' | 'red' | 'gray';
 }
 
 // Text Button is just the basic Button Props, nothing else. 

--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -82,7 +82,8 @@
     display: flex;
     flex-direction: row;
     gap: 8px;
-    padding: 5px;
+    margin-top: 10px;
+    margin-bottom: 10px;
     flex-wrap: wrap;
 }
 

--- a/mito-ai/style/TextAndIconButton.css
+++ b/mito-ai/style/TextAndIconButton.css
@@ -46,3 +46,12 @@
     padding: 2px;
     font-size: 12px;
 }
+
+.text-and-icon-button.gray {
+    background-color: var(--jp-layout-color2);
+    color: var(--jp-content-font-color1);
+}
+
+.text-and-icon-button.gray:hover {
+    background-color: var(--jp-layout-color3);
+}


### PR DESCRIPTION
# Description

Switch the overwrite and copy buttons to grey so that the Apply or Reject buttons stand out more. 

Dark Mode:
<img width="307" alt="Screenshot 2024-12-27 at 12 50 05 PM" src="https://github.com/user-attachments/assets/574f3012-d19f-467d-b574-2b1a630a5eda" />


Light Mode:
<img width="338" alt="Screenshot 2024-12-27 at 12 50 19 PM" src="https://github.com/user-attachments/assets/9133ccde-56b5-47fa-ae48-ec0b0e9f4cbf" />


# Testing

Try them out

# Documentation

Not yet