### PR TITLE
Agent Mode: Pre-Release Polish

### DIFF
--- a/mito-ai/mito_ai/prompt_builders/agent_planning_prompt.py
+++ b/mito-ai/mito_ai/prompt_builders/agent_planning_prompt.py
@@ -25,5 +25,6 @@ Given the dataset (if provided) and the question below:
 1. Break the problem into the **smallest possible number of clear, high-level tasks** necessary to achieve the solution. 
 2. **Do not include any code or specific implementation details.** Focus only on describing the high-level steps required to solve the problem.
 3. Additionally, provide a list of python packages that are required to complete the actions. 
-{input}
+
+Your task: {input}
 """

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -238,9 +238,25 @@ def log_ai_completion_success(
         log("mito_ai_chat_success", params=final_params)
     elif prompt_type == "agent:planning":
         final_params = base_params
+
+        # Chunk the user input
+        user_input = last_message_content.split("Your task: ")[-1]
+        user_input_chunks = chunk_param(user_input, "user_input")
+        
+        for chunk_key, chunk_value in user_input_chunks.items():
+            final_params[chunk_key] = chunk_value
+
         log("mito_ai_agent_planning_success", params=final_params)
     elif prompt_type == "agent:execution":
         final_params = base_params
+
+        # Chunk the user input
+        user_input = last_message_content.split("Your task: ")[-1]
+        user_input_chunks = chunk_param(user_input, "user_input")
+        
+        for chunk_key, chunk_value in user_input_chunks.items():
+            final_params[chunk_key] = chunk_value
+
         log("mito_ai_agent_execution_success", params=final_params)
     elif prompt_type == "inline_completion":
         final_params = base_params

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -144,7 +144,7 @@ export class ChatHistoryManager {
         }
     }
 
-    addAgentMessage(message: string): IOutgoingMessage {
+    addAgentMessage(message: string, index?: number): IOutgoingMessage {
         const variables = this.variableManager.variables
 
         const metadata: IChatMessageMetadata = {
@@ -160,6 +160,12 @@ export class ChatHistoryManager {
                 promptType: 'agent:planning'
             }
         )
+
+        // If editing the first agent message, the user will want a new plan.
+        // So we drop all steps in the agent's previous plan.
+        if (index === 1) {
+            this.displayOptimizedChatHistory = this.displayOptimizedChatHistory.slice(0, index + 1);
+        }
 
         return {
             promptType: 'agent:planning',

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -21,6 +21,7 @@ interface ChatInputProps {
     notebookTracker: INotebookTracker;
     renderMimeRegistry: IRenderMimeRegistry;
     displayActiveCellCode?: boolean;
+    agentModeEnabled?: boolean;
 }
 
 export interface ExpandedVariable extends Variable {
@@ -37,6 +38,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
     notebookTracker,
     renderMimeRegistry,
     displayActiveCellCode = true,
+    agentModeEnabled = false,
 }) => {
 
     const [input, setInput] = useState(initialContent);
@@ -196,7 +198,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             <div style={{ position: 'relative', height: 'min-content'}}>
                 <textarea
                     ref={textAreaRef}
-                    className={classNames("message", "message-user", 'chat-input')}
+                    className={classNames("message", "message-user", 'chat-input', {"agent-mode": agentModeEnabled})}
                     placeholder={placeholder}
                     value={input}
                     onChange={handleInputChange}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -37,7 +37,7 @@ interface IChatMessageProps {
     previewAICode: () => void
     acceptAICode: () => void
     rejectAICode: () => void
-    onUpdateMessage: (messageIndex: number, newContent: string, messageType: IDisplayOptimizedChatHistory['type']) => void
+    onUpdateMessage: (messageIndex: number, newContent: string, promptType: PromptType) => void
     variableManager?: IVariableManager
     codeReviewStatus: CodeReviewStatus
 }
@@ -75,7 +75,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
     };
 
     const handleSave = (content: string) => {
-        onUpdateMessage(messageIndex, content, messageType);
+        onUpdateMessage(messageIndex, content, promptType);
         setIsEditing(false);
     };
 

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -19,7 +19,6 @@ import ChatInput from './ChatMessage/ChatInput';
 import ChatMessage from './ChatMessage/ChatMessage';
 import { 
     ChatHistoryManager, 
-    IDisplayOptimizedChatHistory, 
     IOutgoingMessage, 
     PromptType 
 } from './ChatHistoryManager';
@@ -278,9 +277,9 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     const handleUpdateMessage = async (
         messageIndex: number,
         newContent: string,
-        messageType: IDisplayOptimizedChatHistory['type']
+        promptType: PromptType
     ) => {
-        if (messageType === 'openai message:agent:planning') {
+        if (promptType === 'agent:planning' && messageIndex !== 1) {
             // In agent planning mode we only update the message locally without sending it to the AI
             // because the user has not yet confirmed that they want the AI to process these messages 
             // until they hit the submit button.
@@ -288,21 +287,21 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             newChatHistoryManager.updateMessageAtIndex(messageIndex, newContent, true)
             setChatHistoryManager(newChatHistoryManager)
         } else if (agentModeEnabled && messageIndex === 1) { 
-            // If editing the original agent message, send it as a new agent message.
-            sendAgentMessage(newContent)
+            // If editing the original agent message
+            sendAgentMessage(newContent, messageIndex)
         } else {
             sendChatInputMessage(newContent, messageIndex)
         }
     };
 
-    const sendAgentMessage = async (message: string) => {
+    const sendAgentMessage = async (message: string, messageIndex?: number) => {
         console.log('Sending agent message: ', message)
         // Step 0: Reject the previous Ai generated code if they did not accept it
         rejectAICode()
 
         // Step 1: Add user message to chat history
         const newChatHistoryManager = getDuplicateChatHistoryManager()
-        const outgoingMessage = newChatHistoryManager.addAgentMessage(message)
+        const outgoingMessage = newChatHistoryManager.addAgentMessage(message, messageIndex)
         setChatHistoryManager(newChatHistoryManager)
 
         // Step 2: Send the message to the AI

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -823,6 +823,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                         variableManager={variableManager}
                         notebookTracker={notebookTracker}
                         renderMimeRegistry={renderMimeRegistry}
+                        agentModeEnabled={agentModeEnabled}
                     />
                     {agentModeEnabled &&
                         <>

--- a/mito-ai/style/ChatInput.css
+++ b/mito-ai/style/ChatInput.css
@@ -1,4 +1,3 @@
-
 .chat-input-container {
     position: sticky;
     bottom: 0;
@@ -6,7 +5,6 @@
     margin: 10px 0;
     margin-top: auto;
     border-radius: 3px;
-    border: 1px solid var(--grey-300);
 }
 
 .chat-input {
@@ -17,12 +15,31 @@
     padding: 10px;
     overflow-y: hidden;
     box-sizing: border-box;
+    border: 1px solid var(--grey-300);
 
     /* 
         The height of the chat input is set in the ChatTaskpane.tsx file. 
         See the adjustHeight function for more detail.
     */
     flex-shrink: 0 !important;
+}
+
+.chat-input.agent-mode {
+    border: 1px solid var(--purple-500);
+    animation: glow 2s ease-in-out;
+    --glow-color: var(--purple-500);
+}
+
+@keyframes glow {
+    0% {
+        box-shadow: 0 0 0 0 var(--glow-color);
+    }
+    50% {
+        box-shadow: 0 0 10px 3px var(--glow-color);
+    }
+    100% {
+        box-shadow: 0 0 0 0 var(--glow-color);
+    }
 }
 
 .active-cell-preview-container {

--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -79,15 +79,7 @@
 }
 
 .message-assistant-agent p {
-    color: var(--jp-content-font-color1) !important;
-}
-
-.markdown-message-part * .jp-RenderedHTMLCommon :not(pre) > code {
-    background-color: var(--purple-300);
-    color: var(--purple-700);
-    border-radius: 3px;
-    display: inline-flex;
-    align-items: center;
+    color: var(--grey-900)!important;
 }
 
 .chat-messages {

--- a/tests/mitoai_ui_tests/agent.spec.ts
+++ b/tests/mitoai_ui_tests/agent.spec.ts
@@ -43,18 +43,35 @@ test.describe("Agent mode integration tests", () => {
     test("Edit original message", async ({ page }) => {
         const newMessage = "print bye";
 
-        // Keep track of the last agent message.
-        // We want to validate that this message is changed to reflect the users edit. 
-        const lastAgentMessageOG = await page.locator('.message-assistant-agent').last().textContent();
+        // Keep track of the original messages in the agent's plan.
+        const oldPlanMessages: string[] = [];
+        const messages = await page.locator('.message-assistant-agent').all();
+        messages.forEach(async (message) => {
+            const messageText = await message.textContent();
+            if (messageText) {
+                oldPlanMessages.push(messageText);
+            }
+        });
 
         // Edit the message
         await editMitoAIMessage(page, newMessage, 0);
         await waitForIdle(page);
 
-        // Ensure that we recieved a new plan 
-        // by checking that the last agent message is different from the original.
-        const lastAgentMessageUpdated = await page.locator('.message-assistant-agent').last().textContent();
-        expect(lastAgentMessageUpdated).not.toEqual(lastAgentMessageOG);
+        // Track new plan.  
+        const newPlanMessages: string[] = [];
+        const newMessages = await page.locator('.message-assistant-agent').all();
+        newMessages.forEach(async (message) => {
+            const messageText = await message.textContent();
+            if (messageText) {
+                newPlanMessages.push(messageText);
+            }
+        });
+        
+        // By editing the original agent message, we should see a new plan
+        // and the old plan messages should be wiped. 
+        oldPlanMessages.forEach(message => {
+            expect(newPlanMessages).not.toContain(message);
+        });
     });
 
     test("Edit message in agent's plan", async ({ page }) => {


### PR DESCRIPTION
# Description

- Added `user_input` field when logging agent mode prompts. We no longer have to go though the `full_prompt` to see the user's question.
- Editing the original agent mode prompt will erase all plans, and generate a new plan. Previously, this would just add a new message to the chat, and the user would have to scroll to see the new plan. 
- Agent plan messages now default to `grey-900`. Using the Jupyter colors meant that plans were unreadable in dark mode.

While it is an extension of chat, we also want to make sure users understand that it is a slightly different paradigm. To this extent:
- Added purple border to agent mode input.
- Added glow animation when switching to agent mode. 

# Testing

Try it out.

# Documentation

N/A