### PR TITLE
Agent: Fix for warnings + errors

### DIFF
--- a/mito-ai/src/utils/agentActions.tsx
+++ b/mito-ai/src/utils/agentActions.tsx
@@ -45,8 +45,11 @@ export const retryIfExecutionError = async (
 
         // If the code cell has an error, we need to send the error to the AI
         // and get it to fix the error.
-        const errorTraceback = cell?.model.outputs?.toJSON()[0].traceback as string[]
-        const errorMessage = getFullErrorMessageFromTraceback(errorTraceback)
+        const errorOutput = cell?.model.outputs?.toJSON().find(output => output.output_type === "error");
+        if (!errorOutput) {
+            return 'success'; // If no error output, we're done
+        }
+        const errorMessage = getFullErrorMessageFromTraceback(errorOutput.traceback as string[]);
 
         const newChatHistoryManager = getDuplicateChatHistoryManager()
 

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -49,7 +49,8 @@ export const didCellExecutionError = (cell: CodeCell): boolean => {
     /* 
         Check the cell's output for an error.
     */
-    return cell?.model.outputs?.toJSON().some(output => output.output_type === "error")
+    const outputs = cell?.model.outputs?.toJSON() || [];
+    return outputs.some(output => output.output_type === "error");
 }
 
 export const getNotebookName = (notebookTracker: INotebookTracker): string => {


### PR DESCRIPTION
# Description

This update fixes a bug in agent mode's smart debugging: if a cell produces both a warning and an error message, the debugging feature would fail. Now, smart debugging works correctly even when both types of messages are output.

# Testing

1. Enter agent mode
2. Create any plan. 
3. Edit the plan so that one of the steps reads, "Using python, create a warning and an error message."

When the plan is run, you should see that the cell with the warning and error will trigger the smart debug workflow.  

# Documentation

N/A