### PR TITLE
Do not repeat prefix and suffix in autocomplete

### DIFF
--- a/.github/workflows/prerelease-tests.yml
+++ b/.github/workflows/prerelease-tests.yml
@@ -54,7 +54,7 @@ jobs:
           uses: actions/upload-artifact@v4
           if: failure()
           with:
-            name: jupyterlab-playwright-report-${{ matrix.python-version }}
+            name: jupyterlab-playwright-report-${{ matrix.python-version }}-${{ github.run_id }}
             path: tests/playwright-report/
             retention-days: 14    
 
@@ -157,7 +157,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: streamlit-playwright-report
+          name: streamlit-playwright-report-${{ matrix.python-version }}-${{ github.run_id }}
           path: tests/playwright-report/
           retention-days: 14
     

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     - name: Upload test-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: mitoai-backend-report-${{ matrix.python-version }}

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -49,6 +49,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: mitoai-backend-report-${{ matrix.python-version }}
+        name: mitoai-backend-report-${{ matrix.python-version }}-${{ github.run_id }}
         path: mito-ai/tests/pytest-report/
         retention-days: 14

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -62,6 +62,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: mitoai-jupyterlab-playwright-report-${{ matrix.python-version }}
+        name: mitoai-jupyterlab-playwright-report-${{ matrix.python-version }}-${{ matrix.use-mito-ai-server }}-${{ github.run_id }}
         path: tests/playwright-report/
         retention-days: 14

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: jupyterlab-playwright-report-${{ matrix.python-version }}
+        name: jupyterlab-playwright-report-${{ matrix.python-version }}-${{ github.run_id }}
         path: tests/playwright-report/
         retention-days: 14
 
@@ -111,7 +111,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: jupyternotebook-playwright-report-${{ matrix.python-version }}
+        name: jupyternotebook-playwright-report-${{ matrix.python-version }}-${{ github.run_id }}
         path: tests/playwright-report/
         retention-days: 14
 

--- a/evals/eval_types.py
+++ b/evals/eval_types.py
@@ -114,6 +114,10 @@ class InlineCodeCompletionPromptGenerator():
 
     def get_prompt(self, prefix: str, suffix: str, notebook_state: NotebookState) -> str:
         raise NotImplementedError("Subclasses must implement this method")
+ 
+    def post_process_output(self, output: str, prefix: str, suffix: str) -> str:
+        # Default implementation returns the output unchanged
+        return output
 
 class DebugPromptGenerator():
 
@@ -121,3 +125,4 @@ class DebugPromptGenerator():
 
     def get_prompt(self, error_message: str, notebook_state: NotebookState) -> str:
         raise NotImplementedError("Subclasses must implement this method")
+    

