### PR TITLE
Secondary icons in dropdown

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -726,20 +726,20 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     return (
         <div className="chat-taskpane">
             <div className="chat-taskpane-header">
-            <DropdownMenu
-                trigger={
-                    <TextAndIconButton
-                        text={agentModeEnabled ? 'Agent ▾' : 'Chat ▾'}
-                        icon={agentModeEnabled ? RobotHeadIcon : ChatIcon}
-                        title={'Enter Agent Mode'}
-                        variant='purple'
-                        width='fit-contents'
-                        iconPosition='left'
-                        onClick={() => { }}
-                    />
-                }
-                items={agentMenuItems}
-            />
+                <DropdownMenu
+                    trigger={
+                        <TextAndIconButton
+                            text={agentModeEnabled ? 'Agent ▾' : 'Chat ▾'}
+                            icon={agentModeEnabled ? RobotHeadIcon : ChatIcon}
+                            title={'Enter Agent Mode'}
+                            variant='purple'
+                            width='fit-contents'
+                            iconPosition='left'
+                            onClick={() => { }}
+                        />
+                    }
+                    items={agentMenuItems}
+                />
                 <div className="chat-taskpane-header-buttons">
                     <IconButton
                         icon={<SupportIcon />}

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -711,7 +711,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                 clearChatHistory()
                 setAgentModeEnabled(false);
             },
-            icon: ChatIcon,
+            primaryIcon: ChatIcon,
         },
         {
             label: 'Agent',
@@ -719,27 +719,27 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                 clearChatHistory()
                 setAgentModeEnabled(true);
             },
-            icon: RobotHeadIcon,
+            primaryIcon: RobotHeadIcon,
         }
     ];
 
     return (
         <div className="chat-taskpane">
             <div className="chat-taskpane-header">
-                <DropdownMenu
-                    trigger={
-                        <TextAndIconButton
-                            text={agentModeEnabled ? 'Agent ▾' : 'Chat ▾'}
-                            icon={agentModeEnabled ? RobotHeadIcon : ChatIcon}
-                            title={'Enter Agent Mode'}
-                            variant='purple'
-                            width='fit-contents'
-                            iconPosition='left'
-                            onClick={() => { }}
-                        />
-                    }
-                    items={agentMenuItems}
-                />
+            <DropdownMenu
+                trigger={
+                    <TextAndIconButton
+                        text={agentModeEnabled ? 'Agent ▾' : 'Chat ▾'}
+                        icon={agentModeEnabled ? RobotHeadIcon : ChatIcon}
+                        title={'Enter Agent Mode'}
+                        variant='purple'
+                        width='fit-contents'
+                        iconPosition='left'
+                        onClick={() => { }}
+                    />
+                }
+                items={agentMenuItems}
+            />
                 <div className="chat-taskpane-header-buttons">
                     <IconButton
                         icon={<SupportIcon />}

--- a/mito-ai/src/components/DropdownMenu.tsx
+++ b/mito-ai/src/components/DropdownMenu.tsx
@@ -1,69 +1,121 @@
 import React, { useState, useRef, useEffect } from 'react';
 import '../../style/DropdownMenu.css';
 
+interface DropdownSecondaryAction {
+  icon: React.ComponentType<{ fill?: string }>;
+  onClick: () => void;
+  tooltip?: string;
+  disabled?: boolean;
+}
+
 interface DropdownMenuItem {
-    label: string;
-    onClick: () => void;
-    icon?: React.ComponentType<{ fill?: string }>;
-    disabled?: boolean;
-    disabledTooltip?: string;
+  label: string;
+  onClick: () => void; // main action
+  primaryIcon?: React.ComponentType<{ fill?: string }>;
+  disabled?: boolean;
+  disabledTooltip?: string;
+  secondaryActions?: DropdownSecondaryAction[];
 }
 
 interface DropdownMenuProps {
-    trigger: React.ReactNode;
-    items: DropdownMenuItem[];
-    className?: string;
+  trigger: React.ReactNode;
+  items: DropdownMenuItem[];
+  className?: string;
+  alignment?: 'left' | 'right';
 }
 
-const DropdownMenu: React.FC<DropdownMenuProps> = ({ trigger, items, className = '' }) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const dropdownRef = useRef<HTMLDivElement>(null);
+const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  trigger,
+  items,
+  className = '',
+  alignment = 'left',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-    // Close dropdown when clicking outside
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-            }
-        };
-
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
-
-    const handleItemClick = (onClick: () => void, disabled?: boolean) => {
-        if (disabled) return;
-        onClick();
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
+      }
     };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Handle the main click (primary action)
