### PR TITLE
[WIP] Add WebSocket keep-alive mechanism

### DIFF
--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -30,7 +30,8 @@ from mito_ai.models import (
     AgentPlanningMetadata,
     AgentExecutionMetadata,
     InlineCompleterMetadata,
-    MessageType
+    MessageType,
+    PingReply
 )
 from mito_ai.providers import OpenAIProvider
 from mito_ai.utils.create import initialize_user
@@ -130,7 +131,15 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
             self.log.error("Invalid completion request.", exc_info=e)
             return
         
-        reply: Union[StartNewChatReply, FetchThreadsReply, DeleteThreadReply, FetchHistoryReply, CompletionReply]
+        reply: Union[StartNewChatReply, FetchThreadsReply, DeleteThreadReply, FetchHistoryReply, CompletionReply, PingReply]
+
+        # Handle ping messages - respond with a pong to keep the connection alive
+        if type == MessageType.PING:
+            reply = PingReply(
+                parent_id=parsed_message.get("message_id")
+            )
+            self.reply(reply)
+            return
 
         # Clear history if the type is "start_new_chat"
         if type == MessageType.START_NEW_CHAT:

--- a/mito-ai/mito_ai/models.py
+++ b/mito-ai/mito_ai/models.py
@@ -50,6 +50,7 @@ class MessageType(Enum):
     FETCH_HISTORY = "fetch_history"
     GET_THREADS = "get_threads"
     DELETE_THREAD = "delete_thread"
+    PING = "ping"  # New message type for keep-alive
 
 @dataclass(frozen=True)
 class ChatMessageMetadata():
@@ -331,3 +332,16 @@ class DeleteThreadReply:
 
     # Message type.
     type: Literal["reply"] = "reply"
+
+@dataclass(frozen=True)
+class PingReply:
+    """
+    Message sent from model to client in response to a ping message.
+    Used for keep-alive to maintain the WebSocket connection.
+    """
+
+    # Message UID.
+    parent_id: str
+
+    # Message type.
+    type: Literal["pong"] = "pong"

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -16,7 +16,8 @@ export type PromptType =
     'fetch_history' |
     'start_new_chat' |
     'get_threads' |
-    'delete_thread';
+    'delete_thread' |
+    'ping';
 
 export type ChatMessageType = 'openai message' | 'openai message:agent:planning' | 'connection error'
 

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -487,6 +487,13 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         setLoadingAIResponse(true)
 
         try {
+            // Skip processing for ping messages - they're only for keeping the connection alive
+            if (completionRequest.type === 'ping') {
+                await websocketClient.sendMessage(completionRequest);
+                setLoadingAIResponse(false);
+                return true;
+            }
+
             const aiResponse = await websocketClient.sendMessage<
                 ICompletionRequest, 
                 ICompletionReply

--- a/mito-ai/src/utils/websocket/models.ts
+++ b/mito-ai/src/utils/websocket/models.ts
@@ -47,7 +47,8 @@ type CompletionRequestMetadata =
   IStartNewChatMetadata |
   IGetThreadsMetadata | 
   IDeleteThreadMetadata |
-  IAgentExecutionMetadata;
+  IAgentExecutionMetadata |
+  IPingMetadata;
 
 export interface IChatMessageMetadata {
     promptType: 'chat'
@@ -111,6 +112,13 @@ export interface IGetThreadsMetadata {
 export interface IDeleteThreadMetadata {
   promptType: 'delete_thread'
   thread_id: string;
+}
+
+/**
+ * Metadata for ping messages to keep the WebSocket connection alive
+ */
+export interface IPingMetadata {
+  promptType: 'ping'
 }
 
 /* 
@@ -178,6 +186,13 @@ export interface IFetchHistoryCompletionRequest extends ICompletionRequest {
   metadata: IFetchHistoryMetadata
 }
 
+/**
+ * Interface for ping request to keep the connection alive
+ */
+export interface IPingRequest extends ICompletionRequest {
+  type: 'ping'
+  metadata: IPingMetadata
+}
 
 /**
  * AI capabilities.
@@ -419,6 +434,21 @@ export interface IDeleteThreadReply {
   success: boolean;
 }
 
+/**
+ * Interface for ping response
+ */
+export interface IPingReply {
+  /**
+   * The type of the message.
+   */
+  type: 'pong';
+
+  /**
+   * The parent message ID.
+   */
+  parent_id: string;
+}
+
 export type CompleterMessage =
   | ErrorMessage
   | IAICapabilities
@@ -427,4 +457,5 @@ export type CompleterMessage =
   | IFetchHistoryReply
   | IStartNewChatReply
   | IFetchThreadsReply
-  | IDeleteThreadReply;
+  | IDeleteThreadReply
+  | IPingReply;


### PR DESCRIPTION
Closing this PR in favor of https://github.com/mito-ds/mito/pull/1558 

I initially misunderstood why disconnects were happening, believing that there was an arbitrary timeout set. In reality, the connection was closed once a users computer went to sleep. 

This fix adds a constant ping to the websocket every 30s to keep the connection alive.