### PR TITLE
New auto enable mito ai

### DIFF
--- a/tests/mitoai_ui_tests/basicInlineComplete.spec.ts
+++ b/tests/mitoai_ui_tests/basicInlineComplete.spec.ts
@@ -16,12 +16,6 @@ import {
 const GHOST_SELECTOR = ".jp-GhostText";
 const THRESHOLD_IN_MS = 5000;
 
-// Before each test, enable inline completion
-test.beforeEach(async ({ page }) => {
-    await page.locator('button:has-text("Enable")').click();
-});
-
-
 test.describe("inline completion integration test", () => {
 
     test('Inline completion', async ({ page }) => {


### PR DESCRIPTION
# Description

The user downloading Mito AI is enough of an expression of them opting in to wanting Mito AI. So now we don't ask them to turn on the feature since we saw that the vast majority of people did not notice the notification.

Let's test this thoroughly and then merge directly into main so we can get this deployed asap and see if it helps numbers.

# Testing

Reset your environment and make sure Mito AI turns on. 

# Documentation

No. 