### PR TITLE
mito-ai: save message immedietly

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -185,6 +185,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         } else {
             outgoingMessage = newChatHistoryManager.addChatInputMessage(input)
         }
+        setChatHistoryManager(newChatHistoryManager)
 
         // Step 2: Scroll to the bottom of the chat messages container
         // Add a small delay to ensure the new message is rendered


### PR DESCRIPTION
# Description

When editing a message, we should clear all future messages in the UI right away. Before this PR, they were not getting cleared until after the new message was returned. 

# Testing

Check it out. 

# Documentation

No