### PR TITLE
System prompt backend only

### DIFF
--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -135,6 +135,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         # Clear history if the type is "start_new_chat"
         if type == MessageType.START_NEW_CHAT:
             thread = message_history.create_new_thread()
+            
             reply = StartNewChatReply(
                 parent_id=parsed_message.get("message_id"),
                 thread_id=thread

--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -136,6 +136,17 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         if type == MessageType.START_NEW_CHAT:
             thread_id = message_history.create_new_thread()
             
+            system_message: ChatCompletionMessageParam = {
+                "role": "system",
+                "content": "You are an expert Python programmer."
+            }
+            
+            await message_history.append_message(
+                ai_optimized_message=system_message,
+                display_message=system_message,
+                llm_provider=self._llm
+            )
+            
             reply = StartNewChatReply(
                 parent_id=parsed_message.get("message_id"),
                 thread_id=thread_id

--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -134,11 +134,11 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
 
         # Clear history if the type is "start_new_chat"
         if type == MessageType.START_NEW_CHAT:
-            thread = message_history.create_new_thread()
+            thread_id = message_history.create_new_thread()
             
             reply = StartNewChatReply(
                 parent_id=parsed_message.get("message_id"),
-                thread_id=thread
+                thread_id=thread_id
             )
             self.reply(reply)
             return

--- a/mito-ai/mito_ai/message_history.py
+++ b/mito-ai/mito_ai/message_history.py
@@ -104,7 +104,7 @@ class GlobalMessageHistory:
     Attributes:
         _lock (Lock): Ensures thread-safe access.
         _chats_dir (str): Directory where chat thread files are stored.
-        _chat_threads (Dict[str, ChatThread]): In-memory cache of all chat threads.
+        _chat_threads (Dict[ThreadID, ChatThread]): In-memory cache of all chat threads.
 
     Methods:
         create_new_thread() -> str:
@@ -129,7 +129,7 @@ class GlobalMessageHistory:
         os.makedirs(self._chats_dir, exist_ok=True)
 
         # In-memory cache of all chat threads loaded from disk
-        self._chat_threads: Dict[str, ChatThread] = {}
+        self._chat_threads: Dict[ThreadID, ChatThread] = {}
 
         # Load existing threads from disk on startup
         self._load_all_threads_from_disk()
@@ -242,7 +242,7 @@ class GlobalMessageHistory:
 
             return self._chat_threads[thread_id].display_history[:]
 
-    def get_histories(self, thread_id: Optional[str] = None) -> tuple[List[ChatCompletionMessageParam], List[ChatCompletionMessageParam]]:
+    def get_histories(self, thread_id: Optional[ThreadID] = None) -> tuple[List[ChatCompletionMessageParam], List[ChatCompletionMessageParam]]:
         """
         For backward compatibility: returns the LLM and display history of the newest thread.
         """
@@ -317,7 +317,7 @@ class GlobalMessageHistory:
             self._update_last_interaction(thread)
             self._save_thread_to_disk(thread)
 
-    def delete_thread(self, thread_id: str) -> bool:
+    def delete_thread(self, thread_id: ThreadID) -> bool:
         """
         Deletes a chat thread by its ID. Removes both the in-memory entry and the JSON file.
         Includes safety checks to ensure we're only deleting valid thread files.

--- a/mito-ai/mito_ai/models.py
+++ b/mito-ai/mito_ai/models.py
@@ -283,7 +283,7 @@ class ChatThreadMetadata:
     Chat thread item.
     """
 
-    thread_id: str
+    thread_id: ThreadID
 
     name: str
 
@@ -301,7 +301,7 @@ class StartNewChatReply:
     parent_id: str
 
     # Chat thread item.
-    thread_id: str
+    thread_id: ThreadID
 
     # Message type.
     type: Literal["reply"] = "reply"

--- a/mito-ai/mito_ai/models.py
+++ b/mito-ai/mito_ai/models.py
@@ -1,9 +1,12 @@
 import traceback
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional, Type, Union
+from typing import List, Literal, Optional, Type, Union, NewType
 from openai.types.chat import ChatCompletionMessageParam
 from enum import Enum
 from pydantic import BaseModel
+
+# The ThreadID is the unique identifier for the chat thread.
+ThreadID = NewType('ThreadID', str)
 
 @dataclass(frozen=True)
 class AIOptimizedCells():
@@ -21,6 +24,7 @@ class CellUpdate(BaseModel):
     index: Optional[int]
     id: Optional[str]
     code: str
+    description: str
 
 # Response format for agent planning
 class PlanOfAttack(BaseModel):

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -298,19 +298,6 @@ export class ChatHistoryManager {
         );
     }
 
-    addSystemMessage(message: string): void {
-        const systemMessage: OpenAI.Chat.ChatCompletionMessageParam = {
-            role: 'system',
-            content: message
-        }
-        this.displayOptimizedChatHistory.push({
-            message: systemMessage, 
-            type: 'openai message',
-            codeCellID: undefined,
-            promptType: 'chat'
-        });
-    }
-
     getLastAIMessageIndex = (): number | undefined => {
         const displayOptimizedChatHistory = this.getDisplayOptimizedHistory()
         const aiMessageIndexes = displayOptimizedChatHistory.map((chatEntry, index) => {

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -69,7 +69,6 @@ import DropdownMenu from '../../components/DropdownMenu';
 
 const getDefaultChatHistoryManager = (notebookTracker: INotebookTracker, contextManager: IContextManager): ChatHistoryManager => {
     const chatHistoryManager = new ChatHistoryManager(contextManager, notebookTracker)
-    chatHistoryManager.addSystemMessage('You are an expert Python programmer.')
     return chatHistoryManager
 }
 

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -800,8 +800,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     }
 
     const startNewChat = async (): Promise<ChatHistoryManager> => {
-        // If current thread is empty (only contains system message), do not create a new thread.
-        if (chatHistoryManagerRef.current.getDisplayOptimizedHistory().length <= 1) {
+        // If current thread is empty, do not create a new thread.
+        if (chatHistoryManagerRef.current.getDisplayOptimizedHistory().length === 0) {
             return chatHistoryManager;
         }
         // Reset frontend chat history

--- a/mito-ai/src/utils/websocket/models.ts
+++ b/mito-ai/src/utils/websocket/models.ts
@@ -20,13 +20,15 @@ export type AIOptimizedCell = {
 export type CellUpdateModification = {
   type: 'modification'
   id: string,
-  code: string
+  code: string,
+  description: string
 }
 
 export type CellUpdateNew = {
   type: 'new'
   index: number,
-  code: string
+  code: string,
+  descirption: string
 }
 
 export type CellUpdate = CellUpdateModification | CellUpdateNew

--- a/mito-ai/src/utils/websocket/models.ts
+++ b/mito-ai/src/utils/websocket/models.ts
@@ -21,14 +21,12 @@ export type CellUpdateModification = {
   type: 'modification'
   id: string,
   code: string,
-  description: string
 }
 
 export type CellUpdateNew = {
   type: 'new'
   index: number,
   code: string,
-  descirption: string
 }
 
 export type CellUpdate = CellUpdateModification | CellUpdateNew


### PR DESCRIPTION
# Description

- Moves the system prompt creation into the backend so we can create a different system prompt for different thread types. In the near future, we will create a big system prompt for agent mode.
- Creates a ThreadID type so we can more easily differentiate when an variable is a ThreadID and when it is just a string

# Testing

All tests are passing

# Documentation

None needed