### PR TITLE
Fix display prompts reconstruction on backend

### DIFF
--- a/mito-ai/mito_ai/completion_handlers/agent_auto_error_fixup_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/agent_auto_error_fixup_handler.py
@@ -26,10 +26,11 @@ class AgentAutoErrorFixupHandler(CompletionHandler[AgentSmartDebugMetadata]):
         
         # Create the prompt
         prompt = create_agent_smart_debug_prompt(metadata)
+        display_prompt = metadata.errorMessage
         
         # Add the prompt to the message history
         new_ai_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": prompt}
-        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": metadata.errorMessage}
+        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider)
         
         # Get the completion

--- a/mito-ai/mito_ai/completion_handlers/agent_execution_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/agent_execution_handler.py
@@ -26,10 +26,11 @@ class AgentExecutionHandler(CompletionHandler[AgentExecutionMetadata]):
         
         # Create the prompt
         prompt = create_agent_execution_prompt(metadata)
+        display_prompt = metadata.input
         
         # Add the prompt to the message history
         new_ai_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": prompt}
-        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": metadata.input}
+        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider)
         

--- a/mito-ai/mito_ai/completion_handlers/chat_completion_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/chat_completion_handler.py
@@ -31,10 +31,11 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
             metadata.activeCellCode or '', 
             metadata.input
         )
+        display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.input}"
         
         # Add the prompt to the message history
         new_ai_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": prompt}
-        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": metadata.input}
+        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider)
         
         # Get the completion

--- a/mito-ai/mito_ai/completion_handlers/code_explain_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/code_explain_handler.py
@@ -28,10 +28,11 @@ class CodeExplainHandler(CompletionHandler[CodeExplainMetadata]):
         
         # Create the prompt
         prompt = create_explain_code_prompt(active_cell_code)
+        display_prompt = f"```python{metadata.activeCellCode or ''}```Explain this code"
         
         # Add the prompt to the message history
         new_ai_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": prompt}
-        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": active_cell_code}
+        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider)
         
         # Get the completion

--- a/mito-ai/mito_ai/completion_handlers/smart_debug_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/smart_debug_handler.py
@@ -34,10 +34,11 @@ class SmartDebugHandler(CompletionHandler[SmartDebugMetadata]):
             variables,
             files
         )
+        display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.errorMessage}"
         
         # Add the prompt to the message history
         new_ai_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": prompt}
-        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": error_message}
+        new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider)
         
         # Get the completion


### PR DESCRIPTION
# Description

Display optimized messages were reconstructed from metadata incorrectly on the backend as a result of recent refactors of chat completions. The way the display prompts constructed diverged from the way they are constructed on the front end leading to change when restoring from chat history