--- a/evals/notebook_states.py
+++ b/evals/notebook_states.py
@@ -171,3 +171,62 @@ returns = {
 
 """, '']
 )
+
+
+nba_players_df = pd.DataFrame({
+    'player_name': [
+        'LeBron James', 'Kevin Durant', 'Stephen Curry', 'Giannis Antetokounmpo',
+        'Kawhi Leonard', 'James Harden', 'Luka Dončić', 'Damian Lillard',
+        'Joel Embiid', 'Nikola Jokić', 'Anthony Davis', 'Chris Paul',
+        'Jayson Tatum', 'Zion Williamson', 'Devin Booker'
+    ],
+    'team': [
+        'Los Angeles Lakers', 'Brooklyn Nets', 'Golden State Warriors', 'Milwaukee Bucks',
+        'Los Angeles Clippers', 'Brooklyn Nets', 'Dallas Mavericks', 'Portland Trail Blazers',
+        'Philadelphia 76ers', 'Denver Nuggets', 'Los Angeles Lakers', 'Phoenix Suns',
+        'Boston Celtics', 'New Orleans Pelicans', 'Phoenix Suns'
+    ],
+    'position': [
+        'SF', 'PF', 'PG', 'PF',
+        'SF', 'SG', 'PG', 'PG',
+        'C', 'C', 'PF', 'PG',
+        'SF', 'PF', 'SG'
+    ],
+    'points_per_game': [
+        25.0, 27.0, 29.0, 28.0,
+        24.0, 25.0, 28.0, 27.0,
+        33.0, 26.0, 22.0, 18.0,
+        26.0, 22.0, 25.0
+    ]
+})
+
+NBA_PLAYERS_NOTEBOOK: NotebookState = NotebookState(
+    global_vars={'nba_players_df': nba_players_df.head(5)},
+    cell_contents=["""import pandas as pd
+nba_players_df = pd.DataFrame({
+    'player_name': [
+        'LeBron James', 'Kevin Durant', 'Stephen Curry', 'Giannis Antetokounmpo',
+        'Kawhi Leonard', 'James Harden', 'Luka Dončić', 'Damian Lillard',
+        'Joel Embiid', 'Nikola Jokić', 'Anthony Davis', 'Chris Paul',
+        'Jayson Tatum', 'Zion Williamson', 'Devin Booker'
+    ],
+    'team': [
+        'Los Angeles Lakers', 'Brooklyn Nets', 'Golden State Warriors', 'Milwaukee Bucks',
+        'Los Angeles Clippers', 'Brooklyn Nets', 'Dallas Mavericks', 'Portland Trail Blazers',
+        'Philadelphia 76ers', 'Denver Nuggets', 'Los Angeles Lakers', 'Phoenix Suns',
+        'Boston Celtics', 'New Orleans Pelicans', 'Phoenix Suns'
+    ],
+    'position': [
+        'SF', 'PF', 'PG', 'PF',
+        'SF', 'SG', 'PG', 'PG',
+        'C', 'C', 'PF', 'PG',
+        'SF', 'PF', 'SG'
+    ],
+    'points_per_game': [
+        25.0, 27.0, 29.0, 28.0,
+        24.0, 25.0, 28.0, 27.0,
+        33.0, 26.0, 22.0, 18.0,
+        26.0, 22.0, 25.0
+    ]
+})""", '']
+)

--- a/evals/prompts/inline_code_completion_prompts/__init__.py
+++ b/evals/prompts/inline_code_completion_prompts/__init__.py
@@ -2,10 +2,12 @@
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v1 import prod_prompt_v1
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v2 import prod_prompt_v2
 from evals.prompts.inline_code_completion_prompts.prod_prompt_v3 import prod_prompt_v3
+from evals.prompts.inline_code_completion_prompts.prod_prompt_v4 import prod_prompt_v4
 
 
 INLINE_CODE_COMPLETION_PROMPT_GENERATORS = [
     prod_prompt_v1,
     prod_prompt_v2,
     prod_prompt_v3,
+    prod_prompt_v4,
 ]

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v3.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v3.py
@@ -56,12 +56,12 @@ Defined Variables: {{
 
 Code in the active code cell:
 ```python
-df['age'] = df[df['age'] > 23<cursor>]
+df['age'] = df[<cursor>['age'] > 23]
 ```
 
 Output:
 ```python
-]
+df
 ```
 </Example 2>
 
@@ -77,6 +77,8 @@ Code in the active code cell:
 
 Output:
 ```python
+
+x=1
 ```
 </Example 3>
 

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -1,0 +1,142 @@
+from evals.eval_types import InlineCodeCompletionPromptGenerator, NotebookState, ChatPromptGenerator
+
+__all__ = ['prod_prompt_v4']
+
+# This prompt makes one big strategy change: Instead of trying to get the AI to just complete fill in the blanks between the prefix and the suffix, 
+# it asks the AI to return the full line of code that matches the user's intent. Then, we post-process the AI's output
+# by making sure that it does not rewrite the last line of the prefix or the first line of the suffix.
+
+class _ProdPromptV4(InlineCodeCompletionPromptGenerator):
+    prompt_name = "prod_prompt_v4"
+
+    def get_prompt(self, prefix: str, suffix: str, notebook_state: NotebookState) -> str:
+    
+        return f"""You are a coding assistant that lives inside of JupyterLab. Your job is to help the user write code. 
+
+You're given the current code cell, the user's cursor position, and the variables defined in the notebook. The user's cursor is signified by the symbol <cursor>.
+
+CRITICAL FORMATTING RULES:
+1. Include a new line character at the start of your response if you want the code you are writing to be added on the line after the cursor. For example, if the cursor is at the end of a comment, you should start your response with a newline character so that the code you write is not added to the comment.
+2. If you are finishing a line of code that the user started, return the full line of code with no newline character at the start or end.
+3. Your response must preserve correct Python indentation and spacing
+
+Your job is to complete the code that matches the user's intent. Write the minimal code to achieve the user's intent. Don't expand upon the user's intent.
+
+<Example 1>
+Defined Variables: {{
+    'loan_multiplier': 1.5,
+    'sales_df': pd.DataFrame({{
+        'transaction_date': ['2024-01-02', '2024-01-02', '2024-01-02', '2024-01-02', '2024-01-03'],
+        'price_per_unit': [10, 9.99, 13.99, 21.00, 100],
+        'units_sold': [1, 2, 1, 4, 5],
+        'total_price': [10, 19.98, 13.99, 84.00, 500]
+    }})
+}}
+
+Code in the active code cell:
+```python
+import pandas as pd
+sales_df = pd.read_csv('./sales.csv')
+
+# Multiply the total_price column by the loan_multiplier<cursor>
+```
+
+Output:
+```python
+
+sales_df['total_price'] = sales_df['total_price'] * loan_multiplier
+```
+</Example 1>
+
+IMPORTANT: Notice in Example 1 that the output starts with a newline because the cursor was at the end of a comment. This newline is REQUIRED to maintain proper Python formatting.
+
+<Example 2>
+Defined Variables: {{
+    df: pd.DataFrame({{
+        'age': [20, 25, 22, 23, 29],
+        'name': ['Nawaz', 'Aaron', 'Charlie', 'Tamir', 'Eve'],
+    }})
+}}
+
+Code in the active code cell:
+```python
+df['age'] = df[<cursor>['age'] > 23]
+```
+
+Output:
+```python
+df['age'] = df[df['age'] > 23]
+```
+</Example 2>
+
+IMPORTANT: Notice in Example 2 that the output does NOT start with a newline because the cursor is in the middle of existing code.
+
+<Example 3>
+Defined Variables: {{}}
+
+Code in the active code cell:
+```python
+voters = pd.read_csv('./voters.csv')
+
+# Create a variable for pennsylvania voters, ohio voters, california voters, and texas voters
+pa_voters = voters[voters['state'] == 'PA']
+ohio_voters<cursor>
+```
+
+Output:
+```python
+ohio_voters = voters[voters['state'] == 'OH']
+ca_voters = voters[voters['state'] == 'CA']
+tx_voters = voters[voters['state'] == 'TX']
+```
+
+IMPORTANT: Notice in Example 3 that output does not start with a newline character because it wasnts to continue the line of code that the user started. Also notice the output contains three lines of code because that is the minimal code to achieve the user's intent.
+
+</Example 3>
+
+<Example 4>
+Defined Variables: {{}}
+
+Code in the active code cell:
+```python
+# Display the first 5 rows of the dataframe
+df.head()
+<cursor>
+```
+
+Output:
+```python
+```
+</Example 4>
+
+IMPORTANT: Notice in Example 4 that the output is empty becuase the user's intent is already complete.
+
+Your Task:
+
+Defined Variables: {notebook_state.global_vars}
+
+Code in the active code cell:
+```python
+{prefix}<cursor>{suffix}
+```
+
+Output:
+"""
+    
+    def post_process_output(self, output: str, prefix: str, suffix: str) -> str:
+
+        last_prefix_line = prefix.split("\n")[-1]
+        if output.startswith(last_prefix_line) and last_prefix_line != "":
+        # Remove the last line of the prefix if it is the same as the first line of the output
+            output = output[len(last_prefix_line):]
+
+        first_suffix_line = suffix.split("\n")[0]
+        if output.endswith(first_suffix_line) and first_suffix_line != "":
+            # Remove the first line of the suffix if it is the same as the last line of the output
+            output = output[:-len(first_suffix_line)]
+
+        return output
+
+prod_prompt_v4 = _ProdPromptV4()
+
+

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -132,6 +132,23 @@ Output:
 
 IMPORTANT: Notice in Example 5 that the output is indented several times because the code must be executed as part of the else block.
 
+<Example 6>
+Defined Variables: {{}}
+
+Code in the active code cell:
+```python
+days_in_week <cursor>
+```
+
+Output:
+```python
+days_in_week = 7
+```
+</Example 6>
+
+IMPORTANT: Notice in Example 6 that inorder to finish the variable declaration, the output continues the existing line of code and does not start with a new line character.
+
+
 Your Task:
 
 Defined Variables: {notebook_state.global_vars}

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -18,7 +18,7 @@ You're given the current code cell, the user's cursor position, and the variable
 CRITICAL FORMATTING RULES:
 1. Include a new line character at the start of your response if you want the code you are writing to be added on the line after the cursor. For example, if the cursor is at the end of a comment, you should start your response with a newline character so that the code you write is not added to the comment.
 2. If you are finishing a line of code that the user started, return the full line of code with no newline character at the start or end.
-3. Your response must preserve correct Python indentation and spacing
+3. Your response must preserve correct Python indentation and spacing. For example, if you're completing a line of indented code, you must preserve the indentation.
 
 Your job is to complete the code that matches the user's intent. Write the minimal code to achieve the user's intent. Don't expand upon the user's intent.
 
@@ -110,6 +110,27 @@ Output:
 </Example 4>
 
 IMPORTANT: Notice in Example 4 that the output is empty becuase the user's intent is already complete.
+
+<Example 5>
+Defined Variables: {{}}
+
+Code in the active code cell:
+```python
+def even_and_odd():
+    for i in range(10):
+        if i % 2 == 0:
+            print(f"Even")
+        else:
+            pri<cursor>
+```
+
+Output:
+```python
+            print(f"Odd")
+```
+</Example 5>
+
+IMPORTANT: Notice in Example 5 that the output is indented several times because the code must be executed as part of the else block.
 
 Your Task:
 

--- a/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
+++ b/evals/prompts/inline_code_completion_prompts/prod_prompt_v4.py
@@ -127,7 +127,7 @@ Output:
 
         last_prefix_line = prefix.split("\n")[-1]
         if output.startswith(last_prefix_line) and last_prefix_line != "":
-        # Remove the last line of the prefix if it is the same as the first line of the output
+            # Remove the last line of the prefix if it is the same as the first line of the output
             output = output[len(last_prefix_line):]
 
         first_suffix_line = suffix.split("\n")[0]

--- a/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
@@ -291,26 +291,6 @@ high_df = loans_df[loans_df['income_category'] == 'High']
     ),
 
     InlineCodeCompletionTestCase(
-        name="nba_players_follow_prefix_pattern",
-        test_case_core=CodeGenTestCaseCore(
-            notebook_state=NBA_PLAYERS_NOTEBOOK,
-            expected_code="""
-lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
-nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
-warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
-bucks_players = nba_players_df[nba_players_df['team'] == 'Milwaukee Bucks']
-""",
-            workflow_tags=["df_transformation", "pandas"],
-        ),
-        prefix="""
-lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
-nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
-warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
-buck""",
-        suffix="""""",
-        type_tags=['code_completion'],
-    ),
-        InlineCodeCompletionTestCase(
         name="nba_players_follow_prefix_pattern_bucks",
         test_case_core=CodeGenTestCaseCore(
             notebook_state=NBA_PLAYERS_NOTEBOOK,
@@ -321,12 +301,34 @@ warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warrio
 bucks_players = nba_players_df[nba_players_df['team'] == 'Milwaukee Bucks']
 """,
             workflow_tags=["df_transformation", "pandas"],
+            variables_to_compare=["lakers_players", "nets_players", "warriors_players", "bucks_players"],
         ),
         prefix="""
 lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
 nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
 warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+buck""",
