### PR TITLE
mito-ai: update http request timeout

### DIFF
--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -96,7 +96,7 @@ async def get_ai_completion_from_mito_server(
         __user_id = get_user_field(UJ_STATIC_USER_ID)
 
     data = {
-        "timeout": timeout,
+        "timeout": 120,
         "max_retries": max_retries,
         "email": __user_email,
         "user_id": __user_id,
@@ -107,8 +107,14 @@ async def get_ai_completion_from_mito_server(
     headers = {
         "Content-Type": "application/json",
     }
+    
+    # The HTTP client timesout after 20 seconds by default. We update this to match the timeout
+    # we give to OpenAI. The OpenAI timeouts are denoted in seconds, wherease the HTTP client
+    # expects milliseconds. We also give the HTTP client a 10 second buffer to account for
+    # the time it takes to send the request, etc.
+    http_client_timeout = timeout * 1000 * max_retries + 10000
 
-    http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"))
+    http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
     try:
         res = await http_client.fetch(
             # Important: DO NOT CHANGE MITO_AI_URL. If you want to use the dev endpoint, 

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -119,7 +119,9 @@ async def get_ai_completion_from_mito_server(
     # If we are running in a test environment, we want a short timeout to prevent tests from hanging
     # for too long, but still give enough time for simple responses.
     if is_running_test():
-        http_client_timeout = 20000  # 20 seconds for tests
+        # Increase timeout specifically for CI environments to prevent kernel shutdown issues
+        # CI environments tend to be slower and need more time to process requests
+        http_client_timeout = 60000  # 60 seconds for CI tests
 
     http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
     try:

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -96,7 +96,7 @@ async def get_ai_completion_from_mito_server(
         __user_id = get_user_field(UJ_STATIC_USER_ID)
 
     data = {
-        "timeout": 120,
+        "timeout": timeout,
         "max_retries": max_retries,
         "email": __user_email,
         "user_id": __user_id,

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -110,8 +110,7 @@ async def get_ai_completion_from_mito_server(
         "Content-Type": "application/json",
     }
     
-    
-    
+    http_client = None
     if is_running_test():
         # If we are running in a test environment, setting the request_timeout fails for some reason.
         http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"))

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -6,7 +6,9 @@
 import json
 from typing import Any, Dict, List, Optional, Type, Final, Union
 from datetime import datetime, timedelta
+import os
 
+from mitoinstaller.mitoinstaller.user_install import is_running_test
 from pydantic import BaseModel
 from tornado.httpclient import AsyncHTTPClient
 from mito_ai.models import MessageType
@@ -113,6 +115,11 @@ async def get_ai_completion_from_mito_server(
     # expects milliseconds. We also give the HTTP client a 10 second buffer to account for
     # the time it takes to send the request, etc.
     http_client_timeout = timeout * 1000 * max_retries + 10000
+    
+    # If we are running in a test environment, we don't want to wait for the timeout
+    # because the test will fail.
+    if is_running_test():
+        http_client_timeout = None
 
     http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
     try:

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Type, Final, Union
 from datetime import datetime, timedelta
 import os
 
-from mitoinstaller.mitoinstaller.user_install import is_running_test
+from mito_ai.utils.utils import is_running_test
 from pydantic import BaseModel
 from tornado.httpclient import AsyncHTTPClient
 from mito_ai.models import MessageType

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -110,20 +110,20 @@ async def get_ai_completion_from_mito_server(
         "Content-Type": "application/json",
     }
     
-    # The HTTP client timesout after 20 seconds by default. We update this to match the timeout
-    # we give to OpenAI. The OpenAI timeouts are denoted in seconds, wherease the HTTP client
-    # expects milliseconds. We also give the HTTP client a 10 second buffer to account for
-    # the time it takes to send the request, etc.
-    http_client_timeout = timeout * 1000 * max_retries + 10000
     
-    # If we are running in a test environment, we want a short timeout to prevent tests from hanging
-    # for too long, but still give enough time for simple responses.
+    
     if is_running_test():
-        # Increase timeout specifically for CI environments to prevent kernel shutdown issues
-        # CI environments tend to be slower and need more time to process requests
-        http_client_timeout = 60000  # 60 seconds for CI tests
-
-    http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
+        # If we are running in a test environment, setting the request_timeout fails for some reason.
+        http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"))
+    else:
+        
+        # The HTTP client timesout after 20 seconds by default. We update this to match the timeout
+        # we give to OpenAI. The OpenAI timeouts are denoted in seconds, wherease the HTTP client
+        # expects milliseconds. We also give the HTTP client a 10 second buffer to account for
+        # the time it takes to send the request, etc.
+        http_client_timeout = timeout * 1000 * max_retries + 10000
+        http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
+    
     try:
         res = await http_client.fetch(
             # Important: DO NOT CHANGE MITO_AI_URL. If you want to use the dev endpoint, 

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -116,10 +116,10 @@ async def get_ai_completion_from_mito_server(
     # the time it takes to send the request, etc.
     http_client_timeout = timeout * 1000 * max_retries + 10000
     
-    # If we are running in a test environment, we don't want to wait for the timeout
-    # because the test will fail.
+    # If we are running in a test environment, we want a short timeout to prevent tests from hanging
+    # for too long, but still give enough time for simple responses.
     if is_running_test():
-        http_client_timeout = None
+        http_client_timeout = 20000  # 20 seconds for tests
 
     http_client = AsyncHTTPClient(defaults=dict(user_agent="Mito-AI client"), request_timeout=http_client_timeout)
     try:


### PR DESCRIPTION
# Description

Set a timeout on the actual http request to give it enough time for the Open AI API. The default was 20 seconds, which was out of sync with the OpenAI timeout and max retries we were setting. 

# Testing

I'm not sure how to test this exactly... 