### PR TITLE
improve dark mode diffs

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
@@ -92,11 +92,6 @@ const ChatDropdown: React.FC<ChatDropdownProps> = ({
                             onClick={() => onSelect(option.variable_name, option.parent_df)}
                         >
                             <span className="chat-dropdown-item-type"
-                                style={{
-                                    color: getShortType(option.type) === 'df' ? 'blue'
-                                        : getShortType(option.type) === 'col' ? 'orange'
-                                            : "green"
-                                }}
                                 title={getShortType(option.type)}
                             >
                                 {getShortType(option.type)}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -45,9 +45,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const [isDropdownVisible, setDropdownVisible] = useState(false);
     const [dropdownFilter, setDropdownFilter] = useState('');
 
-    console.log('ChatInput rendering, activeCellID:', activeCellID);
-
-
     // Debounce the active cell ID change to avoid multiple rerenders. 
     // We use this to avoid a flickering screen when the active cell changes. 
     const debouncedSetActiveCellID = useDebouncedFunction((newID: string | undefined) => {

--- a/mito-ai/src/Extensions/AiChat/CodeDiffDisplay.tsx
+++ b/mito-ai/src/Extensions/AiChat/CodeDiffDisplay.tsx
@@ -13,8 +13,8 @@ import { deepEqualArrays } from '../../utils/arrays';
 // Defines new styles for this extension
 const baseTheme = EditorView.baseTheme({
   // We need to set some transparency because the stripes are above the selection layer
-  '.cm-codeDiffRemovedStripe': { backgroundColor: 'rgba(250, 212, 212, 0.62)' },
-  '.cm-codeDiffInsertedStripe': { backgroundColor: 'rgba(79, 255, 105, 0.38)' },
+  '.cm-codeDiffRemovedStripe': { backgroundColor: 'color-mix(in srgb, var(--error-color) 30%, transparent)' },
+  '.cm-codeDiffInsertedStripe': { backgroundColor: 'color-mix(in srgb, var(--jp-accent-color2) 35%, transparent)' },
 });
 
 // Resolve step to use in the editor

--- a/mito-ai/style/ChatDropdown.css
+++ b/mito-ai/style/ChatDropdown.css
@@ -52,7 +52,7 @@
 }
 
 .chat-dropdown-item-type {
-    color: var(--muted-text-color);
+    color: var(--jp-brand-color1);
     font-family: var(--jp-code-font-family);
     min-width: 35px;
     width: 35px;

--- a/mito-ai/style/ChatDropdown.css
+++ b/mito-ai/style/ChatDropdown.css
@@ -17,7 +17,7 @@
     position: relative;
     border: 0px;
     border-radius: 5px;
-    background-color: white;
+    background-color: var(--jp-layout-color1);
     list-style-type: none;
     padding: 0;
     margin: 0;
@@ -31,11 +31,12 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    color: var(--jp-content-font-color1);
 }
 
 .chat-dropdown-item:hover,
 .chat-dropdown-item.selected {
-    background-color: var(--purple-300);
+    background-color: var(--jp-layout-color3);
 }
 
 .chat-dropdown-item:first-child {


### PR DESCRIPTION
# Description

Address this issue https://github.com/mito-ds/mito/issues/1444

<details>
<summary> Improve diffs on dark mode by switching to Jupyter Lab colors. </summary>
<img width="1077" alt="Screenshot 2024-12-27 at 1 14 15 PM" src="https://github.com/user-attachments/assets/2c8d37db-0438-4989-9ed0-94a774db6a48" />
<img width="1071" alt="Screenshot 2024-12-27 at 1 14 24 PM" src="https://github.com/user-attachments/assets/d06daab7-9443-4bc2-ac5c-0551db4ab871" />
</details>

<details>
<summary> Improve variable dropdown on dark mode by switching to Jupyter Lab colors. </summary>
<img width="418" alt="Screenshot 2024-12-27 at 1 30 43 PM" src="https://github.com/user-attachments/assets/e1f5a9ef-0b7e-4c2c-aeb6-8a30e77c9e8a" />
<img width="414" alt="Screenshot 2024-12-27 at 1 31 03 PM" src="https://github.com/user-attachments/assets/63c6647f-cffc-40c3-8a19-6254ab5376e3" />

</details>

# Testing

Just try it out. 

# Documentation

Not yet