### PR TITLE
Return focus to active cell after accept

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -312,6 +312,13 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
 
         // Write to the cell that has the code diffs
         writeCodeToCellAndTurnOffDiffs(aiGeneratedCode, cellStateBeforeDiff.current.codeCellID)
+
+        // Focus on the active cell after the code is written
+        const notebook = notebookTracker.currentWidget?.content;
+        const activeCell = notebook?.activeCell;
+        if (activeCell) {
+            activeCell.activate();
+        }
     }
 
     const rejectAICode = () => {


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1452

# Testing

Send a message using Mito AI chat, then accept. The cursor should now be in the active cell, allowing you to run the cell right away.

# Documentation

N/A