+        suffix="""""",
+        type_tags=['code_completion'],
+    ),
+        InlineCodeCompletionTestCase(
+        name="nba_players_follow_prefix_pattern_clippers",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+clippers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Clippers']
 """,
+            workflow_tags=["df_transformation", "pandas"],
+            variables_to_compare=["lakers_players", "nets_players", "warriors_players", "clippers_players"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+clip""",
         suffix="""""",
         type_tags=['code_completion'],
     ),
@@ -341,6 +343,7 @@ warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warrio
 mavericks_players = nba_players_df[nba_players_df['team'] == 'Dallas Mavericks']
 """,
             workflow_tags=["df_transformation", "pandas"],
+            variables_to_compare=["lakers_players", "nets_players", "warriors_players", "mavericks_players"],
         ),
         prefix="""
 lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
@@ -360,12 +363,32 @@ nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
 warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
 """,
             workflow_tags=["df_transformation", "pandas"],
+            variables_to_compare=["lakers_players", "nets_players", "warriors_players"],
         ),
         prefix="""
 lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
 nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
 warr""",
         suffix="""""",
+        type_tags=['code_completion'],
+    ),
+    InlineCodeCompletionTestCase(
+        name="nba_players_follow_suffix_pattern_warriors",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+""",
+            workflow_tags=["df_transformation", "pandas"],
+            variables_to_compare=["lakers_players", "nets_players", "warriors_players"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+""",
+        suffix="""nba_players_df[nba_players_df['team'] == 'Golden State Warriors']""",
         type_tags=['code_completion'],
     ),
 ]

--- a/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
@@ -1,6 +1,7 @@
 
 
-from evals.eval_types import InlineCodeCompletionTestCase
+from evals.eval_types import CodeGenTestCaseCore, InlineCodeCompletionTestCase
+from evals.notebook_states import NBA_PLAYERS_NOTEBOOK
 from evals.test_cases.chat_tests.dataframe_transformation_tests import CONVERT_ANNUAL_INCOME_TO_FLOAT, CONVERT_INTEREST_RATE_TO_INT, CONVERT_KILOMETERS_DRIVEN_TO_FLOAT, DATETIME_CONVERSION, EXTRACT_YEAR_FROM_STRING_DATE, FILTER_ANNUAL_INCOME_AND_LOAN_CONDITION, FILTER_ANNUAL_INCOME_GREATER_THAN_100K, NUMBER_OF_BMW_FORD_TOYOTA_FIRST_OWNER_FUNCTION, REPLACE_UNDERSCORE_WITH_SPACE_IN_COLUMN_NAMES, SEPARATE_DATA_BY_COLUMN_VALUE, WEIGHTED_AVERAGE_INTEREST_RATE
 
 
@@ -289,5 +290,84 @@ high_df = loans_df[loans_df['income_category'] == 'High']
         type_tags=['code_completion'],
     ),
 
-
+    InlineCodeCompletionTestCase(
+        name="nba_players_follow_prefix_pattern",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+bucks_players = nba_players_df[nba_players_df['team'] == 'Milwaukee Bucks']
+""",
+            workflow_tags=["df_transformation", "pandas"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+buck""",
+        suffix="""""",
+        type_tags=['code_completion'],
+    ),
+        InlineCodeCompletionTestCase(
+        name="nba_players_follow_prefix_pattern_bucks",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+bucks_players = nba_players_df[nba_players_df['team'] == 'Milwaukee Bucks']
+""",
+            workflow_tags=["df_transformation", "pandas"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+""",
+        suffix="""""",
+        type_tags=['code_completion'],
+    ),
+    InlineCodeCompletionTestCase(
+        name="nba_players_follow_prefix_pattern_mavs",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+mavericks_players = nba_players_df[nba_players_df['team'] == 'Dallas Mavericks']
+""",
+            workflow_tags=["df_transformation", "pandas"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+mav
+""",
+        suffix="""""",
+        type_tags=['code_completion'],
+    ),
+    InlineCodeCompletionTestCase(
+        name="nba_players_follow_prefix_pattern_warrios",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=NBA_PLAYERS_NOTEBOOK,
+            expected_code="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
+""",
+            workflow_tags=["df_transformation", "pandas"],
+        ),
+        prefix="""
+lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
+nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
+warr
+""",
+        suffix="""""",
+        type_tags=['code_completion'],
+    ),
 ]

--- a/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/dataframe_transformation_tests.py
@@ -346,8 +346,7 @@ mavericks_players = nba_players_df[nba_players_df['team'] == 'Dallas Mavericks']
 lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
 nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
 warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warriors']
-mav
-""",
+mav""",
         suffix="""""",
         type_tags=['code_completion'],
     ),
