### PR TITLE
Separated Inline and Chat Usage Checks

### DIFF
--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -206,7 +206,9 @@ This attribute is observed by the websocket provider to push the error to the cl
                 self.log.warning("Failed to set first usage date in user.json", exc_info=e)
 
         try:
-            check_mito_server_quota(_num_usages or 0, _first_usage_date or "")
+            # Check the count-based limit for non-inline completions.
+            # Inline completions will be checked when the user sends an inline completion.
+            check_mito_server_quota(_num_usages or 0, _first_usage_date or "", False)
         except Exception as e:
             self.last_error = CompletionError.from_exception(e)
 
@@ -302,6 +304,7 @@ This attribute is observed by the websocket provider to push the error to the cl
                     },
                     _num_usages or 0,
                     _first_usage_date or "",
+                    prompt_type == "inline_completion",
                 )
 
                 # Increment the number of usages for everything EXCEPT inline completions.

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -26,25 +26,31 @@ __user_email = None
 __user_id = None
 
 
-def check_mito_server_quota(n_counts: int, first_usage_date: str) -> None:
-    """Check whether the user has reached the limit of completions for the free tier or not.
+def check_mito_server_quota(n_counts: int, first_usage_date: str, is_inline: bool) -> None:
+    """Check whether the user has reached the limit for the specific completion type.
 
     Args:
         n_counts: The number of completions the user has made so far.
         first_usage_date: The date of the user's first usage.
+        is_inline: Whether this is an inline completion request
     Raises:
         PermissionError: If the user has reached the limit.
     """
     pro = is_pro()
+    if pro:
+        return
 
-    if not pro and n_counts >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
-        log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
-        raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
-
-    if first_usage_date != "":
-        first_use = datetime.strptime(first_usage_date, "%Y-%m-%d")
-        one_month_later = first_use + timedelta(days=OPEN_SOURCE_INLINE_COMPLETIONS_LIMIT)
-        if datetime.now() > one_month_later:
+    if is_inline:
+        # Only check the time-based limit for inline completions
+        if first_usage_date:
+            first_use = datetime.strptime(first_usage_date, "%Y-%m-%d")
+            one_month_later = first_use + timedelta(days=OPEN_SOURCE_INLINE_COMPLETIONS_LIMIT)
+            if datetime.now() > one_month_later:
+                log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+                raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+    else:
+        # Only check the count-based limit for non-inline completions
+        if n_counts >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
             raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
 
@@ -54,6 +60,7 @@ async def get_ai_completion_from_mito_server(
     ai_completion_data: Dict[str, Any],
     n_counts: int,
     first_usage_date: str,
+    is_inline: bool,
 ) -> str:
     global __user_email, __user_id
 
@@ -62,7 +69,7 @@ async def get_ai_completion_from_mito_server(
     if __user_id is None:
         __user_id = get_user_field(UJ_STATIC_USER_ID)
 
-    check_mito_server_quota(n_counts, first_usage_date)
+    check_mito_server_quota(n_counts, first_usage_date, is_inline)
 
     data = {
         "email": __user_email,


### PR DESCRIPTION
# Description

Separated the usage checks for inline completions and chat interactions. This ensures that users who have completed their trial period for inline completions but still have remaining chat messages can continue using the chat feature.

# Testing

Test the following cases with a server key:

- chat messages < 500 & first inline date < 30 days -chat ✅, inline ✅
- chat messages > 500 & first inline date < 30 days - chat ❌, inline ✅
- chat messages < 500 & first inline date > 30 days - chat ✅, inline ❌
- chat messages > 500 & first inline date > 30 days - chat ❌, inline ❌


# Documentation

N/A