### PR TITLE
Added Tests for Server Quota

### DIFF
--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -44,7 +44,7 @@ jobs:
         cd mito-ai
         pytest
       env:
-        OPENAI_API_KEY: ${{ matrix.use-mito-ai-server && '' || secrets.OPENAI_API_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     - name: Upload test-results
       uses: actions/upload-artifact@v3
       if: failure()

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -35,6 +35,10 @@ jobs:
       run: |
         cd mito-ai
         pip install -e ".[test, deploy]"
+        jlpm install
+        jlpm build
+        jupyter labextension develop . --overwrite
+        jupyter server extension enable --py mito_ai
     - name: Run tests
       run: |
         cd mito-ai

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -1,0 +1,50 @@
+name: Test - Mito AI Backend
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mito-ai/**'
+  pull_request:
+    paths:
+      - 'mito-ai/**'
+jobs:
+  test-mitoai-backend:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.10', '3.11']
+      fail-fast: false
+
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          mito-ai/setup.py
+          tests/requirements.txt
+    - name: Install dependencies
+      run: |
+        cd mito-ai
+        pip install -e ".[test, deploy]"
+    - name: Run tests
+      run: |
+        cd mito-ai
+        pytest
+      env:
+        OPENAI_API_KEY: ${{ matrix.use-mito-ai-server && '' || secrets.OPENAI_API_KEY }}
+    - name: Upload test-results
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: mitoai-backend-report-${{ matrix.python-version }}
+        path: mito-ai/tests/pytest-report/
+        retention-days: 14

--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -179,19 +179,6 @@ This attribute is observed by the websocket provider to push the error to the cl
         """
         return bool(self.api_key)
 
-    # DELETE THIS
-    @property
-    def get_num_usages(self) -> int:
-        global _num_usages
-        return _num_usages or 0
-
-    @property
-    def get_first_usage_date(self) -> str:
-        global _first_usage_date
-        return _first_usage_date or ""
-
-    # DELETE END
-
     @property
     def capabilities(self) -> AICapabilities:
         """Get the provider capabilities.

--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -179,6 +179,19 @@ This attribute is observed by the websocket provider to push the error to the cl
         """
         return bool(self.api_key)
 
+    # DELETE THIS
+    @property
+    def get_num_usages(self) -> int:
+        global _num_usages
+        return _num_usages or 0
+
+    @property
+    def get_first_usage_date(self) -> str:
+        global _first_usage_date
+        return _first_usage_date or ""
+
+    # DELETE END
+
     @property
     def capabilities(self) -> AICapabilities:
         """Get the provider capabilities.

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -1,0 +1,8 @@
+from mito_ai.utils.open_ai_utils import (
+    OPEN_SOURCE_AI_COMPLETIONS_LIMIT,
+    check_mito_server_quota,
+)
+
+
+def test_check_mito_server_quota():
+    check_mito_server_quota(1, )

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -1,8 +1,37 @@
+import pytest
+from datetime import datetime
+from unittest.mock import patch
 from mito_ai.utils.open_ai_utils import (
+    MITO_SERVER_FREE_TIER_LIMIT_REACHED,
     OPEN_SOURCE_AI_COMPLETIONS_LIMIT,
     check_mito_server_quota,
 )
 
+REALLY_OLD_DATE = "2020-01-01"
+TODAY = datetime.now().strftime("%Y-%m-%d")
 
-def test_check_mito_server_quota():
-    check_mito_server_quota(1, )
+
+def test_check_mito_server_quota_open_source_user():
+    # Under both limits
+    check_mito_server_quota(1, TODAY)
+
+    # Over the both limits
+    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED):
+        check_mito_server_quota(OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1, REALLY_OLD_DATE)
+
+    # Over the chat limit
+    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED):
+        check_mito_server_quota(OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1, TODAY)
+
+    # Over the inline limit
+    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED):
+        check_mito_server_quota(1, REALLY_OLD_DATE)
+
+
+def test_check_mito_server_quota_pro_user():
+    # No error should be thrown since pro users don't have limits
+    with patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True):
+        check_mito_server_quota(1, TODAY)
+        check_mito_server_quota(OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1, REALLY_OLD_DATE)
+        check_mito_server_quota(OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1, TODAY)
+        check_mito_server_quota(1, REALLY_OLD_DATE)

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -1,0 +1,67 @@
+import pytest
+from datetime import datetime
+from unittest.mock import patch
+import os
+from unittest.mock import mock_open
+from mito_ai.providers import OpenAIProvider
+
+CHAT_LIMIT = 500
+
+
+def test_os_user_mito_server_below_limit():
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", 1),
+        patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is None
+
+
+def test_os_user_mito_server_above_limit():
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is not None
+        assert llm.last_error.title == "mito_server_free_tier_limit_reached"
+
+
+def test_os_user_openai_key_set_below_limit():
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch("mito_ai.providers._num_usages", 1),
+        patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_os_user_openai_key_set_above_limit():
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -1,8 +1,6 @@
-import pytest
+import os
 from datetime import datetime
 from unittest.mock import patch
-import os
-from unittest.mock import mock_open
 from mito_ai.providers import OpenAIProvider
 
 CHAT_LIMIT = 500

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -9,6 +9,11 @@ CHAT_LIMIT = 500
 
 
 def test_os_user_mito_server_below_limit():
+    """
+    Open source user, with no OpenAI API key set (Mito server), below both limits.
+    No error should be thrown.
+    """
+
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -24,6 +29,11 @@ def test_os_user_mito_server_below_limit():
 
 
 def test_os_user_mito_server_above_limit():
+    """
+    Open source user, with no OpenAI API key set (Mito server), above chat limit.
+    An error should be thrown.
+    """
+
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -40,6 +50,11 @@ def test_os_user_mito_server_above_limit():
 
 
 def test_os_user_openai_key_set_below_limit():
+    """
+    Open source user, with OpenAI API key set, below both limits.
+    No error should be thrown.
+    """
+
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -54,6 +69,11 @@ def test_os_user_openai_key_set_below_limit():
 
 
 def test_os_user_openai_key_set_above_limit():
+    """
+    Open source user, with OpenAI API key set, above chat limit.
+    No error should be thrown, since the user is using their own key.
+    """
+
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -2,13 +2,10 @@ import os
 from datetime import datetime
 from unittest.mock import patch
 from mito_ai.providers import OpenAIProvider
-from mito_ai.utils.open_ai_utils import (
-    OPEN_SOURCE_AI_COMPLETIONS_LIMIT,
-    OPEN_SOURCE_INLINE_COMPLETIONS_LIMIT,
-    check_mito_server_quota,
-)
+from mito_ai.utils.open_ai_utils import OPEN_SOURCE_AI_COMPLETIONS_LIMIT
 
 REALLY_OLD_DATE = "2020-01-01"
+TODAY = datetime.now().strftime("%Y-%m-%d")
 
 
 def test_os_user_mito_server_below_limit():
@@ -18,12 +15,11 @@ def test_os_user_mito_server_below_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
     ):
         capabilities = llm.capabilities
 
@@ -38,13 +34,12 @@ def test_os_user_mito_server_above_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     # Above the chat limit
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
     ):
         capabilities = llm.capabilities
 
@@ -72,11 +67,10 @@ def test_os_user_openai_key_set_below_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     with (
         patch("mito_ai.providers._num_usages", 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
     ):
         capabilities = llm.capabilities
 
@@ -91,12 +85,11 @@ def test_os_user_openai_key_set_above_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     # Above the chat limit
     with (
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
     ):
         capabilities = llm.capabilities
 
@@ -121,12 +114,11 @@ def test_pro_user_mito_server_set_below_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities
@@ -142,13 +134,12 @@ def test_pro_user_mito_server_above_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     # Above the chat limit
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities
@@ -176,11 +167,10 @@ def test_pro_user_openai_key_set_below_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     with (
         patch("mito_ai.providers._num_usages", 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities
@@ -196,12 +186,11 @@ def test_pro_user_openai_key_set_above_limit():
     """
 
     llm = OpenAIProvider()
-    today = datetime.now().strftime("%Y-%m-%d")
 
     # Above the chat limit
     with (
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.providers._first_usage_date", TODAY),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -2,8 +2,7 @@ import os
 from datetime import datetime
 from unittest.mock import patch
 from mito_ai.providers import OpenAIProvider
-
-CHAT_LIMIT = 500
+from mito_ai.utils.open_ai_utils import OPEN_SOURCE_AI_COMPLETIONS_LIMIT
 
 
 def test_os_user_mito_server_below_limit():
@@ -37,7 +36,7 @@ def test_os_user_mito_server_above_limit():
 
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
-        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
     ):
         capabilities = llm.capabilities
@@ -76,7 +75,7 @@ def test_os_user_openai_key_set_above_limit():
     today = datetime.now().strftime("%Y-%m-%d")
 
     with (
-        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
     ):
         capabilities = llm.capabilities
@@ -117,7 +116,7 @@ def test_pro_user_mito_server_above_limit():
 
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
-        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
@@ -157,7 +156,7 @@ def test_pro_user_openai_key_set_above_limit():
     today = datetime.now().strftime("%Y-%m-%d")
 
     with (
-        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -83,3 +83,85 @@ def test_os_user_openai_key_set_above_limit():
 
         assert "user key" in capabilities.provider
         assert llm.last_error is None
+
+
+def test_pro_user_mito_server_set_below_limit():
+    """
+    Pro user, with no OpenAI API key set (Mito server), below chat limit.
+    No error should be thrown.
+    """
+
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", 1),
+        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is None
+
+
+def test_pro_user_mito_server_above_limit():
+    """
+    Pro user, with no OpenAI API key set (Mito server), with usage above chat limit.
+    No error should be thrown since pro users don't have limits.
+    """
+
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is None
+
+
+def test_pro_user_openai_key_set_below_limit():
+    """
+    Pro user, with OpenAI API key set, below chat limit.
+    No error should be thrown.
+    """
+
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch("mito_ai.providers._num_usages", 1),
+        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_pro_user_openai_key_set_above_limit():
+    """
+    Pro user, with OpenAI API key set, above chat limit.
+    No error should be thrown since pro users don't have limits.
+    """
+
+    llm = OpenAIProvider()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    with (
+        patch("mito_ai.providers._num_usages", CHAT_LIMIT + 1),
+        patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -2,7 +2,13 @@ import os
 from datetime import datetime
 from unittest.mock import patch
 from mito_ai.providers import OpenAIProvider
-from mito_ai.utils.open_ai_utils import OPEN_SOURCE_AI_COMPLETIONS_LIMIT
+from mito_ai.utils.open_ai_utils import (
+    OPEN_SOURCE_AI_COMPLETIONS_LIMIT,
+    OPEN_SOURCE_INLINE_COMPLETIONS_LIMIT,
+    check_mito_server_quota,
+)
+
+REALLY_OLD_DATE = "2020-01-01"
 
 
 def test_os_user_mito_server_below_limit():
@@ -27,17 +33,30 @@ def test_os_user_mito_server_below_limit():
 
 def test_os_user_mito_server_above_limit():
     """
-    Open source user, with no OpenAI API key set (Mito server), above chat limit.
+    Open source user, with no OpenAI API key set (Mito server), above both limits.
     An error should be thrown.
     """
 
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
+    # Above the chat limit
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is not None
+        assert llm.last_error.title == "mito_server_free_tier_limit_reached"
+
+    # Above the inline limit
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT),
+        patch("mito_ai.providers._first_usage_date", REALLY_OLD_DATE),
     ):
         capabilities = llm.capabilities
 
@@ -67,16 +86,27 @@ def test_os_user_openai_key_set_below_limit():
 
 def test_os_user_openai_key_set_above_limit():
     """
-    Open source user, with OpenAI API key set, above chat limit.
+    Open source user, with OpenAI API key set, above both limits.
     No error should be thrown, since the user is using their own key.
     """
 
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
+    # Above the chat limit
     with (
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+    # Above the inline limit
+    with (
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT),
+        patch("mito_ai.providers._first_usage_date", REALLY_OLD_DATE),
     ):
         capabilities = llm.capabilities
 
@@ -107,17 +137,30 @@ def test_pro_user_mito_server_set_below_limit():
 
 def test_pro_user_mito_server_above_limit():
     """
-    Pro user, with no OpenAI API key set (Mito server), with usage above chat limit.
+    Pro user, with no OpenAI API key set (Mito server), with usage above both limits.
     No error should be thrown since pro users don't have limits.
     """
 
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
+    # Above the chat limit
     with (
         patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert capabilities.provider == "Mito server"
+        assert llm.last_error is None
+
+    # Above the inline limit
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}),
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT),
+        patch("mito_ai.providers._first_usage_date", REALLY_OLD_DATE),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities
@@ -148,16 +191,28 @@ def test_pro_user_openai_key_set_below_limit():
 
 def test_pro_user_openai_key_set_above_limit():
     """
-    Pro user, with OpenAI API key set, above chat limit.
+    Pro user, with OpenAI API key set, above both limits.
     No error should be thrown since pro users don't have limits.
     """
 
     llm = OpenAIProvider()
     today = datetime.now().strftime("%Y-%m-%d")
 
+    # Above the chat limit
     with (
         patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1),
         patch("mito_ai.providers._first_usage_date", today),
+        patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
+    ):
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+    # Above the inline limit
+    with (
+        patch("mito_ai.providers._num_usages", OPEN_SOURCE_AI_COMPLETIONS_LIMIT),
+        patch("mito_ai.providers._first_usage_date", REALLY_OLD_DATE),
         patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True),
     ):
         capabilities = llm.capabilities

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -37,7 +37,10 @@ def check_mito_server_quota(n_counts: int, first_usage_date: str) -> None:
     """
     pro = is_pro()
 
-    if not pro and n_counts >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
+    if pro:
+        return
+
+    if n_counts >= OPEN_SOURCE_AI_COMPLETIONS_LIMIT:
         log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
         raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
 

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -98,6 +98,9 @@ setup(
             'twine==5.1.1',
             "setuptools==56.0.0"
         ],
+        'test': [
+            'pytest==8.3.4',
+        ],
     },
     keywords=["AI", "Jupyter", "Mito"],
     entry_points={


### PR DESCRIPTION
# Description

Added the following tests:

1. OS user, Mito Server, Below Limit
2. OS user, Mito Server, Over Limit
3. OS user, OpenAI key set, Below Limit
4. OS user, OpenAI key set, Over Limit
5. Pro user, Mito Server, Below Limit
6. Pro user, Mito Server, Over Limit
7. Pro user, OpenAI key set, Below Limit
8. Pro user, OpenAI key set, Over Limit

Note that I am only running tests on Python 3.10 and 3.11. I had to remove 3.8, because you cant use patches within a `with` loop. However, this shouldn't be too much of an issue since the code in question is only used for testing.

Full explanation from ChatGPT:

> The issue lies in the way you are using patch.dict and patch together in a with statement. In Python 3.8, patch.dict and patch objects are not context managers when combined using parentheses and do not have the __enter__ method. This behavior is allowed in Python 3.10 and later due to improved support for nested context managers. 

# Testing

cd into `mito-ai` and run:

```
pip install -e ".[test, deploy]"
```

Then run `pytest`.

# Documentation

N/A