@@ -365,8 +364,7 @@ warriors_players = nba_players_df[nba_players_df['team'] == 'Golden State Warrio
         prefix="""
 lakers_players = nba_players_df[nba_players_df['team'] == 'Los Angeles Lakers']
 nets_players = nba_players_df[nba_players_df['team'] == 'Brooklyn Nets']
-warr
-""",
+warr""",
         suffix="""""",
         type_tags=['code_completion'],
     ),

--- a/evals/test_cases/inline_code_completion_tests/function_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/function_tests.py
@@ -13,6 +13,8 @@ FUNCTION_TESTS = [
 # Return the sum of two numbers
 def my_sum(a, b):
     return a + b
+    
+x = my_sum(1, 2)
 """,
         ),
         prefix="""# Return the sum of two numbers""",

--- a/evals/test_cases/inline_code_completion_tests/function_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/function_tests.py
@@ -41,6 +41,77 @@ x = my_sum(1, 2)
 """,
         type_tags=["code_completion"],
     ),
+
+    InlineCodeCompletionTestCase(
+        name="indented_code_location_finder_function_else_block",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            workflow_tags=["function"],
+            expected_code="""
+def location_finder(x):
+    if x == 'NY':
+        print("You are in NY")
+    elif x == 'PA':
+        print("You are in PA")
+""",
+        ),
+        prefix="""
+def location_finder(x):
+    if x == 'NY':
+        print("You are in NY")
+    elif x == 'PA':
+        print("You are""",
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+        InlineCodeCompletionTestCase(
+        name="indented_code_location_finder_function_else_clause",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            workflow_tags=["function"],
+            expected_code="""
+def location_finder(x):
+    if x == 'NY':
+        print("You are in NY")
+    elif x == 'PA':
+        print("You are in PA")
+""",
+        ),
+        prefix="""
+def location_finder(x):
+    # Handle the NY Case
+    if x == 'NY':
+        print("You are in NY")
+    # Handle the PA Case
+    elif x""",
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
+        name="indented_code_location_finder_function_continue_after_else_clause",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            workflow_tags=["function"],
+            expected_code="""
+def location_finder(x):
+    if x == 'NY':
+        print("You are in NY")
+    elif x == 'PA':
+        print("You are in PA")
+""",
+        ),
+        prefix="""
+def location_finder(x):
+    # Handle the NY Case
+    if x == 'NY':
+        print("You are in NY")
+    # Handle the PA Case
+    elif x == 'PA':""",
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
     
     # NUMBER_OF_BMW_FORD_TOYOTA_FIRST_OWNER_FUNCTION
     InlineCodeCompletionTestCase(

--- a/evals/test_cases/inline_code_completion_tests/loops.py
+++ b/evals/test_cases/inline_code_completion_tests/loops.py
@@ -155,6 +155,7 @@ percent_changes = []
         suffix="""
     current_close = returns[year]['current_close']
     previous_close = returns[year]['previous_close']
+    percent_changes.append(calculate_percent_change(current_close, previous_close))
 """,
         type_tags=["code_completion"],
     ),

