### PR TITLE
Update mitosheet to use Jupyter colors

### DIFF
--- a/mitosheet/css/elements/TextButton.css
+++ b/mitosheet/css/elements/TextButton.css
@@ -78,6 +78,11 @@ a.text-button {
     width: 100%;
 }
 
+.text-button-variant-default {
+    background-color: var(--jp-layout-color1);
+    color: var(--jp-ui-font-color1);
+}
+
 .text-button-variant-light {
     background-color: var(--mito-highlight-very-light);
     color: var(--mito-highlight);
@@ -86,6 +91,10 @@ a.text-button {
 .text-button-variant-dark {
     background-color: var(--mito-highlight);
     color: var(--mito-background); 
+}
+
+.text-button-variant-default:hover:not(.text-button-disabled) {
+    background-color: var(--jp-layout-color2);
 }
 
 /* Style the LIGHT text button when it is hovered and not disabled */

--- a/mitosheet/css/elements/TextButton.css
+++ b/mitosheet/css/elements/TextButton.css
@@ -79,8 +79,8 @@ a.text-button {
 }
 
 .text-button-variant-default {
-    background-color: var(--jp-layout-color3);
-    color: var(--jp-ui-font-color1) !important;
+    background-color: var(--mito-background-default);
+    color: var(--mito-text) !important;
 }
 
 .text-button-variant-light {
@@ -94,7 +94,7 @@ a.text-button {
 }
 
 .text-button-variant-default:hover:not(.text-button-disabled) {
-    background-color: var(--jp-layout-color1);
+    background-color: var(--mito-background-default-hover);
 }
 
 /* Style the LIGHT text button when it is hovered and not disabled */

--- a/mitosheet/css/elements/TextButton.css
+++ b/mitosheet/css/elements/TextButton.css
@@ -79,8 +79,8 @@ a.text-button {
 }
 
 .text-button-variant-default {
-    background-color: var(--jp-layout-color1);
-    color: var(--jp-ui-font-color1);
+    background-color: var(--jp-layout-color3);
+    color: var(--jp-ui-font-color1) !important;
 }
 
 .text-button-variant-light {
@@ -94,7 +94,7 @@ a.text-button {
 }
 
 .text-button-variant-default:hover:not(.text-button-disabled) {
-    background-color: var(--jp-layout-color2);
+    background-color: var(--jp-layout-color1);
 }
 
 /* Style the LIGHT text button when it is hovered and not disabled */

--- a/mitosheet/css/endo/GridData.css
+++ b/mitosheet/css/endo/GridData.css
@@ -30,11 +30,11 @@
 
 /* We make selected cells look different on even and odd rows */
 .mito-grid-row-even .mito-grid-cell-selected:not(.mito-grid-cell-conditional-format-background-color):not(.recon) {
-    background-color: var(--mito-highlight-very-light);
+    background-color: color-mix(in srgb, var(--mito-highlight) 25%, transparent);
 }
 .mito-grid-row-odd .mito-grid-cell-selected:not(.mito-grid-cell-conditional-format-background-color):not(.recon) {
-    background-color: var(--mito-highlight-light);
-}
+    background-color: color-mix(in srgb, var(--mito-highlight-medium) 50%, transparent);
+}   
 
 .mito-grid-cell-hidden {
     visibility: hidden;

--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -116,8 +116,8 @@
     /* The selected sheet tab does not need a border */
     border: 0px;  
     box-sizing: border-box;
-    background-color: var(--mito-highlight);
-    color: var(--mito-background); 
+    background-color: var(--mito-background-default);
+    color: var(--mito-text); 
 }
 
 .tab-content {

--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -25,8 +25,6 @@
     flex-direction: column;
     justify-content: space-around;
 
-    background-color: var(--mito-highlight-light);
-
     padding-left: 10px;
     padding-right: 10px;
 
@@ -34,7 +32,7 @@
 }
 
 .footer-add-button:hover {
-    background-color: var(--mito-highlight-light);
+    background-color: var(--jp-layout-color2);
 }
 
 .footer-tab-bar {

--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -32,7 +32,7 @@
 }
 
 .footer-add-button:hover {
-    background-color: var(--jp-layout-color2);
+    background-color: var(--mito-background-off);
 }
 
 .footer-tab-bar {
@@ -76,7 +76,7 @@
 
 .tab {
     /* Set background color and border of sheet tab*/
-    background: var(--mito-background-highlight);
+    background: var(--mito-background);
     color: var(--mito-text);
 
     /* 
@@ -116,7 +116,7 @@
     /* The selected sheet tab does not need a border */
     border: 0px;  
     box-sizing: border-box;
-    background-color: var(--mito-background-default);
+    background-color: var(--mito-background-off);
     color: var(--mito-text); 
 }
 

--- a/mitosheet/css/taskpanes/ControlPanel/ControlPanelTaskpane.css
+++ b/mitosheet/css/taskpanes/ControlPanel/ControlPanelTaskpane.css
@@ -1,13 +1,11 @@
 
 .control-panel-taskpane-tab-container {
-
     width: 100%;
     display: flex;
     justify-content: space-around;
-
     box-sizing: border-box;
-
     width: inherit;
+    cursor: pointer;
 }
 
 .control-panel-taskpane-tab {
@@ -22,8 +20,8 @@
 
 /* When the taskpane tab is selected, turn it purple. */
 .control-panel-taskpane-tab.selected {
-    background-color: var(--mito-highlight);
-    color: var(--mito-background); 
+    background-color: var(--mito-background-default);
+    color: var(--mito-text); 
 }
 
 /* When the taskpane tab is not selected, turn it light blue */

--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -21,7 +21,6 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  background-color: var(--mito-background-highlight);
   border-bottom: 1px solid var(--mito-text-light);
 }
 

--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -273,14 +273,12 @@
 /* The button in the toolbar that lets the user upgrade or tells them they are pro */
 .mito-plan-button {
   border-radius: 3px;
-  background-color: var(--mito-highlight);
   font-size: 12px;
   text-align: center;
   justify-content: center;
   display: flex;
   flex-direction: column;
   padding: 0px 5px;
-  color: var(--mito-background);
   height: 18px;
 }
 

--- a/mitosheet/css/toolbar.css
+++ b/mitosheet/css/toolbar.css
@@ -182,6 +182,7 @@
 }
 
 .mito-toolbar-button-container-enabled.vertical-align-content:hover .mito-toolbar-button-icon-container,
+.mito-toolbar-top .mito-toolbar-button-container-enabled.vertical-align-content:hover .mito-toolbar-button-icon-container,
 .mito-toolbar-button-container-enabled.horizontal-align-content:hover {
   background-color: var(--mito-toolbar-hover);
 }
@@ -344,10 +345,6 @@
 
 .mito-toolbar-tabbar-right a {
   margin-right: 3px;
-}
-
-.mito-toolbar-top .mito-toolbar-button-container-enabled.vertical-align-content:hover .mito-toolbar-button-icon-container {
-  background-color: var(--mito-highlight-medium);
 }
 
 .mito-toolbar-top svg path {

--- a/mitosheet/src/mito/components/elements/GetSupportButton.tsx
+++ b/mitosheet/src/mito/components/elements/GetSupportButton.tsx
@@ -26,7 +26,7 @@ const GetSupportButton = (props: GetSupportButtonProps): JSX.Element => {
     return (
         <TextButton 
             className={classNames(props.className, 'cursor-pointer')}
-            variant='dark'
+            variant='default'
             width={props.width || 'hug-contents'}
             href={props.userProfile.mitoConfig.MITO_CONFIG_SUPPORT_EMAIL === DEFAULT_SUPPORT_EMAIL ? DISCORD_INVITE_LINK : `mailto:${props.userProfile.mitoConfig.MITO_CONFIG_SUPPORT_EMAIL}?subject=Mito support request`}
             target='_blank'

--- a/mitosheet/src/mito/components/elements/TextButton.tsx
+++ b/mitosheet/src/mito/components/elements/TextButton.tsx
@@ -15,7 +15,7 @@ interface TextButtonProps {
     /** 
         * @param variant - Color style of the button
     */
-    variant: 'light' | 'dark';
+    variant: 'light' | 'dark' | 'default';
 
     /** 
         * @param [onClick] - Function to be called when button is pressed

--- a/mitosheet/src/mito/components/icons/SelectedSheetTabDropdownIcon.tsx
+++ b/mitosheet/src/mito/components/icons/SelectedSheetTabDropdownIcon.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 const SelectedSheetTabDropdownIcon = (): JSX.Element => {
     return (
         <svg width="8" height="6" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 1L4.00283 4L7 1" stroke="var(--mito-background)" strokeWidth="2" strokeMiterlimit="10" strokeLinecap="round"/>
+            <path d="M1 1L4.00283 4L7 1" stroke="var(--mito-text)" strokeWidth="2" strokeMiterlimit="10" strokeLinecap="round"/>
         </svg>
     )
 }

--- a/mitosheet/src/mito/components/toolbar/PlanButton.tsx
+++ b/mitosheet/src/mito/components/toolbar/PlanButton.tsx
@@ -29,7 +29,7 @@ const PlanButton = (props: PlanButtonProps): JSX.Element => {
 
     return (
         <div 
-            className={classNames('text-button', 'text-button-variant-dark', 'mito-plan-button', 'cursor-pointer')}
+            className={classNames('text-button', 'text-button-variant-default', 'mito-plan-button', 'cursor-pointer')}
             onClick={() => {
                 
                 if (disabledDueToReplayAnalysis) {

--- a/mitosheet/src/mito/utils/colors.tsx
+++ b/mitosheet/src/mito/utils/colors.tsx
@@ -25,7 +25,7 @@ const DEFAULT_HIGHLIGHT_VERY_LIGHT = 'var(--mito-very-light-purple)';
 const TEXT_VARIABLE_NAME = '--mito-text';
 const TEXT_MEDIUM_VARIABLE_NAME = '--mito-text-medium';
 const TEXT_LIGHT_VARIABLE_NAME = '--mito-text-light';
-const DEFAULT_TEXT = 'var(--mito-gray)';
+const DEFAULT_TEXT = 'var(--jp-content-font-color1)';
 const DEFAULT_TEXT_MEDIUM = 'var(--mito-medium-gray)';
 const DEFAULT_TEXT_LIGHT = 'var(--mito-light-gray)';
 
@@ -33,9 +33,9 @@ const BACKGROUND_VARIABLE_NAME = '--mito-background';
 const BACKGROUND_OFF_VARIABLE_NAME = '--mito-background-off';
 const BACKGROUND_HIGHLIGHT_VARIABLE_NAME = '--mito-background-highlight';
 const TOOLBAR_HOVER_VARIABLE_NAME = '--mito-toolbar-hover';
-const DEFAULT_BACKGROUND = 'var(--mito-white)';
-const DEFAULT_BACKGROUND_OFF = 'var(--mito-very-light-gray)';
-const DEFAULT_BACKGROUND_HIGHLIGHT = 'var(--mito-light-blue)';
+const DEFAULT_BACKGROUND = 'var(--jp-layout-color1)';
+const DEFAULT_BACKGROUND_OFF = 'var(--jp-layout-color2)';
+const DEFAULT_BACKGROUND_HIGHLIGHT = 'var(--jp-input-background)';
 const TOOLBAR_HOVER_BACKGROUND = 'var(--mito-pretty-light-gray)';
 
 const getHighlightTheme = (primaryColor: string | undefined): React.CSSProperties => {

--- a/mitosheet/src/mito/utils/colors.tsx
+++ b/mitosheet/src/mito/utils/colors.tsx
@@ -32,13 +32,15 @@ const DEFAULT_TEXT_LIGHT = 'var(--mito-light-gray)';
 const BACKGROUND_VARIABLE_NAME = '--mito-background';
 const BACKGROUND_OFF_VARIABLE_NAME = '--mito-background-off';
 const BACKGROUND_HIGHLIGHT_VARIABLE_NAME = '--mito-background-highlight';
-const BACKGROUND_DEFAULT_VARIABLE_NAME = '--mito-background-default'
+const BACKGROUND_DEFAULT_VARIABLE_NAME = '--mito-background-default';
+const BACKGROUND_DEFAULT_HOVER_VARIABLE_NAME = '--mito-background-default-hover';
 const TOOLBAR_HOVER_VARIABLE_NAME = '--mito-toolbar-hover';
 const DEFAULT_BACKGROUND = 'var(--jp-layout-color1)';
 const DEFAULT_BACKGROUND_OFF = 'var(--jp-layout-color2)';
 const DEFAULT_BACKGROUND_HIGHLIGHT = 'var(--jp-input-background)';
 const TOOLBAR_HOVER_BACKGROUND = 'var(--jp-layout-color3)';
 const DEFAULT_BACKGROUND_DEFAULT = 'var(--jp-layout-color3)';
+const DEFAULT_BACKGROUND_DEFAULT_HOVER = 'var(--jp-layout-color4)';
 
 
 const getHighlightTheme = (primaryColor: string | undefined): React.CSSProperties => {
@@ -85,6 +87,7 @@ const getBackgroundColors = (backgroundColor: string | undefined): React.CSSProp
             [BACKGROUND_HIGHLIGHT_VARIABLE_NAME]: DEFAULT_BACKGROUND_HIGHLIGHT,
             [TOOLBAR_HOVER_VARIABLE_NAME]: TOOLBAR_HOVER_BACKGROUND,
             [BACKGROUND_DEFAULT_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT,
+            [BACKGROUND_DEFAULT_HOVER_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT_HOVER,
         } as React.CSSProperties
     }
 
@@ -97,6 +100,7 @@ const getBackgroundColors = (backgroundColor: string | undefined): React.CSSProp
         [BACKGROUND_HIGHLIGHT_VARIABLE_NAME]: highlightBackground,
         [TOOLBAR_HOVER_VARIABLE_NAME]: hexToRGBString(backgroundColorHex, .8),
         [BACKGROUND_DEFAULT_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT,
+        [BACKGROUND_DEFAULT_HOVER_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT_HOVER,
     } as React.CSSProperties
 }
 

--- a/mitosheet/src/mito/utils/colors.tsx
+++ b/mitosheet/src/mito/utils/colors.tsx
@@ -36,7 +36,7 @@ const TOOLBAR_HOVER_VARIABLE_NAME = '--mito-toolbar-hover';
 const DEFAULT_BACKGROUND = 'var(--jp-layout-color1)';
 const DEFAULT_BACKGROUND_OFF = 'var(--jp-layout-color2)';
 const DEFAULT_BACKGROUND_HIGHLIGHT = 'var(--jp-input-background)';
-const TOOLBAR_HOVER_BACKGROUND = 'var(--mito-pretty-light-gray)';
+const TOOLBAR_HOVER_BACKGROUND = 'var(--jp-layout-color3)';
 
 const getHighlightTheme = (primaryColor: string | undefined): React.CSSProperties => {
     if (primaryColor === undefined) {

--- a/mitosheet/src/mito/utils/colors.tsx
+++ b/mitosheet/src/mito/utils/colors.tsx
@@ -32,11 +32,14 @@ const DEFAULT_TEXT_LIGHT = 'var(--mito-light-gray)';
 const BACKGROUND_VARIABLE_NAME = '--mito-background';
 const BACKGROUND_OFF_VARIABLE_NAME = '--mito-background-off';
 const BACKGROUND_HIGHLIGHT_VARIABLE_NAME = '--mito-background-highlight';
+const BACKGROUND_DEFAULT_VARIABLE_NAME = '--mito-background-default'
 const TOOLBAR_HOVER_VARIABLE_NAME = '--mito-toolbar-hover';
 const DEFAULT_BACKGROUND = 'var(--jp-layout-color1)';
 const DEFAULT_BACKGROUND_OFF = 'var(--jp-layout-color2)';
 const DEFAULT_BACKGROUND_HIGHLIGHT = 'var(--jp-input-background)';
 const TOOLBAR_HOVER_BACKGROUND = 'var(--jp-layout-color3)';
+const DEFAULT_BACKGROUND_DEFAULT = 'var(--jp-layout-color3)';
+
 
 const getHighlightTheme = (primaryColor: string | undefined): React.CSSProperties => {
     if (primaryColor === undefined) {
@@ -81,6 +84,7 @@ const getBackgroundColors = (backgroundColor: string | undefined): React.CSSProp
             [BACKGROUND_OFF_VARIABLE_NAME]: DEFAULT_BACKGROUND_OFF,
             [BACKGROUND_HIGHLIGHT_VARIABLE_NAME]: DEFAULT_BACKGROUND_HIGHLIGHT,
             [TOOLBAR_HOVER_VARIABLE_NAME]: TOOLBAR_HOVER_BACKGROUND,
+            [BACKGROUND_DEFAULT_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT,
         } as React.CSSProperties
     }
 
@@ -92,6 +96,7 @@ const getBackgroundColors = (backgroundColor: string | undefined): React.CSSProp
         [BACKGROUND_OFF_VARIABLE_NAME]: offBackground,
         [BACKGROUND_HIGHLIGHT_VARIABLE_NAME]: highlightBackground,
         [TOOLBAR_HOVER_VARIABLE_NAME]: hexToRGBString(backgroundColorHex, .8),
+        [BACKGROUND_DEFAULT_VARIABLE_NAME]: DEFAULT_BACKGROUND_DEFAULT,
     } as React.CSSProperties
 }
 


### PR DESCRIPTION
# Description

Updates the colors used in the Mito Spreadsheet to use the Jupyter colors. This allows us to better support Dark Mode and to more seamlessly integrate into Jupyter. 

Old Light Mode:
<img width="1509" alt="Screenshot 2025-01-24 at 2 20 49 PM" src="https://github.com/user-attachments/assets/0dab4f9f-8337-4ee8-83a4-66bcbefc7d15" />

New Light Mode:
<img width="1508" alt="Screenshot 2025-01-24 at 2 20 22 PM" src="https://github.com/user-attachments/assets/5e45bc2f-cc85-4420-ba44-2691dc796a46" />

Old Dark Mode: (The same as light mode since we didn't inherit colors from Jupyter themes)
<img width="1509" alt="Screenshot 2025-01-24 at 2 21 03 PM" src="https://github.com/user-attachments/assets/7847c523-57ba-4cb3-8df3-10831ea02b9f" />

New Dark Mode: 
<img width="1508" alt="Screenshot 2025-01-24 at 2 20 08 PM" src="https://github.com/user-attachments/assets/ecb68f4b-5ed6-48ef-bdff-c2d604ee1a15" />

# Testing

Try it out and make sure all the colors work well. 

# Documentation

I don't think we need to update now. 