### PR TITLE
Bump upload artificats

### DIFF
--- a/.github/workflows/prerelease-tests.yml
+++ b/.github/workflows/prerelease-tests.yml
@@ -51,7 +51,7 @@ jobs:
             jupyter lab --config jupyter_server_test_config.py &
             npm run test:jupyterlab
         - name: Upload test-results
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           if: failure()
           with:
             name: jupyterlab-playwright-report-${{ matrix.python-version }}
@@ -154,7 +154,7 @@ jobs:
           Start-Job { streamlit run automation-app.py --server.port 8555 } -WorkingDirectory (Get-Location)
           npm run test:streamlit:demo -- --project="${{ matrix.project }}"
       - name: Upload test-results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: streamlit-playwright-report

--- a/.github/workflows/test-mito-ai.yml
+++ b/.github/workflows/test-mito-ai.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         OPENAI_API_KEY: ${{ matrix.use-mito-ai-server && '' || secrets.OPENAI_API_KEY }}
     - name: Upload test-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: mitoai-jupyterlab-playwright-report-${{ matrix.python-version }}

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -57,7 +57,7 @@ jobs:
         jupyter lab --config jupyter_server_test_config.py &
         npm run test:jupyterlab
     - name: Upload test-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: jupyterlab-playwright-report-${{ matrix.python-version }}
@@ -108,7 +108,7 @@ jobs:
         jupyter notebook --config jupyter_notebook_config.py &
         npm run test:notebook
     - name: Upload test-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: jupyternotebook-playwright-report-${{ matrix.python-version }}
@@ -225,7 +225,7 @@ jobs:
         Start-Job { streamlit run streamlit_test.py --server.port 8555 } -WorkingDirectory (Get-Location)
         npm run test -- --project="${{ matrix.project.test-name }}" streamlit_ui_tests/${{matrix.testfiles}}
     - name: Upload test-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: test-results-${{matrix.testfiles}}-${{ matrix.os }}-python${{ matrix.python-version }}-${{ matrix.project.test-name }}

--- a/mitosheet/mitosheet/scheduling/schedule_utils.py
+++ b/mitosheet/mitosheet/scheduling/schedule_utils.py
@@ -253,7 +253,7 @@ jobs:
       - name: Run automation
         run: python {automation_base_folder}/automation.py {current_timestamp_variable}
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: results-{current_timestamp_variable}
           path: {automation_base_folder}/runs/{current_timestamp_variable}


### PR DESCRIPTION
# Description

Bumps upload-artifacts@v3 to v4 because v3 is deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

# Testing

See that the tests still pass

# Documentation

No