--- a/evals/test_cases/inline_code_completion_tests/misc_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/misc_tests.py
@@ -52,4 +52,95 @@ print('Hi')""",
         type_tags=["comment_following"],
     ),
 
+    InlineCodeCompletionTestCase(
+        name="finish_today_variable_with_equals",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+import datetime
+
+# Get today's date with just the date component using datetime.datetime.today().date()
+today_date = datetime.datetime.today().date()
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+import datetime
+
+# Get today's date with just the date component using datetime.datetime.today().date()
+today_date = """,
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
+        name="finish_today_variable_without_equals",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+import datetime
+
+# Get today's date with just the date component using datetime.datetime.today().date()
+today_date = datetime.datetime.today().date()
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+import datetime
+
+# Get today's date with just the date component using datetime.datetime.today().date()
+today_date """,
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
+        name="print_after_15th_cursor_at_end_of_comment",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+import datetime
+
+today_date = datetime.datetime.today().date()
+
+# If today is after the 15th of the month print 'After 15th'
+if today_date.day > 15:
+    print('After 15th')
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+import datetime
+
+today_date = datetime.datetime.today().date()
+
+# If today is after the 15th of the month print 'After 15th'""",
+        suffix="""""",
+        type_tags=["comment_following"],
+    ),
+            InlineCodeCompletionTestCase(
+        name="print_after_2pm_cursor_after_comment",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+import datetime
+
+today_date = datetime.datetime.today().date()
+
+# If today is after the 15th of the month print 'After 15th'
+if today_date.day > 15:
+    print('After 15th')
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+import datetime
+
+today_date = datetime.datetime.today().date()
+
+# If today is after the 15th of the month print 'After 15th'
+""",
+        suffix="""""",
+        type_tags=["comment_following"],
+    ),
 ]

--- a/evals/test_cases/inline_code_completion_tests/misc_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/misc_tests.py
@@ -14,4 +14,42 @@ MISC_TESTS = [
         suffix="""""",
         type_tags=["no_expressed_intent"],
     ),
+    InlineCodeCompletionTestCase(
+        name="print_hi_with_prefix",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="print('Hi')",
+            workflow_tags=["misc"],
+        ),
+        prefix="""#Print 'Hi'
+pri""",
+        suffix="""""",
+        type_tags=["comment_following"],
+    ),
+    InlineCodeCompletionTestCase(
+        name="print_hi_most_of_line",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="print('Hi')",
+            workflow_tags=["misc"],
+        ),
+        prefix="""#Print 'Hi'
+print('Hi""",
+        suffix="""""",
+        type_tags=["comment_following"],
+    ),
+    # No expressed intent left in the line
+    InlineCodeCompletionTestCase(
+        name="print_hi_finished_line",
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="print('Hi')",
+            workflow_tags=["misc"],
+        ),
+        prefix="""#Print 'Hi'
+print('Hi')""",
+        suffix="""""",
+        type_tags=["comment_following"],
+    ),
+
 ]

