### PR TITLE
No focus on smart debug

### DIFF
--- a/mito-ai/src/Extensions/AiChat/AiChatPlugin.ts
+++ b/mito-ai/src/Extensions/AiChat/AiChatPlugin.ts
@@ -10,6 +10,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IVariableManager } from '../VariableManager/VariableManagerPlugin';
 import { COMMAND_MITO_AI_OPEN_CHAT } from '../../commands';
 import { IChatTracker } from './token';
+import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 
 /**
@@ -53,7 +54,7 @@ const AiChatPlugin: JupyterFrontEndPlugin<WidgetTracker> = {
     // Add an application command
     app.commands.addCommand(COMMAND_MITO_AI_OPEN_CHAT, {
       label: 'Your friendly Python Expert chat bot',
-      execute: () => {
+      execute: (args?: ReadonlyPartialJSONObject) => {
         // In order for the widget to be accessible, the widget must be:
         // 1. Created
         // 2. Added to the widget tracker
@@ -79,6 +80,14 @@ const AiChatPlugin: JupyterFrontEndPlugin<WidgetTracker> = {
         // Now that the widget is potentially accessible, activating the
         // widget opens the taskpane
         app.shell.activateById(widget.id);
+
+
+        // If the command is called with focus on chat input set to false, 
+        // don't focus. This is useful when we don't want to active cell 
+        // preview to be displayed when using the smart debugger.
+        if (args?.focusChatInput === false) {
+          return;
+        }
 
         // Set focus on the chat input
         const chatInput: HTMLTextAreaElement | null =

--- a/mito-ai/src/Extensions/ErrorMimeRenderer/ErrorMimeRendererPlugin.tsx
+++ b/mito-ai/src/Extensions/ErrorMimeRenderer/ErrorMimeRendererPlugin.tsx
@@ -98,8 +98,6 @@ class AugmentedStderrRenderer extends Widget implements IRenderMime.IRenderer {
             }
         }
 
-
-
         // Append the original error/warning rendered node
         this.node.appendChild(originalNode);
     }
@@ -110,7 +108,7 @@ class AugmentedStderrRenderer extends Widget implements IRenderMime.IRenderer {
     */
     openChatInterfaceWithError(model: IRenderMime.IMimeModel): void {
         const conciseErrorMessage = this.getErrorString(model);
-        this.app.commands.execute(COMMAND_MITO_AI_OPEN_CHAT)
+        this.app.commands.execute(COMMAND_MITO_AI_OPEN_CHAT, { focusChatInput: false });
         this.app.commands.execute(COMMAND_MITO_AI_SEND_DEBUG_ERROR_MESSAGE, { input: conciseErrorMessage });
     }
 

--- a/tests/mitoai_ui_tests/mitoai.spec.ts
+++ b/tests/mitoai_ui_tests/mitoai.spec.ts
@@ -220,7 +220,7 @@ test.describe('Mito AI Chat', () => {
     expect(codeMessagePartContainersCount).toBe(1);
   });
 
-  test('Test fix error button', async ({ page }) => {
+  test('Fix error button', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['print(1']);
     await waitForIdle(page);
 
@@ -228,6 +228,9 @@ test.describe('Mito AI Chat', () => {
     await waitForIdle(page);
 
     await waitForMitoAILoadingToDisappear(page);
+
+    // Ensure the chat input is not focussed on 
+    await expect(page.locator('.chat-input')).not.toBeFocused();
 
     // No code diffs should be visible before the user clicks preview
     await expect(page.locator('.cm-codeDiffRemovedStripe')).not.toBeVisible();
@@ -242,7 +245,7 @@ test.describe('Mito AI Chat', () => {
     expect(code).toContain('print(1)');
   });
 
-  test('Test no fix error button for warnings', async ({ page }) => {
+  test('No fix error button for warnings', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['import warnings', 'warnings.warn("This is a warning")']);
     await waitForIdle(page);
 
@@ -250,7 +253,7 @@ test.describe('Mito AI Chat', () => {
     expect(page.getByRole('button', { name: 'Fix Error in AI Chat' })).not.toBeVisible();
   });
 
-  test('Test explain code button', async ({ page }) => {
+  test('Explain code button', async ({ page }) => {
     await createAndRunNotebookWithCells(page, ['print(1)']);
     await waitForIdle(page);
 


### PR DESCRIPTION
# Description

Do not focus on the chat input when using the Smart Debug button. We have already sent the message, so the user does not need to type anything. Without doing this, the active cell preview appears and is confusing. 

# Testing

See test + try it out. 

# Documentation

No. 