+  const handlePrimaryClick = (onClick: () => void, disabled?: boolean) => {
+    if (disabled) return;
+    onClick();
+    setIsOpen(false);
+  };
+
+  // Choose the alignment class
+  const alignmentClass =
+    alignment === 'right' ? 'dropdown-menu-right' : 'dropdown-menu-left';
 
     return (
         <div className={`dropdown-container ${className}`} ref={dropdownRef}>
-            <div onClick={() => setIsOpen(!isOpen)}>
-                {trigger}
-            </div>
-            {isOpen && (
-                <div className="dropdown-menu">
-                    {items.map((item, index) => (
-                        <button
-                            key={index}
-                            className={`dropdown-item ${item.icon ? 'dropdown-item-with-icon' : ''} ${item.disabled ? 'dropdown-item-disabled' : ''}`}
-                            onClick={() => handleItemClick(item.onClick, item.disabled)}
-                            title={item.disabled ? item.disabledTooltip : undefined}
-                            style={{ display: 'flex', gap: '5px' }}
-                        >
-                            {item.icon && (
-                                <span className="dropdown-item-icon" style={{ width: '20px', display: 'flex' }}>
-                                    {React.createElement(item.icon)}
-                                </span>
-                            )}
-                            <span className="dropdown-item-label">{item.label}</span>
-                        </button>
-                    ))}
+          <div onClick={() => setIsOpen(!isOpen)}>
+            {trigger}
+          </div>
+          {isOpen && (
+            <div className={`dropdown-menu ${alignmentClass}`}>
+              {items.map((item, index) => (
+                <div
+                  key={index}
+                  className={
+                    `dropdown-item-row ${item.disabled ? 'dropdown-item-disabled' : ''}`
+                }
+                  style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '4px 8px' }}
+                >
+
+                  <button
+                    className="dropdown-item-main"
+                    onClick={() => handlePrimaryClick(item.onClick, item.disabled)}
+                    disabled={item.disabled}
+                    title={item.disabled ? item.disabledTooltip : undefined}
+                  >
+                    {/* Optional primary icon on the left */}
+                    <span className="dropdown-item-icon">
+                        {item.primaryIcon && React.createElement(item.primaryIcon)}
+                    </span>
+                    <span className="dropdown-item-label">{item.label}</span>
+                  </button>
+                  {item.secondaryActions && item.secondaryActions.map((action, actionIndex) => (
+                    <button
+                      key={actionIndex}
+                      className="dropdown-item-secondary"
+                      onClick={(e) => {
+                        e.stopPropagation();  // prevent triggering the main onClick
+                        if (!action.disabled) {
+                          action.onClick();
+                          setIsOpen(false); // optional: close the dropdown after secondary action
+                        }
+                      }}
+                      disabled={action.disabled}
+                      title={action.tooltip}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: action.disabled ? 'default' : 'pointer',
+                        padding: 0,
+                      }}
+                    >
+                      {React.createElement(action.icon, { fill: 'currentColor' })}
+                    </button>
+                  ))}
                 </div>
-            )}
+              ))}
+            </div>
+          )}
         </div>
-    );
+      );
 };
 
 export default DropdownMenu;

--- a/mito-ai/style/DropdownMenu.css
+++ b/mito-ai/style/DropdownMenu.css
@@ -6,7 +6,6 @@
 .dropdown-menu {
     position: absolute;
     top: calc(100% + 4px);
-    left: 0;
     z-index: 1000;
     background-color: var(--jp-layout-color1);
     border: 1px solid var(--jp-layout-color2);
@@ -14,21 +13,53 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     display: flex;
     flex-direction: column;
-    min-width: 150px;
+    min-width: 200px;
+    white-space: nowrap;
 }
 
-.dropdown-item {
-    padding: 8px 12px;
+/* Left-aligned dropdown */
+.dropdown-menu-left {
+    left: 0;
+    right: auto;
+}
+
+/* Right-aligned dropdown */
+.dropdown-menu-right {
+    right: 0;
+    left: auto;
+}
+
+.dropdown-item-main {
     border: none;
     background: none;
     cursor: pointer;
     color: var(--jp-ui-font-color1);
     text-align: left;
-    height: 36px;
-    line-height: 20px;
-    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    flex: 1;
+    overflow: hidden; 
+    text-overflow: ellipsis;
 }
 
 .dropdown-item:hover {
     background-color: var(--jp-layout-color3);
+}
+
+.dropdown-item-icon {
+    width: 20px;
+    min-width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dropdown-item-label {
+    padding-left: 3px; /* Add consistent padding */
+}
+
+.dropdown-item-disabled {
+    opacity: 0.5;
+    cursor: default;
 }


### PR DESCRIPTION
# Description

Update DropdownMenu to allow secondary action icons on the right, similarly how other apps do it

The dropdown items then would look like this:
```
| primparyIcon | label | ... | secondaryActions |
```

_Inspiration: VSCode Copilot_
<img width="585" alt="Screenshot 2025-02-13 at 2 45 07 PM" src="https://github.com/user-attachments/assets/af9d646f-a574-43c3-8f9e-31626c641e9b" />

_Example usage (from upcoming feature)_
<img width="318" alt="image" src="https://github.com/user-attachments/assets/9c2f6463-b5fb-43bc-be4f-4531c57b593a" />

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.