--- a/evals/test_cases/inline_code_completion_tests/misc_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/misc_tests.py
@@ -95,6 +95,106 @@ today_date """,
     ),
 
     InlineCodeCompletionTestCase(
+        name='finish_total_variable_before_equals',
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum = x + y + z
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum""",
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+        InlineCodeCompletionTestCase(
+        name='finish_total_variable_before_equals_with_space',
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum = x + y + z
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum """,
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
+        name='finish_total_variable_at_equals',
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum = x + y + z
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum =""",
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
+        name='finish_total_variable_after_equals_space',
+        test_case_core=CodeGenTestCaseCore(
+            notebook_state=EMPTY_NOTEBOOK,
+            expected_code="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum = x + y + z
+""",
+            workflow_tags=["misc"],
+        ),
+        prefix="""
+x = 10
+y = 20
+z = 30
+
+# Sum of x, y, and z
+total_sum = """,
+        suffix="""""",
+        type_tags=["code_completion"],
+    ),
+
+    InlineCodeCompletionTestCase(
         name="print_after_15th_cursor_at_end_of_comment",
         test_case_core=CodeGenTestCaseCore(
             notebook_state=EMPTY_NOTEBOOK,

--- a/evals/test_cases/inline_code_completion_tests/variable_tests.py
+++ b/evals/test_cases/inline_code_completion_tests/variable_tests.py
@@ -84,8 +84,7 @@ d = 4 # set d to 4""",
             workflow_tags=["variable_declaration"],
         ),
         prefix="""
-a
-""",
+a""",
         suffix="""
 b = 2 # set b to 2
 c = 3 # set c to 3

--- a/evals/test_runners/code_gen_test_runner.py
+++ b/evals/test_runners/code_gen_test_runner.py
@@ -88,6 +88,21 @@ def run_code_gen_test(
         # We always add a newline between the current_cell_contents and the prefix. 
         # But we don't add a newline between the prefix -> ai_generated_code -> suffix, 
         # because the inline code completion can occur in the middle of a line. 
+
+        def strip_last_line_of_prefix_from_ai_generated_code(prefix: str, ai_generated_code: str) -> str:
+            # Remove the last line of the prefix
+            prefix_lines = prefix.split("\n")
+            last_prefix_line = prefix_lines[-1]
+
+            # If the ai_generated_code starts with the prefix_line, remove it
+            if ai_generated_code.startswith(last_prefix_line):
+                ai_generated_code = ai_generated_code[len(last_prefix_line):]
+
+            return ai_generated_code
+
+
+        ai_generated_code = strip_last_line_of_prefix_from_ai_generated_code(test.prefix or "", ai_generated_code)
+
         actual_code = current_cell_contents_script + "\n" + (test.prefix or "") + ai_generated_code + (test.suffix or "")
 
     # Execute the code and check if they produce the same results

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -188,7 +188,7 @@ export class MitoAIInlineCompleter
       const result = await this._client.sendMessage({
         messages: openAIFormattedMessages,
         message_id: messageId.toString(),
-        stream: true,
+        stream: false,
         type: 'inline_completion',
       });
 

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -208,7 +208,6 @@ export class MitoAIInlineCompleter
         );
       }
 
