### PR TITLE
Inline Prompt Update - Line rewrite

### DIFF
--- a/evals/prompts/inline_code_completion_prompts/__init__.py
+++ b/evals/prompts/inline_code_completion_prompts/__init__.py
@@ -2,10 +2,13 @@
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v1 import prod_prompt_v1
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v2 import prod_prompt_v2
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v3 import prod_prompt_v3
+from evals.prompts.inline_code_completion_prompts.prod_prompt_v4 import prod_prompt_v4
 
 
 INLINE_CODE_COMPLETION_PROMPT_GENERATORS = [
     prod_prompt_v1,
     prod_prompt_v2,
     prod_prompt_v3,
+    prod_prompt_v4,
 ]
+

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -1,0 +1,111 @@
+from evals.eval_types import InlineCodeCompletionPromptGenerator, NotebookState, ChatPromptGenerator
+
+__all__ = ['prod_prompt_v4']
+
+class _ProdPromptV4(InlineCodeCompletionPromptGenerator):
+    prompt_name = "prod_prompt_v4"
+
+    def get_prompt(self, prefix: str, suffix: str, notebook_state: NotebookState) -> str:
+    
+        return f"""You are a code completion assistant integrated into JupyterLab. Your role is to intelligently complete code based on the user's partial input and context.
+
+CONTEXT PROVIDED:
+- The current code cell content
+- The cursor position (marked as <cursor>)
+- Variables defined in the notebook environment
+
+CORE PRINCIPLES:
+1. Complete the code minimally and accurately
+2. Stay focused on the user's apparent intent
+3. Maintain Python's syntax and style conventions
+
+CRITICAL FORMATTING RULES:
+1. Add newline WHEN cursor appears:
+   - At the end of a complete line
+   - After a comment
+   - After a function/class definition
+2. DO NOT add newline WHEN cursor appears:
+   - Mid-line
+   - In incomplete statements
+3. Preserve exact indentation level
+4. Return ONLY the completion text (no prefix code)
+
+Examples:
+
+<Example 1: Same Line Completion>
+Defined Variables: {{
+    'loan_multiplier': 1.5,
+    'sales_df': pd.DataFrame({{
+        'transaction_date': ['2024-01-02', '2024-01-02', '2024-01-02', '2024-01-02', '2024-01-03'],
+        'price_per_unit': [10, 9.99, 13.99, 21.00, 100],
+        'units_sold': [1, 2, 1, 4, 5],
+        'total_price': [10, 19.98, 13.99, 84.00, 500]
+    }})
+}}
+
+Code in the active code cell:
+```python
+import pandas as pd
+sales_df = pd.read_csv('./sales.<cursor>
+```
+
+Output:
+```python
+csv')
+```
+</Example 1>
+
+IMPORTANT: Notice in Example 1 that the output does NOT contain the line's previous code. It only contains the code required to complete the user's intent.
+
+<Example 2: Mid-line Completion>
+Defined Variables: {{
+    df: pd.DataFrame({{
+        'age': [20, 25, 22, 23, 29],
+        'name': ['Nawaz', 'Aaron', 'Charlie', 'Tamir', 'Eve'],
+    }})
+}}
+
+Code in the active code cell:
+```python
+# filter df by age greater than 25
+filtered_df = df[df['age'] <cursor> 25]
+```
+
+Output:
+```python
+>
+```
+</Example 2>
+
+IMPORTANT: Notice in Example 2 that the output does NOT start with a newline because the cursor is in the middle of existing code.
+
+<Example 3: New Line Required>
+Defined Variables: {{}}
+
+Code in the active code cell:
+```python
+# Create a variable x and set it equal to 1<cursor>
+```
+
+Output:
+```python
+
+x = 1
+```
+</Example 3>
+
+IMPORTANT: Notice in Example 3 that the output starts with a newline because the cursor appears at the end of a comment line.
+
+Your Task:
+
+Defined Variables: {notebook_state.global_vars}
+
+Code in the active code cell:
+```python
+${prefix}<cursor>${suffix}
+```
+
+Output:
+"""
+
+prod_prompt_v4 = _ProdPromptV4()

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -7,28 +7,18 @@ class _ProdPromptV4(InlineCodeCompletionPromptGenerator):
 
     def get_prompt(self, prefix: str, suffix: str, notebook_state: NotebookState) -> str:
     
-        return f"""You are a code completion assistant integrated into JupyterLab. Your role is to intelligently complete code based on the user's partial input and context.
+        return f"""You are a code completion assistant that lives inside of JupyterLab. Your job is to predict the rest of the code that the user has started to write.
 
