### PR TITLE
Always show accept reject buttons

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -388,8 +388,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             Register the code cell toolbar buttons for accepting and rejecting code.
         */
         app.commands.addCommand(COMMAND_MITO_AI_CELL_TOOLBAR_ACCEPT_CODE, {
-            label: `Accept ${operatingSystem === 'mac' ? '⌘Y' : 'Ctrl+Y'}`,
-            className: 'text-and-icon-button green small',
+            label: `Accept AI edits ${operatingSystem === 'mac' ? '⌘Y' : 'Ctrl+Y'}`,
+            className: 'text-and-icon-button green',
             caption: 'Accept Code',
             execute: () => {acceptAICode()},
             // We use the cellStateBeforeDiff because it contains the code cell ID that we want to write to
@@ -404,8 +404,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         });
 
         app.commands.addCommand(COMMAND_MITO_AI_CELL_TOOLBAR_REJECT_CODE, {
-            label: `Reject ${operatingSystem === 'mac' ? '⌘U' : 'Ctrl+U'}`,
-            className: 'text-and-icon-button red small',
+            label: `Reject AI edits ${operatingSystem === 'mac' ? '⌘U' : 'Ctrl+U'}`,
+            className: 'text-and-icon-button red',
             caption: 'Reject Code',
             execute: () => {rejectAICode()},
             isVisible: () => {

--- a/mito-ai/style/TextAndIconButton.css
+++ b/mito-ai/style/TextAndIconButton.css
@@ -42,11 +42,6 @@
     background-color: var(--red-500);
 }
 
-.text-and-icon-button.small {
-    padding: 2px;
-    font-size: 12px;
-}
-
 .text-and-icon-button.gray {
     background-color: var(--jp-layout-color2);
     color: var(--jp-content-font-color1);

--- a/mito-ai/style/base.css
+++ b/mito-ai/style/base.css
@@ -46,3 +46,21 @@
     --purple-400: #D0B9FE;
     --purple-300: #E9E0FD;
 }
+
+
+/* 
+    Jupyter tries to ensure that the cell toolbar does not overlap with the contents of the cell. 
+    There's some algorithm that adds the class `.jp-toolbar-overlap` to the cell toolbar 
+    when it gets too close to the cell contents. 
+
+    However, we don't want to hide the Accept and Reject toolbar buttons! We always want them to be visible.
+    To do this, we change the method for hiding the cell toolbar. Instead of hiding the entire toolbar, 
+    we hide individual buttons, excluding the Accept and Reject buttons.
+*/
+.jp-toolbar-overlap .jp-cell-toolbar {
+    display: flex !important;
+} 
+
+.jp-toolbar-overlap .jp-cell-toolbar > *:not([data-jp-item-name="accept-code"]):not([data-jp-item-name="reject-code"]) {
+    display: none !important;
+}

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -46,7 +46,7 @@ test.describe('Mito AI Chat', () => {
     expect(code).toContain('df["C"] = [7, 8, 9]');
   });
 
-  test.only("Accept using cell toolbar button", async ({ page }) => {
+  test("Accept using cell toolbar button", async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import pandas as pd', 'df=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
@@ -79,7 +79,7 @@ test.describe('Mito AI Chat', () => {
     expect(code?.trim()).toBe("")
   });
 
-  test.only("Reject using cell toolbar button", async ({ page }) => {
+  test("Reject using cell toolbar button", async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import pandas as pd', 'df=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -46,19 +46,13 @@ test.describe('Mito AI Chat', () => {
     expect(code).toContain('df["C"] = [7, 8, 9]');
   });
 
-  test("Accept using cell toolbar button", async ({ page }) => {
+  test.only("Accept using cell toolbar button", async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import pandas as pd', 'df=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
     await clickPreviewButton(page);
-    await page.waitForTimeout(1000);
-
-    // We need to close the chat taskpane to ensure that 
-    // the cell toolbar has enough space to be visible.
-    // If the screen is too narrow, Jupyter does not show the cell toolbar.
-    await closeMitoAIChat(page);
     await page.waitForTimeout(1000);
 
     expect(page.locator('.jp-cell-toolbar').getByRole('button', { name: 'Accept' })).toBeVisible();
@@ -85,19 +79,13 @@ test.describe('Mito AI Chat', () => {
     expect(code?.trim()).toBe("")
   });
 
-  test("Reject using cell toolbar button", async ({ page }) => {
+  test.only("Reject using cell toolbar button", async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import pandas as pd', 'df=pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})']);
     await waitForIdle(page);
 
     await sendMessageToMitoAI(page, 'Write the code df["C"] = [7, 8, 9]');
 
     await clickPreviewButton(page);
-    await page.waitForTimeout(1000);
-
-    // We need to close the chat taskpane to ensure that 
-    // the cell toolbar has enough space to be visible.
-    // If the screen is too narrow, Jupyter does not show the cell toolbar.
-    await closeMitoAIChat(page);
     await page.waitForTimeout(1000);
 
     expect(page.locator('.jp-cell-toolbar').getByRole('button', { name: 'Reject' })).toBeVisible();

--- a/tests/mitoai_ui_tests/utils.ts
+++ b/tests/mitoai_ui_tests/utils.ts
@@ -78,9 +78,7 @@ export const clickAcceptButton = async (
     { useCellToolbar = false }: { useCellToolbar?: boolean } = {useCellToolbar: false}
 ) => {
     if (useCellToolbar) {
-        await closeMitoAIChat(page);
-        await page.getByLabel('notebook content').getByText('Accept').click();
-
+        await page.getByText('Accept AI edits').click();
     } else {
         await page.locator('.chat-taskpane').getByRole('button', { name: 'Accept code' }).click();
     }
@@ -94,10 +92,7 @@ export const clickDenyButton = async (
     { useCellToolbar = false }: { useCellToolbar?: boolean } = {useCellToolbar: false}
 ) => {
     if (useCellToolbar) {
-        await closeMitoAIChat(page);
-        // For some reason, the same selector doesn't work here. It ends up just scrolling the page
-        // up and down a bunch of times until it times out. So instead, we use this selector 
-        await page.getByLabel('notebook content').getByText('Reject').click();
+        await page.getByText('Reject AI edits').click();
     } else {
         await page.locator('.chat-taskpane').getByRole('button', { name: 'Reject code' }).click();
     }


### PR DESCRIPTION
# Description

Updates the cell toolbar css strategy so that when we want to display the Accept and Reject buttons we always can. 

Read the css docstring for a more thorough explanation. 
<img width="649" alt="Screenshot 2024-12-27 at 4 53 20 PM" src="https://github.com/user-attachments/assets/dfe792ce-3ba6-46ab-9481-0f2012701e55" />

# Testing

Try it out + see tests. 

# Documentation

No