-      console.log('calling _cleanCompletion from fetch')
       return {
         items: result.items.map(item => ({
           ...item,
@@ -328,7 +327,6 @@ export class MitoAIInlineCompleter
     fullCompletion += chunk.chunk.content;
     this._fullCompletionMap.set(this._currentStream, fullCompletion);
 
-    console.log('calling _cleanCompletion from stream')
     let cleanedCompletion = this._cleanCompletion(fullCompletion);
 
     this._currentStream.emit({
@@ -347,26 +345,21 @@ export class MitoAIInlineCompleter
 
   private _cleanCompletion(rawCompletion: string, prefix?: string, suffix?: string) {
 
-
-    console.log('rawCompletion', rawCompletion)
     let cleanedCompletion = rawCompletion
       .replace(/^```python\n?/, '')  // Remove opening code fence with optional python language
       .replace(/```$/, '')           // Remove closing code fence
       .replace(/\n$/, '')    
-      
-    console.log('prefix', prefix)
-    console.log('suffix', suffix)
 
+    // Remove duplicate prefix content
     if (prefix) {
-      // Remove duplicate prefix content
       const lastPrefixLine = prefix.split('\n').slice(-1)[0];
       if (cleanedCompletion.startsWith(lastPrefixLine) && lastPrefixLine !== '') {
         cleanedCompletion = cleanedCompletion.slice(lastPrefixLine.length);
       }
     }
 
+    // Remove duplicate suffix content
     if (suffix) {
-      // Remove duplicate suffix content
       const firstSuffixLine = suffix.split('\n')[0];
       if (cleanedCompletion.endsWith(firstSuffixLine) && firstSuffixLine !== '') {
         cleanedCompletion = cleanedCompletion.slice(0, -firstSuffixLine.length);

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -349,30 +349,22 @@ export class MitoAIInlineCompleter
       .replace(/```$/, '')           // Remove closing code fence
       .replace(/\n$/, '')            // Remove trailing newline
 
-    console.log("IN CLEANING")
-    console.log('prefix', prefix)
-    console.log('suffix', suffix)
-
     if (prefix) {
       // Remove duplicate prefix content
       const lastPrefixLine = prefix.split('\n').slice(-1)[0];
       if (cleanedCompletion.startsWith(lastPrefixLine) && lastPrefixLine !== '') {
-        console.log(`Removing Prefix: ${lastPrefixLine} from ${cleanedCompletion}`)
         cleanedCompletion = cleanedCompletion.slice(lastPrefixLine.length);
       }
-
     }
 
     if (suffix) {
       // Remove duplicate suffix content
       const firstSuffixLine = suffix.split('\n')[0];
       if (cleanedCompletion.endsWith(firstSuffixLine) && firstSuffixLine !== '') {
-        console.log(`Removing Suffix: ${firstSuffixLine} from ${cleanedCompletion}`)
         cleanedCompletion = cleanedCompletion.slice(0, -firstSuffixLine.length);
       }
     }
 
-    console.log(cleanedCompletion)
     return cleanedCompletion;
   }
 

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -346,6 +346,9 @@ export class MitoAIInlineCompleter
   }
 
   private _cleanCompletion(rawCompletion: string, prefix?: string, suffix?: string) {
+
+
+    console.log('rawCompletion', rawCompletion)
     let cleanedCompletion = rawCompletion
       .replace(/^```python\n?/, '')  // Remove opening code fence with optional python language
       .replace(/```$/, '')           // Remove closing code fence

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -347,7 +347,10 @@ export class MitoAIInlineCompleter
     let cleanedCompletion = rawCompletion
       .replace(/^```python\n?/, '')  // Remove opening code fence with optional python language
       .replace(/```$/, '')           // Remove closing code fence
-      .replace(/\n$/, '')            // Remove trailing newline
+      .replace(/\n$/, '')    
+      
+    console.log('prefix', prefix)
+    console.log('suffix', suffix)
 
     if (prefix) {
       // Remove duplicate prefix content

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -208,6 +208,7 @@ export class MitoAIInlineCompleter
         );
       }
 
+      console.log('calling _cleanCompletion from fetch')
       return {
         items: result.items.map(item => ({
           ...item,
@@ -327,6 +328,7 @@ export class MitoAIInlineCompleter
     fullCompletion += chunk.chunk.content;
     this._fullCompletionMap.set(this._currentStream, fullCompletion);
 
+    console.log('calling _cleanCompletion from stream')
     let cleanedCompletion = this._cleanCompletion(fullCompletion);
 
     this._currentStream.emit({

--- a/mito-ai/src/prompts/InlinePrompt.tsx
+++ b/mito-ai/src/prompts/InlinePrompt.tsx
@@ -5,15 +5,14 @@ export function createInlinePrompt(
     suffix: string,
     variables: Variable[]
 ): string {
-    const prompt = `You are a code completion assistant that lives inside of JupyterLab. Your job is to predict the rest of the code that the user has started to write.
+    const prompt = `You are a coding assistant that lives inside of JupyterLab. Your job is to help the user write code. 
 
 You're given the current code cell, the user's cursor position, and the variables defined in the notebook. The user's cursor is signified by the symbol <cursor>.
-
+    
 CRITICAL FORMATTING RULES:
-1. If the cursor appears at the end of a complete line (especially after a comment), ALWAYS start your code with a newline character
-2. If the cursor appears at the end of a function definition, ALWAYS start your code with a newline character
-3. If the cursor appears in the middle of existing code or in an incomplete line of code, do NOT add any newline characters
-4. Your response must preserve correct Python indentation and spacing
+1. Include a new line character at the start of your response if you want the code you are writing to be added on the line after the cursor. For example, if the cursor is at the end of a comment, you should start your response with a newline character so that the code you write is not added to the comment.
+2. If you are finishing a line of code that the user started, return the full line of code with no newline character at the start or end.
+3. Your response must preserve correct Python indentation and spacing
 
 Your job is to complete the code that matches the user's intent. Write the minimal code to achieve the user's intent. Don't expand upon the user's intent.
 
@@ -55,12 +54,12 @@ Defined Variables: {{
 
 Code in the active code cell:
 \`\`\`python
-df['age'] = df[df['age'] > 23<cursor>]
+df['age'] = df[<cursor>['age'] > 23]
 \`\`\`
 
 Output:
 \`\`\`python
-]
+df['age'] = df[df['age'] > 23]
 \`\`\`
 </Example 2>
 
@@ -71,19 +70,45 @@ Defined Variables: {{}}
 
 Code in the active code cell:
 \`\`\`python
-# Create a variable x and set it equal to 1<cursor>
+voters = pd.read_csv('./voters.csv')
+
+# Create a variable for pennsylvania voters, ohio voters, california voters, and texas voters
+pa_voters = voters[voters['state'] == 'PA']
+ohio_voters<cursor>
+\`\`\`
+
+Output:
+\`\`\`python
+ohio_voters = voters[voters['state'] == 'OH']
+ca_voters = voters[voters['state'] == 'CA']
+tx_voters = voters[voters['state'] == 'TX']
+\`\`\`
+
+IMPORTANT: Notice in Example 3 that output does not start with a newline character because it wasnts to continue the line of code that the user started. Also notice the output contains three lines of code because that is the minimal code to achieve the user's intent.
+
+</Example 3>
+
+<Example 4>
+Defined Variables: {{}}
+
+Code in the active code cell:
+\`\`\`python
+# Display the first 5 rows of the dataframe
+df.head()
+<cursor>
 \`\`\`
 
 Output:
 \`\`\`python
 \`\`\`
-</Example 3>
+</Example 4>
 
-IMPORTANT: Notice in Example 3 that the output starts with a newline because the cursor appears at the end of a comment line.
+IMPORTANT: Notice in Example 4 that the output is empty becuase the user's intent is already complete.
 
 Your Task:
 
-Defined Variables: ${variables?.map(variable => `${JSON.stringify(variable, null, 2)}\n`).join('')}
+Defined Variables: 
+${variables?.map(variable => `${JSON.stringify(variable, null, 2)}\n`).join('')}
 
 Code in the active code cell:
 \`\`\`python

--- a/mito-ai/src/prompts/InlinePrompt.tsx
+++ b/mito-ai/src/prompts/InlinePrompt.tsx
@@ -12,7 +12,7 @@ You're given the current code cell, the user's cursor position, and the variable
 CRITICAL FORMATTING RULES:
 1. Include a new line character at the start of your response if you want the code you are writing to be added on the line after the cursor. For example, if the cursor is at the end of a comment, you should start your response with a newline character so that the code you write is not added to the comment.
 2. If you are finishing a line of code that the user started, return the full line of code with no newline character at the start or end.
-3. Your response must preserve correct Python indentation and spacing
+3. Your response must preserve correct Python indentation and spacing. For example, if you're completing a line of indented code, you must preserve the indentation.
 
 Your job is to complete the code that matches the user's intent. Write the minimal code to achieve the user's intent. Don't expand upon the user's intent.
 
@@ -104,6 +104,27 @@ Output:
 </Example 4>
 
 IMPORTANT: Notice in Example 4 that the output is empty becuase the user's intent is already complete.
+
+<Example 5>
+Defined Variables: {{}}
+
+Code in the active code cell:
+\`\`\`python
+def even_and_odd():
+    for i in range(10):
+        if i % 2 == 0:
+            print(f"Even: {i}")
+        else:
+            pri<cursor>
+\`\`\`
+
+Output:
+\`\`\`python
+            print(f"Odd: {i}")
+\`\`\`
+</Example 5>
+
+IMPORTANT: Notice in Example 5 that the output is indented several times because the code must be executed as part of the else block.
 
 Your Task:
 

--- a/mito-ai/src/prompts/InlinePrompt.tsx
+++ b/mito-ai/src/prompts/InlinePrompt.tsx
@@ -126,6 +126,22 @@ Output:
 
 IMPORTANT: Notice in Example 5 that the output is indented several times because the code must be executed as part of the else block.
 
+<Example 6>
+Defined Variables: {{}}
+
+Code in the active code cell:
+\`\`\`python
+days_in_week <cursor>
+\`\`\`
+
+Output:
+\`\`\`python
+days_in_week = 7
+\`\`\`
+</Example 6>
+
+IMPORTANT: Notice in Example 6 that inorder to finish the variable declaration, the output continues the existing line of code and does not start with a new line character.
+
 Your Task:
 
 Defined Variables: 

--- a/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
+++ b/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
@@ -81,7 +81,7 @@ test.describe("default inline completion", () => {
     },
   });
 
-  test.only("should display inline completion", async ({ page, tmpPath }) => {
+  test("should display inline completion", async ({ page, tmpPath }) => {
     const replyDone = new PromiseDelegate<void>();
     // Mock completion request with code prefix 'def fib'
     await page.routeWebSocket(/.*\/mito-ai\/completions/, (ws) => {

--- a/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
+++ b/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
@@ -91,18 +91,11 @@ test.describe("default inline completion", () => {
         const messageId = payload.number;
         if (
           payload.type === "inline_completion" &&
-          payload.messages.find((message) => message.content.includes("def fib")) &&
-          payload.stream
+          payload.messages.find((message) => message.content.includes("print")) &&
+          payload.stream == false
         ) {
-          let counter = -1;
-          const streamReply = setInterval(() => {
-            if (++counter < MOCKED_MESSAGES.length) {
-              ws.send(JSON.stringify(MOCKED_MESSAGES[counter]));
-            } else {
-              clearInterval(streamReply);
-              replyDone.resolve();
-            }
-          }, 100);
+          // Send the fetch message back to the client
+          ws.send(JSON.stringify(MOCKED_FETCH_MESSAGE));
         } else {
           ws.send(
             JSON.stringify({
@@ -127,21 +120,21 @@ test.describe("default inline completion", () => {
     // before it grabs the text content.
     await (await page.notebook.getCellLocator(0))!
       .getByRole("textbox")
-      .fill("def fib");
+      .fill("print('hel");
 
     await replyDone.promise;
 
     expect.soft(page.locator(GHOST_SELECTOR)).toHaveCount(1);
     expect
       .soft((await page.notebook.getCellLocator(0))!.getByRole("textbox"))
-      .toHaveText("def fib(n):\n    pass\n");
+      .toHaveText("print('hello')");
 
     await page.keyboard.press("Tab");
 
     expect.soft(page.locator(GHOST_SELECTOR)).toHaveCount(0);
     expect(
       (await page.notebook.getCellLocator(0))!.getByRole("textbox")
-    ).toHaveText("def fib(n):\n    pass\n");
+    ).toHaveText("print('hello')");
   });
 });
 
@@ -184,8 +177,8 @@ test.describe("default manual inline completion", () => {
         ) {
           let counter = -1;
           const streamReply = setInterval(() => {
-            if (++counter < MOCKED_MESSAGES.length) {
-              ws.send(JSON.stringify(MOCKED_MESSAGES[counter]));
+            if (++counter < MOCKED_STREAM_MESSAGES.length) {
+              ws.send(JSON.stringify(MOCKED_STREAM_MESSAGES[counter]));
             } else {
               clearInterval(streamReply);
               replyDone.resolve();
@@ -231,8 +224,21 @@ test.describe("default manual inline completion", () => {
   });
 });
 
+const MOCKED_FETCH_MESSAGE = {
+  error: null,
+  items: [
+    {
+      content: "```python\nprint('hello')\n```",
+      isIncomplete: false,
+      token: null,
+    },
+  ],
+  parent_id: "2",
+  type: "reply",
+};
+
 // Mocked messages to simulate the inline completion process
-const MOCKED_MESSAGES = [
+const MOCKED_STREAM_MESSAGES = [
   {
     items: [
       {

--- a/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
+++ b/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
@@ -85,11 +85,9 @@ test.describe("default inline completion", () => {
     const replyDone = new PromiseDelegate<void>();
     // Mock completion request with code prefix 'def fib'
     await page.routeWebSocket(/.*\/mito-ai\/completions/, (ws) => {
-      console.log("Mocking inline completion request");
       ws.onMessage((message) => {
         const payload = JSON.parse(message as string);
         const messageId = payload.number;
-        console.log(payload)
         if (
           payload.type === "inline_completion" &&
           payload.messages.find((message) => message.content.includes("print")) &&


### PR DESCRIPTION
# Description

Improves our autocomplete responses by changing what we're asking of the AI. Previously, we heavily relied on the Ai to only return the new code that the user should type. This wasn't working well. Now, we ask the AI to return the complete line of code and then deduplicate it with the end of the prefix and beginning of the suffix. 

To do so, autocomplete prompts in our evals can now optionally implement a post processing step. 

This PR also fixes a few broken evals and adds some new evals based on the prefix issues documented here https://github.com/mito-ds/mito/issues/1414

On the new set of evals our v3 prompt (with some of bug fixes suggested by @ngafar) scored an average of 63% across three runs and the new v4 prompt with this prefix/suffix stripping strategy scored an average 65.6% of across three runs. 

# Testing

Use it kinda heavily and see if you're getting prefix repetition issues

# Documentation

No.