### PR TITLE
mito-ai: bring back markdown code styling

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -21,6 +21,7 @@ import copyToClipboard from '../../../utils/copyToClipboard';
 import TextButton from '../../../components/TextButton';
 import { IDisplayOptimizedChatItem } from '../ChatHistoryManager';
 import '../../../../style/ChatMessage.css';
+import '../../../../style/MarkdownMessage.css'
 
 interface IChatMessageProps {
     message: OpenAI.Chat.ChatCompletionMessageParam

--- a/mito-ai/style/MarkdownMessage.css
+++ b/mito-ai/style/MarkdownMessage.css
@@ -1,0 +1,7 @@
+.markdown-message-part * .jp-RenderedHTMLCommon :not(pre) > code {
+    background-color: var(--purple-300);
+    color: var(--purple-700);
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+}


### PR DESCRIPTION
# Description

Brings back the styling for these code blocks in markdown. The styling got accidentally deleted in a refactor I did. 

![Screenshot 2025-03-14 at 2 14 05 PM](https://github.com/user-attachments/assets/87395c40-228d-410c-9182-ec73b35a7050)

At some point, we can add screenshot testing for things like this. 

# Testing

Just make sure that it works! 

# Documentation

Nope. 