-CONTEXT PROVIDED:
-- The current code cell content
-- The cursor position (marked as <cursor>)
-- Variables defined in the notebook environment
-
-CORE PRINCIPLES:
-1. Complete the code minimally and accurately
-2. Stay focused on the user's apparent intent
-3. Maintain Python's syntax and style conventions
+You're given the current code cell, the user's cursor position, and the variables defined in the notebook. The user's cursor is signified by the symbol <cursor>.
 
 CRITICAL FORMATTING RULES:
-1. Add newline WHEN cursor appears:
-   - At the end of a complete line
-   - After a comment
-   - After a function/class definition
-2. DO NOT add newline WHEN cursor appears:
-   - Mid-line
-   - In incomplete statements
-3. Preserve exact indentation level
-4. Return ONLY the completion text (no prefix code)
+1. If the cursor appears at the end of a complete line (especially after a comment), ALWAYS start your code with a newline character
+2. If the cursor appears at the end of a function definition, ALWAYS start your code with a newline character
+3. If the cursor appears in the middle of existing code or in an incomplete line of code, do NOT add any newline characters
+4. Your response must preserve correct Python indentation and spacing
+5. Your response should NOT contain any of the code that the user has already written. 
+
+Your job is to complete the current line of code. Only return the code that the user has not yet written.
 
 Examples:
 

--- a/mito-ai/src/prompts/InlinePrompt.tsx
+++ b/mito-ai/src/prompts/InlinePrompt.tsx
@@ -14,8 +14,9 @@ CRITICAL FORMATTING RULES:
 2. If the cursor appears at the end of a function definition, ALWAYS start your code with a newline character
 3. If the cursor appears in the middle of existing code or in an incomplete line of code, do NOT add any newline characters
 4. Your response must preserve correct Python indentation and spacing
+5. Your response should NOT contain any of the code that the user has already written. 
 
-Your job is to complete the code that matches the user's intent. Write the minimal code to achieve the user's intent. Don't expand upon the user's intent.
+Your job is to complete the current line of code. Only return the code that the user has not yet written.
 
 <Example 1>
 Defined Variables: {{

--- a/mito-ai/src/prompts/InlinePrompt.tsx
+++ b/mito-ai/src/prompts/InlinePrompt.tsx
@@ -31,19 +31,16 @@ Defined Variables: {{
 Code in the active code cell:
 \`\`\`python
 import pandas as pd
-sales_df = pd.read_csv('./sales.csv')
-
-# Multiply the total_price column by the loan_multiplier<cursor>
+sales_df = pd.read_csv('./sales.<cursor>
 \`\`\`
 
 Output:
 \`\`\`python
-
-sales_df['total_price'] = sales_df['total_price'] * loan_multiplier
+csv')
 \`\`\`
 </Example 1>
 
-IMPORTANT: Notice in Example 1 that the output starts with a newline because the cursor was at the end of a comment. This newline is REQUIRED to maintain proper Python formatting.
+IMPORTANT: Notice in Example 1 that the output does NOT contain the line's previous code. It only contains the code required to complete the user's intent.
 
 <Example 2>
 Defined Variables: {{
@@ -55,12 +52,13 @@ Defined Variables: {{
 
 Code in the active code cell:
 \`\`\`python
-df['age'] = df[df['age'] > 23<cursor>]
+# filter df by age greater than 25
+filtered_df = df[df['age'] <cursor> 25]
 \`\`\`
 
 Output:
 \`\`\`python
-]
+>
 \`\`\`
 </Example 2>
 
@@ -76,6 +74,8 @@ Code in the active code cell:
 
 Output:
 \`\`\`python
+
+x = 1
 \`\`\`
 </Example 3>
 


### PR DESCRIPTION
# Description

Update the inline prompt to address issue where it rewrites the entire line. 

For example, with the old prompt `pri<cursor>` would return `priprint()`.

This PR tried to fix this issue entirely in prompt. To do so we:

1. Fix some of the examples we were providing to the LLM.
2. Add a fifth clause to the *Critical Formatting Rules* section.
3. Simplified the "Your job is to..." paragraph. This also lets the LLM be a little more imaginative.

We have not fully solved the issue, but there is a noticeable improvement. Looking at the evals, accruacy has dropped from 48% to 46%. However, 2% does seem to be within the acceptable margin of error (yesterday the old prompt was returning 50%, so there is some flux).    

# Testing

Clone it, prompt it.

# Documentation

N/A - behind the scenes prompt update