### PR TITLE
Manually setting shortcut for inline-completer:accept

### DIFF
--- a/mito-ai/src/Extensions/InlineCompleter/index.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/index.ts
@@ -37,15 +37,6 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry,
     variableManager: IVariableManager
   ) => {
-    // Explicitly add a keyboard binding for the inline-completer:accept command.
-    // This should be automatically set by the inline-completer extension,
-    // but we've seen some users not have the tab key set as the default key binding.
-    app.commands.addKeyBinding({
-      command: 'inline-completer:accept',
-      keys: ['Tab'],  
-      selector: '.jp-Notebook'  // Only active in notebooks
-    });
-
     if (typeof completionManager.registerInlineProvider === 'undefined') {
       // Gracefully short-circuit on JupyterLab 4.0 and Notebook 7.0
       console.warn(
@@ -119,6 +110,25 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
                           providers
                         );
                         updateConfig();
+
+                        const acceptBinding = app.commands.keyBindings.find(binding => binding.command === 'inline-completer:accept')
+
+                        if (acceptBinding?.keys.length === 1 && acceptBinding?.keys[0] !== 'Tab') {
+                          Notification.info(
+                            `🚀 Mito AI Tip: Your current key binding for accepting code suggestions is ${acceptBinding?.keys}. You can change this in Settings > Keyboard Shortcuts.`,
+                            {
+                            autoClose: false,
+                            actions: [
+                              {
+                                label: 'Got it',
+                                displayType: 'accent',
+                                callback: () => {
+                                  // Do nothing
+                                }
+                              }
+                            ]
+                          })
+                        }
                       }
                     },
                     {

--- a/mito-ai/src/Extensions/InlineCompleter/index.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/index.ts
@@ -109,26 +109,13 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
                           'providers',
                           providers
                         );
+                        // Set the Tab key as the shortcut for accepting Mito AI suggestions
+                        app.commands.addKeyBinding({
+                          command: 'inline-completer:accept',
+                          keys: ['Tab'],
+                          selector: '.jp-mod-inline-completer-active'
+                        });                    
                         updateConfig();
-
-                        const hasTabShortcut = app.commands.keyBindings.find(binding => binding.command === 'inline-completer:accept' && binding.keys.length === 1 && binding.keys[0] === 'Tab')
-
-                        if (!hasTabShortcut) {
-                          Notification.info(
-                            `🚀 Mito AI Tip: Your current key binding for accepting code suggestions is ${acceptBinding?.keys}. You can change this in Settings > Keyboard Shortcuts.`,
-                            {
-                            autoClose: false,
-                            actions: [
-                              {
-                                label: 'Got it',
-                                displayType: 'accent',
-                                callback: () => {
-                                  // Do nothing
-                                }
-                              }
-                            ]
-                          })
-                        }
                       }
                     },
                     {

--- a/mito-ai/src/Extensions/InlineCompleter/index.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/index.ts
@@ -37,6 +37,15 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry,
     variableManager: IVariableManager
   ) => {
+    // Explicitly add a keyboard binding for the inline-completer:accept command.
+    // This should be automatically set by the inline-completer extension,
+    // but we've seen some users not have the tab key set as the default key binding.
+    app.commands.addKeyBinding({
+      command: 'inline-completer:accept',
+      keys: ['Tab'],  
+      selector: '.jp-Notebook'  // Only active in notebooks
+    });
+
     if (typeof completionManager.registerInlineProvider === 'undefined') {
       // Gracefully short-circuit on JupyterLab 4.0 and Notebook 7.0
       console.warn(

--- a/mito-ai/src/Extensions/InlineCompleter/index.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/index.ts
@@ -111,9 +111,9 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
                         );
                         updateConfig();
 
-                        const acceptBinding = app.commands.keyBindings.find(binding => binding.command === 'inline-completer:accept')
+                        const hasTabShortcut = app.commands.keyBindings.find(binding => binding.command === 'inline-completer:accept' && binding.keys.length === 1 && binding.keys[0] === 'Tab')
 
-                        if (acceptBinding?.keys.length === 1 && acceptBinding?.keys[0] !== 'Tab') {
+                        if (!hasTabShortcut) {
                           Notification.info(
                             `🚀 Mito AI Tip: Your current key binding for accepting code suggestions is ${acceptBinding?.keys}. You can change this in Settings > Keyboard Shortcuts.`,
                             {

--- a/mito-ai/src/Extensions/InlineCompleter/index.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/index.ts
@@ -21,8 +21,8 @@ interface IMitoAIConfig {
   };
 }
 
-const JUPYTERLAB_INLINE_COMPLETER_ID =
-  '@jupyterlab/completer-extension:inline-completer';
+const JUPYTERLAB_INLINE_COMPLETER_ID = '@jupyterlab/completer-extension:inline-completer';
+const JUPYTERLAB_SHORTCUTS_ID = '@jupyterlab/shortcuts-extension:shortcuts';
 export const completionPlugin: JupyterFrontEndPlugin<void> = {
   id: 'mito-ai:inline-completion',
   autoStart: true,
@@ -71,6 +71,13 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
               )
             ).composite as any;
 
+            let shortcuts = (
+              await settingRegistry.get(
+                JUPYTERLAB_SHORTCUTS_ID,
+                'shortcuts'
+              )
+            ).composite as any;
+
             const updateConfig = () => {
               // Set the settingsChecked flag to true to store
               // that the user has acknowledge the notification.
@@ -109,12 +116,20 @@ export const completionPlugin: JupyterFrontEndPlugin<void> = {
                           'providers',
                           providers
                         );
-                        // Set the Tab key as the shortcut for accepting Mito AI suggestions
-                        app.commands.addKeyBinding({
+
+                        // For some reason, it seems that unless the Tab shortcut is registered first, 
+                        // Jupyter does not accept it. So we try removing the existing shortcut.
+                        shortcuts = shortcuts.filter((shortcut: {command: string}) => shortcut.command !== 'inline-completer:accept');
+                        shortcuts.push({
                           command: 'inline-completer:accept',
                           keys: ['Tab'],
                           selector: '.jp-mod-inline-completer-active'
-                        });                    
+                        });
+                        await settingRegistry.set(
+                          JUPYTERLAB_SHORTCUTS_ID,
+                          'shortcuts',
+                          shortcuts
+                        );
                         updateConfig();
                       }
                     },


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1479

This is an issue we've seen happen at least twice, where the default shortcut for accepting an inline completion was not set to `Tab`. To avoid this, we're simply setting the Tab key as the default for the `inline-completer:accept` command. This happens right after a user enables Mito AI for the first time. 

To keep this as nondestructive as possible, we're only using the `.jp-mod-inline-completer-active` selector, and setting the shortcut once. 

# Testing

Disable Mito AI by updating `.jupyter/serverconfig/mitoaiconfig.json` so that `settingsChecked` is false. Then start the server, and look for the "enable Mito AI notification." 

# Documentation

https://docs.trymito.io/mito-ai/autocomplete#updating-keyboard-shortcuts