### PR TITLE
Monthly limit

### DIFF
--- a/mito-ai/mito_ai/completion_handlers/open_ai_models.py
+++ b/mito-ai/mito_ai/completion_handlers/open_ai_models.py
@@ -2,15 +2,16 @@ from mito_ai.models import MessageType
 
 # Model name constants
 GPT4O_MINI = "gpt-4o-mini"
+GPT4O = "gpt-4o"
 O3_MINI = "o3-mini"
 
 # Mapping from message type to model name
 MESSAGE_TYPE_TO_MODEL = {
-    MessageType.SMART_DEBUG: GPT4O_MINI,
-    MessageType.CHAT: O3_MINI,
-    MessageType.CODE_EXPLAIN: GPT4O_MINI,
+    MessageType.SMART_DEBUG: GPT4O,
+    MessageType.CHAT: GPT4O,
+    MessageType.CODE_EXPLAIN: GPT4O,
     MessageType.INLINE_COMPLETION: GPT4O_MINI,
-    MessageType.AGENT_AUTO_ERROR_FIXUP: GPT4O_MINI,
-    MessageType.AGENT_EXECUTION: O3_MINI,
-    MessageType.CHAT_NAME_GENERATION: GPT4O_MINI
+    MessageType.AGENT_AUTO_ERROR_FIXUP: GPT4O,
+    MessageType.AGENT_EXECUTION: GPT4O,
+    MessageType.CHAT_NAME_GENERATION: GPT4O
 }

--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -26,8 +26,8 @@ from mito_ai.utils.open_ai_utils import (
     check_mito_server_quota,
     get_ai_completion_from_mito_server,
     get_open_ai_completion_function_params,
-    update_mito_server_quota,
 )
+from mito_ai.utils.server_limits import update_mito_server_quota
 
 from mito_ai.utils.telemetry_utils import (
     KEY_TYPE_PARAM,
@@ -162,7 +162,8 @@ This attribute is observed by the websocket provider to push the error to the cl
             )
 
         try:
-            check_mito_server_quota()
+            # Default to chat completion for capabilities check
+            check_mito_server_quota(MessageType.CHAT)
         except Exception as e:
             self.log.warning("Failed to set first usage date in user.json", exc_info=e)
             self.last_error = CompletionError.from_exception(e)
@@ -249,6 +250,7 @@ This attribute is observed by the websocket provider to push the error to the cl
                     completion_function_params,
                     self.timeout,
                     self.max_retries,
+                    message_type,
                 )
                 
                 update_mito_server_quota(message_type)

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -1,12 +1,16 @@
 import pytest
 from datetime import datetime
 from unittest.mock import patch
+from mito_ai.utils.server_limits import (
+    check_mito_server_quota,
+    OS_MONTHLY_AI_COMPLETIONS_LIMIT,
+    OS_MONTHLY_AUTOCOMPLETE_LIMIT,
+)
+from mito_ai.utils.telemetry_utils import MITO_SERVER_FREE_TIER_LIMIT_REACHED
+from mito_ai.models import MessageType
 from mito_ai.utils.open_ai_utils import (
     MITO_AI_PROD_URL,
     MITO_AI_URL,
-    MITO_SERVER_FREE_TIER_LIMIT_REACHED,
-    OPEN_SOURCE_AI_COMPLETIONS_LIMIT,
-    check_mito_server_quota,
 )
 
 REALLY_OLD_DATE = "2020-01-01"
@@ -14,44 +18,54 @@ TODAY = datetime.now().strftime("%Y-%m-%d")
 
 
 def test_check_mito_server_quota_open_source_user() -> None:
-    # Under both limits
-    with patch("mito_ai.utils.open_ai_utils.get_completion_count", return_value=1) as mock_count, \
-         patch("mito_ai.utils.open_ai_utils.get_first_completion_date", return_value=TODAY) as mock_date:
-        check_mito_server_quota()
+    # Under chat completions limit
+    with patch("mito_ai.utils.db.get_completion_count", return_value=1) as mock_count, \
+         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+        check_mito_server_quota(MessageType.CHAT)
         assert mock_count.called
         assert mock_date.called
         assert mock_count.return_value == 1
         assert mock_date.return_value == TODAY
 
-    # Over both limits
-    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED), \
-         patch("mito_ai.utils.open_ai_utils.get_completion_count", return_value=OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
-         patch("mito_ai.utils.open_ai_utils.get_first_completion_date", return_value=REALLY_OLD_DATE) as mock_date:
-        check_mito_server_quota()
+    # Under autocomplete limit
+    with patch("mito_ai.utils.db.get_autocomplete_count", return_value=1) as mock_count, \
+         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+        check_mito_server_quota(MessageType.INLINE_COMPLETION)
         assert mock_count.called
         assert mock_date.called
-        assert mock_count.return_value == OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1
-        assert mock_date.return_value == REALLY_OLD_DATE
+        assert mock_count.return_value == 1
+        assert mock_date.return_value == TODAY
 
-    # Over the chat limit
-    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED), \
-         patch("mito_ai.utils.open_ai_utils.get_completion_count", return_value=OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1), \
-         patch("mito_ai.utils.open_ai_utils.get_first_completion_date", return_value=TODAY):
-        check_mito_server_quota()
+    # Over chat completions limit
+    with pytest.raises(PermissionError), \
+         patch("mito_ai.utils.db.get_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
+         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+        check_mito_server_quota(MessageType.CHAT)
+        assert mock_count.called
+        assert mock_date.called
+        assert mock_count.return_value == OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1
+        assert mock_date.return_value == TODAY
 
-    # Over the inline limit
-    with pytest.raises(PermissionError, match=MITO_SERVER_FREE_TIER_LIMIT_REACHED), \
-         patch("mito_ai.utils.open_ai_utils.get_completion_count", return_value=1), \
-         patch("mito_ai.utils.open_ai_utils.get_first_completion_date", return_value=REALLY_OLD_DATE):
-        check_mito_server_quota()
+    # Over autocomplete limit
+    with pytest.raises(PermissionError), \
+         patch("mito_ai.utils.db.get_autocomplete_count", return_value=OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1) as mock_count, \
+         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+        check_mito_server_quota(MessageType.INLINE_COMPLETION)
+        assert mock_count.called
+        assert mock_date.called
+        assert mock_count.return_value == OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1
+        assert mock_date.return_value == TODAY
 
 
 def test_check_mito_server_quota_pro_user() -> None:
     # No error should be thrown since pro users don't have limits
-    with patch("mito_ai.utils.open_ai_utils.is_pro", return_value=True), \
-         patch("mito_ai.utils.db.get_completion_count", return_value=OPEN_SOURCE_AI_COMPLETIONS_LIMIT + 1), \
-         patch("mito_ai.utils.db.get_first_completion_date", return_value=REALLY_OLD_DATE):
-        check_mito_server_quota()
+    with patch("mito_ai.utils.version_utils.is_pro", return_value=True), \
+         patch("mito_ai.utils.db.get_completion_count", return_value=1000), \
+         patch("mito_ai.utils.db.get_last_reset_date", return_value=REALLY_OLD_DATE):
+        check_mito_server_quota(MessageType.CHAT)
+
 
 def test_mito_ai_url_is_prod_url() -> None:
+    # This test ensures that the MITO_AI_URL is set to the prod URL 
+    # before merging into dev.
     assert MITO_AI_URL == MITO_AI_PROD_URL

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -19,7 +19,7 @@ TODAY = datetime.now().strftime("%Y-%m-%d")
 
 def test_check_mito_server_quota_open_source_user() -> None:
     # Under chat completions limit
-    with patch("mito_ai.utils.db.get_completion_count", return_value=1) as mock_count, \
+    with patch("mito_ai.utils.db.get_chat_completion_count", return_value=1) as mock_count, \
          patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
         check_mito_server_quota(MessageType.CHAT)
         assert mock_count.called
@@ -38,7 +38,7 @@ def test_check_mito_server_quota_open_source_user() -> None:
 
     # Over chat completions limit
     with pytest.raises(PermissionError), \
-         patch("mito_ai.utils.db.get_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
+         patch("mito_ai.utils.db.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
          patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
         check_mito_server_quota(MessageType.CHAT)
         assert mock_count.called
@@ -60,7 +60,7 @@ def test_check_mito_server_quota_open_source_user() -> None:
 def test_check_mito_server_quota_pro_user() -> None:
     # No error should be thrown since pro users don't have limits
     with patch("mito_ai.utils.version_utils.is_pro", return_value=True), \
-         patch("mito_ai.utils.db.get_completion_count", return_value=1000), \
+         patch("mito_ai.utils.db.get_chat_completion_count", return_value=1000), \
          patch("mito_ai.utils.db.get_last_reset_date", return_value=REALLY_OLD_DATE):
         check_mito_server_quota(MessageType.CHAT)
 

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -19,8 +19,10 @@ TODAY = datetime.now().strftime("%Y-%m-%d")
 
 def test_check_mito_server_quota_open_source_user() -> None:
     # Under chat completions limit
-    with patch("mito_ai.utils.db.get_chat_completion_count", return_value=1) as mock_count, \
-         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+    with patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1) as mock_count, \
+         patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=TODAY) as mock_date, \
+         patch("mito_ai.utils.server_limits.is_pro", return_value=False):
+        
         check_mito_server_quota(MessageType.CHAT)
         assert mock_count.called
         assert mock_date.called
@@ -28,8 +30,10 @@ def test_check_mito_server_quota_open_source_user() -> None:
         assert mock_date.return_value == TODAY
 
     # Under autocomplete limit
-    with patch("mito_ai.utils.db.get_autocomplete_count", return_value=1) as mock_count, \
-         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+    with patch("mito_ai.utils.server_limits.get_autocomplete_count", return_value=1) as mock_count, \
+         patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=TODAY) as mock_date, \
+         patch("mito_ai.utils.server_limits.is_pro", return_value=False):
+        
         check_mito_server_quota(MessageType.INLINE_COMPLETION)
         assert mock_count.called
         assert mock_date.called
@@ -38,8 +42,10 @@ def test_check_mito_server_quota_open_source_user() -> None:
 
     # Over chat completions limit
     with pytest.raises(PermissionError), \
-         patch("mito_ai.utils.db.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
-         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+         patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1) as mock_count, \
+         patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=TODAY) as mock_date, \
+         patch("mito_ai.utils.server_limits.is_pro", return_value=False):
+        
         check_mito_server_quota(MessageType.CHAT)
         assert mock_count.called
         assert mock_date.called
@@ -48,8 +54,10 @@ def test_check_mito_server_quota_open_source_user() -> None:
 
     # Over autocomplete limit
     with pytest.raises(PermissionError), \
-         patch("mito_ai.utils.db.get_autocomplete_count", return_value=OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1) as mock_count, \
-         patch("mito_ai.utils.db.get_last_reset_date", return_value=TODAY) as mock_date:
+         patch("mito_ai.utils.server_limits.get_autocomplete_count", return_value=OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1) as mock_count, \
+         patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=TODAY) as mock_date, \
+         patch("mito_ai.utils.server_limits.is_pro", return_value=False):
+        
         check_mito_server_quota(MessageType.INLINE_COMPLETION)
         assert mock_count.called
         assert mock_date.called
@@ -60,8 +68,9 @@ def test_check_mito_server_quota_open_source_user() -> None:
 def test_check_mito_server_quota_pro_user() -> None:
     # No error should be thrown since pro users don't have limits
     with patch("mito_ai.utils.version_utils.is_pro", return_value=True), \
-         patch("mito_ai.utils.db.get_chat_completion_count", return_value=1000), \
-         patch("mito_ai.utils.db.get_last_reset_date", return_value=REALLY_OLD_DATE):
+         patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1000), \
+         patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=REALLY_OLD_DATE):
+        
         check_mito_server_quota(MessageType.CHAT)
 
 

--- a/mito-ai/mito_ai/tests/open_ai_utils_test.py
+++ b/mito-ai/mito_ai/tests/open_ai_utils_test.py
@@ -67,7 +67,7 @@ def test_check_mito_server_quota_open_source_user() -> None:
 
 def test_check_mito_server_quota_pro_user() -> None:
     # No error should be thrown since pro users don't have limits
-    with patch("mito_ai.utils.version_utils.is_pro", return_value=True), \
+    with patch("mito_ai.utils.server_limits.is_pro", return_value=True), \
          patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1000), \
          patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=REALLY_OLD_DATE):
         

--- a/mito-ai/mito_ai/tests/server_limits_test.py
+++ b/mito-ai/mito_ai/tests/server_limits_test.py
@@ -1,0 +1,198 @@
+import os
+from datetime import datetime
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+from mito_ai.models import MessageType
+from mito_ai.utils.server_limits import (
+    OS_MONTHLY_AI_COMPLETIONS_LIMIT,
+    OS_MONTHLY_AUTOCOMPLETE_LIMIT,
+    check_mito_server_quota,
+    UJ_AI_MITO_API_NUM_USAGES,
+    UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES,
+    UJ_MITO_AI_LAST_RESET_DATE
+)
+from mito_ai.utils.telemetry_utils import MITO_SERVER_FREE_TIER_LIMIT_REACHED
+
+# Constants for testing
+CURRENT_DATE = datetime.now().strftime("%Y-%m-%d")
+OLD_DATE = "2020-01-01"
+FUTURE_DATE = (datetime.now().replace(year=datetime.now().year + 1)).strftime("%Y-%m-%d")
+
+# Each test case is a tuple of:
+# (is_pro, chat_completion_count, autocomplete_count, last_reset_date, message_type, should_raise_error)
+
+# 1. Open Source Subscription Tests
+OS_SUBSCRIPTION_TESTS = [
+    # Below both limits
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.CHAT, False),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+    
+    # Above AI completions limit only
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.CHAT, True),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+    
+    # Above autocomplete limit only
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1, CURRENT_DATE, MessageType.CHAT, False),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, True),
+    
+    # Above both limits
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1, CURRENT_DATE, MessageType.CHAT, True),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, True),
+    
+    # Equal to limits
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.CHAT, True),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT, CURRENT_DATE, MessageType.CHAT, False),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT, CURRENT_DATE, MessageType.INLINE_COMPLETION, True),
+]
+
+# 2. Pro Subscription Tests
+PRO_SUBSCRIPTION_TESTS = [
+    # Pro user below limits
+    (True, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.CHAT, False),
+    (True, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+    
+    # Pro user above limits - should still not raise error
+    (True, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 100, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 100, CURRENT_DATE, MessageType.CHAT, False),
+    (True, OS_MONTHLY_AI_COMPLETIONS_LIMIT + 100, OS_MONTHLY_AUTOCOMPLETE_LIMIT + 100, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+]
+
+# 3. Error Handling Tests - Note: None values are replaced in the test function
+ERROR_HANDLING_TESTS = [
+    # Missing last reset date - should not raise error and set the date
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, None, MessageType.CHAT, False),
+    (False, OS_MONTHLY_AI_COMPLETIONS_LIMIT - 1, OS_MONTHLY_AUTOCOMPLETE_LIMIT - 1, None, MessageType.INLINE_COMPLETION, False),
+]
+
+# 4. Edge Cases
+EDGE_CASE_TESTS = [
+    # Negative counts - should be treated as below limit
+    (False, -10, -10, CURRENT_DATE, MessageType.CHAT, False),
+    (False, -10, -10, CURRENT_DATE, MessageType.INLINE_COMPLETION, False),
+]
+
+# Combine all tests
+ALL_TEST_CASES = OS_SUBSCRIPTION_TESTS + PRO_SUBSCRIPTION_TESTS + ERROR_HANDLING_TESTS + EDGE_CASE_TESTS
+
+@pytest.mark.parametrize(
+    "is_pro, chat_completion_count, autocomplete_count, last_reset_date, message_type, should_raise_error",
+    ALL_TEST_CASES
+)
+def test_check_mito_server_quota(is_pro, chat_completion_count, autocomplete_count, last_reset_date, message_type, should_raise_error):
+    """Test the check_mito_server_quota function with various combinations of inputs."""
+    
+    # Create the patch context managers
+    patches = [
+        patch("mito_ai.utils.server_limits.is_pro", return_value=is_pro),
+        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=chat_completion_count),
+        patch("mito_ai.utils.server_limits.get_autocomplete_count", return_value=autocomplete_count),
+        patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=last_reset_date),
+    ]
+    
+    # Add set_user_field mock if needed for None values
+    if last_reset_date is None:
+        patches.append(patch("mito_ai.utils.server_limits.set_user_field"))
+    
+    # Apply all patches
+    for p in patches:
+        p.start()
+    
+    try:
+        if should_raise_error:
+            # Should raise PermissionError
+            with pytest.raises(PermissionError) as exc_info:
+                check_mito_server_quota(message_type)
+            assert str(exc_info.value) == MITO_SERVER_FREE_TIER_LIMIT_REACHED
+        else:
+            # Should not raise any error
+            check_mito_server_quota(message_type)
+    finally:
+        # Stop all patches
+        for p in patches:
+            p.stop()
+
+# New dedicated test cases for date-related reset behavior
+# Each test case is a tuple of:
+# (reset_date, is_pro, message_type, should_reset)
+DATE_RESET_TEST_CASES = [
+    # Old date should trigger reset for both message types
+    (OLD_DATE, False, MessageType.CHAT, True),
+    (OLD_DATE, False, MessageType.INLINE_COMPLETION, True),
+    
+    # Pro user with old date should not trigger reset (they have no limits)
+    (OLD_DATE, True, MessageType.CHAT, False),
+    (OLD_DATE, True, MessageType.INLINE_COMPLETION, False),
+    
+    # Current date should not trigger reset
+    (CURRENT_DATE, False, MessageType.CHAT, False),
+    (CURRENT_DATE, False, MessageType.INLINE_COMPLETION, False),
+    
+    # Future date should not trigger reset
+    (FUTURE_DATE, False, MessageType.CHAT, False),
+    (FUTURE_DATE, False, MessageType.INLINE_COMPLETION, False),
+]
+
+@pytest.mark.parametrize(
+    "reset_date, is_pro, message_type, should_reset",
+    DATE_RESET_TEST_CASES
+)
+def test_date_triggers_reset(reset_date, is_pro, message_type, should_reset):
+    """
+    Test whether different dates trigger counter reset operations.
+    Rather than checking downstream behavior, directly verify the reset operation occurs.
+    """
+    # Mock set_user_field to track calls
+    mock_set_user_field = MagicMock()
+    
+    with (
+        patch("mito_ai.utils.server_limits.is_pro", return_value=is_pro),
+        patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=reset_date),
+        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1),
+        patch("mito_ai.utils.server_limits.get_autocomplete_count", return_value=1),
+        patch("mito_ai.utils.server_limits.set_user_field", mock_set_user_field)
+    ):
+        # Call the function
+        check_mito_server_quota(message_type)
+        
+        # Verify whether reset was triggered based on expectations
+        reset_calls = [
+            call(UJ_AI_MITO_API_NUM_USAGES, 0),
+            call(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+        ]
+        
+        if should_reset:
+            # Check that the API usages and autocomplete usages were reset to 0
+            # The format is slightly different because of how we're building the calls list
+            for reset_call in reset_calls:
+                assert reset_call in mock_set_user_field.call_args_list, f"Expected reset call {reset_call} not found"
+            
+            # Also verify that the reset date was updated
+            assert any(call[0][0] == UJ_MITO_AI_LAST_RESET_DATE for call in mock_set_user_field.call_args_list), "Reset date was not updated"
+        else:
+            # For cases that shouldn't reset, verify the reset calls were NOT made
+            # If we're setting a missing date (None), we'll still see calls, but they won't be resets
+            if reset_date is not None:
+                for reset_call in reset_calls:
+                    assert reset_call not in mock_set_user_field.call_args_list, f"Unexpected reset call {reset_call} found"
+
+# Special test cases that require specific patching of constants
+def test_zero_limits_configured():
+    """Test when limits are configured as zero."""
+    with (
+        patch("mito_ai.utils.server_limits.OS_MONTHLY_AI_COMPLETIONS_LIMIT", 0),
+        patch("mito_ai.utils.server_limits.OS_MONTHLY_AUTOCOMPLETE_LIMIT", 0),
+        patch("mito_ai.utils.server_limits.is_pro", return_value=False),
+        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1),
+        patch("mito_ai.utils.server_limits.get_autocomplete_count", return_value=1),
+        patch("mito_ai.utils.server_limits.get_last_reset_date", return_value=CURRENT_DATE)
+    ):
+        # Test with chat completion - should raise error
+        with pytest.raises(PermissionError) as exc_info:
+            check_mito_server_quota(MessageType.CHAT)
+        assert str(exc_info.value) == MITO_SERVER_FREE_TIER_LIMIT_REACHED
+        
+        # Test with inline completion - should raise error
+        with pytest.raises(PermissionError) as exc_info:
+            check_mito_server_quota(MessageType.INLINE_COMPLETION)
+        assert str(exc_info.value) == MITO_SERVER_FREE_TIER_LIMIT_REACHED

--- a/mito-ai/mito_ai/utils/db.py
+++ b/mito-ai/mito_ai/utils/db.py
@@ -37,7 +37,7 @@ def set_user_field(field: str, value: Any) -> None:
         with open(USER_JSON_PATH, 'w+') as f:
             f.write(json.dumps(old_user_json))
             
-def get_completion_count() -> int:
+def get_chat_completion_count() -> int:
     """
     Returns the number of AI completions the user has made in the current 30-day period.
     

--- a/mito-ai/mito_ai/utils/db.py
+++ b/mito-ai/mito_ai/utils/db.py
@@ -4,7 +4,13 @@ Helpers for accessing the user.json file
 import os
 import json
 from typing import Any, Optional, Final
-from mito_ai.utils.schema import MITO_FOLDER, UJ_AI_MITO_API_NUM_USAGES, UJ_MITO_AI_FIRST_USAGE_DATE
+from mito_ai.utils.schema import (
+    MITO_FOLDER, 
+    UJ_AI_MITO_API_NUM_USAGES, 
+    UJ_MITO_AI_FIRST_USAGE_DATE, 
+    UJ_MITO_AI_LAST_RESET_DATE,
+    UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES
+)
 
 # The path of the user.json file
 USER_JSON_PATH: Final[str] = os.path.join(MITO_FOLDER, 'user.json')
@@ -33,16 +39,33 @@ def set_user_field(field: str, value: Any) -> None:
             
 def get_completion_count() -> int:
     """
-    Returns the number of AI completions the user has made.
+    Returns the number of AI completions the user has made in the current 30-day period.
     
     Using this helper function lets us mock the number of completions in tests.
     """
     return get_user_field(UJ_AI_MITO_API_NUM_USAGES) or 0
 
-def get_first_completion_date() -> str:
+def get_autocomplete_count() -> int:
+    """
+    Returns the number of autocomplete completions the user has made in the current 30-day period.
+    
+    Using this helper function lets us mock the number of autocomplete completions in tests.
+    """
+    return get_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES) or 0
+
+def get_first_completion_date() -> Optional[str]:
     """
     Returns the date of the user's last completion in YYYY-MM-DD format.
     
     Using this helper function lets us mock the date of the first completion in tests.
     """
-    return get_user_field(UJ_MITO_AI_FIRST_USAGE_DATE) or ""
+    return get_user_field(UJ_MITO_AI_FIRST_USAGE_DATE) or None
+
+def get_last_reset_date() -> Optional[str]:
+    """
+    Returns the date of the user's last reset in YYYY-MM-DD format.
+    Both chat completions and autocomplete share the same reset date.
+    
+    Using this helper function lets us mock the date of the last reset in tests.
+    """
+    return get_user_field(UJ_MITO_AI_LAST_RESET_DATE) or None

--- a/mito-ai/mito_ai/utils/schema.py
+++ b/mito-ai/mito_ai/utils/schema.py
@@ -30,7 +30,9 @@ UJ_EXPERIMENT = 'experiment'
 UJ_RECEIVED_CHECKLISTS = 'received_checklists'
 UJ_AI_PRIVACY_POLICY = 'ai_privacy_policy'
 UJ_AI_MITO_API_NUM_USAGES = 'ai_mito_api_num_usages'
+UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES = 'ai_mito_autocomplete_num_usages'
 UJ_MITO_AI_FIRST_USAGE_DATE = 'mito_ai_first_usage_date'
+UJ_MITO_AI_LAST_RESET_DATE = 'mito_ai_last_reset_date'
 
 MITO_CONFIG_KEY_HOME_FOLDER = 'MITO_CONFIG_HOME_FOLDER'
 if MITO_CONFIG_KEY_HOME_FOLDER in os.environ:
@@ -71,7 +73,9 @@ USER_JSON_VERSION_10 = {
     UJ_RECEIVED_CHECKLISTS: {},
     UJ_AI_PRIVACY_POLICY: False,
     UJ_AI_MITO_API_NUM_USAGES: 0,
+    UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES: 0,
     UJ_MITO_AI_FIRST_USAGE_DATE: datetime.today().strftime('%Y-%m-%d'),
+    UJ_MITO_AI_LAST_RESET_DATE: datetime.today().strftime('%Y-%m-%d'),
 }
 
 # This is the most up to date user json, and you must update it when

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -1,6 +1,6 @@
 from typing import Final
 from mito_ai.utils.db import (
-    get_completion_count, 
+    get_chat_completion_count, 
     get_autocomplete_count,
     get_first_completion_date, 
     get_last_reset_date,
@@ -40,6 +40,7 @@ def check_mito_server_quota(message_type: MessageType) -> None:
     or we will no longer be able to provide this free tier.
     """
     if is_pro():
+        print('pro')
         return
 
     # Get current date
@@ -53,6 +54,7 @@ def check_mito_server_quota(message_type: MessageType) -> None:
         set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
         set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
         set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+        print('no last reset date')
         return
     
     # Convert the last reset date string to a datetime object
@@ -66,7 +68,7 @@ def check_mito_server_quota(message_type: MessageType) -> None:
         set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
         set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
         set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
-    
+        print('reset')
     # Check the appropriate limit based on message type
     if message_type == MessageType.INLINE_COMPLETION:
         # Check autocomplete limit
@@ -76,12 +78,16 @@ def check_mito_server_quota(message_type: MessageType) -> None:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
             raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
     else:
+        print('not inline completion')
         # Check chat completion limit
-        completion_count = get_completion_count()
+        completion_count = get_chat_completion_count()
+        print('completion count', completion_count)
         
         if completion_count >= OS_MONTHLY_AI_COMPLETIONS_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
             raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+        
+    print('no error')
 
 def update_mito_server_quota(message_type: MessageType) -> None:
     """
@@ -133,7 +139,7 @@ def update_mito_server_quota(message_type: MessageType) -> None:
             raise e
     else:
         # Increment chat completion count
-        completion_count = get_completion_count()
+        completion_count = get_chat_completion_count()
         if completion_count is None:
             completion_count = 0
         completion_count = completion_count + 1

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -26,8 +26,9 @@ or we will no longer be able to provide this free tier.
 """
 # Monthly chat completions limit for free tier users
 OS_MONTHLY_AI_COMPLETIONS_LIMIT: Final[int] = 30
+
 # Monthly autocomplete limit for free tier users
-OS_MONTHLY_AUTOCOMPLETE_LIMIT: Final[int] = 500 
+OS_MONTHLY_AUTOCOMPLETE_LIMIT: Final[int] = 5000
 
 def check_mito_server_quota(message_type: MessageType) -> None:
     """

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -72,7 +72,6 @@ def check_mito_server_quota(message_type: MessageType) -> None:
     if message_type == MessageType.INLINE_COMPLETION:
         # Check autocomplete limit
         autocomplete_count = get_autocomplete_count()
-        print('autocomplete_count', autocomplete_count)
         
         if autocomplete_count >= OS_MONTHLY_AUTOCOMPLETE_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
@@ -80,7 +79,6 @@ def check_mito_server_quota(message_type: MessageType) -> None:
     else:
         # Check chat completion limit
         completion_count = get_chat_completion_count()
-        print('completion_count', completion_count)
         
         if completion_count >= OS_MONTHLY_AI_COMPLETIONS_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -1,0 +1,146 @@
+from typing import Final
+from mito_ai.utils.db import (
+    get_completion_count, 
+    get_autocomplete_count,
+    get_first_completion_date, 
+    get_last_reset_date,
+    get_user_field, 
+    set_user_field
+)
+from mito_ai.utils.schema import (
+    UJ_MITO_AI_FIRST_USAGE_DATE, 
+    UJ_AI_MITO_API_NUM_USAGES, 
+    UJ_MITO_AI_LAST_RESET_DATE,
+    UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES
+)
+from mito_ai.utils.telemetry_utils import (MITO_SERVER_FREE_TIER_LIMIT_REACHED, log)
+from mito_ai.utils.version_utils import is_pro
+from mito_ai.models import MessageType
+from datetime import datetime, timedelta
+
+"""
+IT IS EXPRESSLY AGAINST THE SOFTWARE LICENSE TO MODIFY, BYPASS, OR OTHERWISE
+CIRCUMVENT THE QUOTA LIMITS OF THE FREE TIER. We want to provide users with a 
+free tier, but running AI models is expensive, so we need to limit the usage 
+or we will no longer be able to provide this free tier.
+"""
+# Monthly chat completions limit for free tier users
+OS_MONTHLY_AI_COMPLETIONS_LIMIT: Final[int] = 30
+# Monthly autocomplete limit for free tier users
+OS_MONTHLY_AUTOCOMPLETE_LIMIT: Final[int] = 500 
+
+def check_mito_server_quota(message_type: MessageType) -> None:
+    """
+    Checks if the user has exceeded their Mito server quota. Pro users have no limits.
+    Raises PermissionError if the user has exceeded their quota.
+    
+    IT IS EXPRESSLY AGAINST THE SOFTWARE LICENSE TO MODIFY, BYPASS, OR OTHERWISE
+    CIRCUMVENT THE QUOTA LIMITS OF THE FREE TIER. We want to provide users with a 
+    free tier, but running AI models is expensive, so we need to limit the usage 
+    or we will no longer be able to provide this free tier.
+    """
+    if is_pro():
+        return
+
+    # Get current date
+    current_date = datetime.now()
+    
+    # Get the date when the last reset occurred
+    last_reset_date_str = get_last_reset_date()
+        
+    # If no last reset date is found, set it to today and reset both counters
+    if last_reset_date_str is None:
+        set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
+        set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
+        set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+        return
+    
+    # Convert the last reset date string to a datetime object
+    last_reset_date = datetime.strptime(last_reset_date_str, "%Y-%m-%d")
+    
+    # Calculate the date one month from the last reset
+    one_month_later = last_reset_date + timedelta(days=30)  # Approximating a month as 30 days
+    
+    # If it's been more than a month since the last reset, reset both counters
+    if current_date >= one_month_later:
+        set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
+        set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+        set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
+    
+    # Check the appropriate limit based on message type
+    if message_type == MessageType.INLINE_COMPLETION:
+        # Check autocomplete limit
+        autocomplete_count = get_autocomplete_count()
+        
+        if autocomplete_count >= OS_MONTHLY_AUTOCOMPLETE_LIMIT:
+            log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+            raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+    else:
+        # Check chat completion limit
+        completion_count = get_completion_count()
+        
+        if completion_count >= OS_MONTHLY_AI_COMPLETIONS_LIMIT:
+            log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+            raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
+
+def update_mito_server_quota(message_type: MessageType) -> None:
+    """
+    Update the user's quota for the Mito Server.
+    
+    IT IS EXPRESSLY AGAINST THE SOFTWARE LICENSE TO MODIFY, BYPASS, OR OTHERWISE
+    CIRCUMVENT THE QUOTA LIMITS OF THE FREE TIER. We want to provide users with a 
+    free tier, but running AI models is expensive, so we need to limit the usage 
+    or we will no longer be able to provide this free tier.
+    """
+    
+    current_date = datetime.now()
+    first_usage_date = get_first_completion_date()
+    last_reset_date_str = get_last_reset_date()
+    
+    if first_usage_date is None:
+        first_usage_date = current_date.strftime("%Y-%m-%d")
+        set_user_field(UJ_MITO_AI_FIRST_USAGE_DATE, first_usage_date)
+    
+    # Initialize the reset date if it doesn't exist
+    if last_reset_date_str is None:
+        last_reset_date_str = current_date.strftime("%Y-%m-%d")
+        set_user_field(UJ_MITO_AI_LAST_RESET_DATE, last_reset_date_str)
+    else:
+        # Convert the last reset date string to a datetime object
+        last_reset_date = datetime.strptime(last_reset_date_str, "%Y-%m-%d")
+        
+        # Calculate the date one month from the last reset
+        one_month_later = last_reset_date + timedelta(days=30)
+        
+        # If it's been more than a month since the last reset, reset both counters
+        if current_date >= one_month_later:
+            set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
+            set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+            last_reset_date_str = current_date.strftime("%Y-%m-%d")
+            set_user_field(UJ_MITO_AI_LAST_RESET_DATE, last_reset_date_str)
+    
+    # Update the appropriate usage counter based on message type
+    if message_type == MessageType.INLINE_COMPLETION:
+        # Increment autocomplete count
+        autocomplete_count = get_autocomplete_count()
+        if autocomplete_count is None:
+            autocomplete_count = 0
+        autocomplete_count = autocomplete_count + 1
+        
+        try:
+            set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, autocomplete_count)
+        except Exception as e:
+            raise e
+    else:
+        # Increment chat completion count
+        completion_count = get_completion_count()
+        if completion_count is None:
+            completion_count = 0
+        completion_count = completion_count + 1
+        
+        try:
+            set_user_field(UJ_AI_MITO_API_NUM_USAGES, completion_count)
+            set_user_field(UJ_MITO_AI_FIRST_USAGE_DATE, first_usage_date)
+        except Exception as e:
+            raise e
+        

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -108,19 +108,20 @@ def update_mito_server_quota(message_type: MessageType) -> None:
     if last_reset_date_str is None:
         last_reset_date_str = current_date.strftime("%Y-%m-%d")
         set_user_field(UJ_MITO_AI_LAST_RESET_DATE, last_reset_date_str)
-    else:
-        # Convert the last reset date string to a datetime object
-        last_reset_date = datetime.strptime(last_reset_date_str, "%Y-%m-%d")
         
-        # Calculate the date one month from the last reset
-        one_month_later = last_reset_date + timedelta(days=30)
-        
-        # If it's been more than a month since the last reset, reset both counters
-        if current_date >= one_month_later:
-            set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
-            set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
-            last_reset_date_str = current_date.strftime("%Y-%m-%d")
-            set_user_field(UJ_MITO_AI_LAST_RESET_DATE, last_reset_date_str)
+    # Convert the last reset date string to a datetime object
+    last_reset_date = datetime.strptime(last_reset_date_str, "%Y-%m-%d")
+    
+    # Calculate the date one month from the last reset
+    one_month_later = last_reset_date + timedelta(days=30)
+    
+    # If it's been more than a month since the last reset, reset both counters
+    # and make today's date the new reset date
+    if current_date >= one_month_later:
+        set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
+        set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
+        last_reset_date_str = current_date.strftime("%Y-%m-%d")
+        set_user_field(UJ_MITO_AI_LAST_RESET_DATE, last_reset_date_str)
     
     # Update the appropriate usage counter based on message type
     if message_type == MessageType.INLINE_COMPLETION:

--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -40,7 +40,6 @@ def check_mito_server_quota(message_type: MessageType) -> None:
     or we will no longer be able to provide this free tier.
     """
     if is_pro():
-        print('pro')
         return
 
     # Get current date
@@ -54,7 +53,6 @@ def check_mito_server_quota(message_type: MessageType) -> None:
         set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
         set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
         set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
-        print('no last reset date')
         return
     
     # Convert the last reset date string to a datetime object
@@ -68,26 +66,25 @@ def check_mito_server_quota(message_type: MessageType) -> None:
         set_user_field(UJ_AI_MITO_API_NUM_USAGES, 0)
         set_user_field(UJ_AI_MITO_AUTOCOMPLETE_NUM_USAGES, 0)
         set_user_field(UJ_MITO_AI_LAST_RESET_DATE, current_date.strftime("%Y-%m-%d"))
-        print('reset')
+        
     # Check the appropriate limit based on message type
     if message_type == MessageType.INLINE_COMPLETION:
         # Check autocomplete limit
         autocomplete_count = get_autocomplete_count()
+        print('autocomplete_count', autocomplete_count)
         
         if autocomplete_count >= OS_MONTHLY_AUTOCOMPLETE_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
             raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
     else:
-        print('not inline completion')
         # Check chat completion limit
         completion_count = get_chat_completion_count()
-        print('completion count', completion_count)
+        print('completion_count', completion_count)
         
         if completion_count >= OS_MONTHLY_AI_COMPLETIONS_LIMIT:
             log(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
             raise PermissionError(MITO_SERVER_FREE_TIER_LIMIT_REACHED)
         
-    print('no error')
 
 def update_mito_server_quota(message_type: MessageType) -> None:
     """

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -15,11 +15,11 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
         return (
             <div className="chat-message-alert">
                 <p>
-                    Your Mito AI free trial has ended. To continue using Mito AI, upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> and get access to:
+                    You've used up your free trial of Mito AI for this month. To continue using Mito AI now, upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> and get access to:
                 </p>
                 <ul>
-                    <li>Unlimited AI Completions</li>
-                    <li>Advanced reasoning with o3 models</li>
+                    <li>Unlimited AI Chat and Agent</li>
+                    <li>Unlimited AI Autocompletes</li>
                     <li>All Mito Spreadsheet Pro features</li>
                 </ul>
                 <p>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -15,7 +15,7 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
         return (
             <div className="chat-message-alert">
                 <p>
-                    You've used up your free trial of Mito AI for this month. To continue using Mito AI now, upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> and get access to:
+                    You&apos;ve used up your free trial of Mito AI for this month. To continue using Mito AI now, upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> and get access to:
                 </p>
                 <ul>
                     <li>Unlimited AI Chat and Agent</li>

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -296,7 +296,7 @@ export class MitoAIInlineCompleter
   }
 
   private _notifyFreeTierLimitReached(): void {
-    Notification.emit(`Your Mito AI free trial ended. Upgrade to Mito Pro to access advanced models and continue using Mito AI or supply your own key.`, 'error', {
+    Notification.emit(`You've used up your free Mito AI completions for this month. Upgrade to Mito Pro to or supply your own key.`, 'error', {
       autoClose: false,
       actions: [
         {

--- a/mito-ai/src/Extensions/status/index.tsx
+++ b/mito-ai/src/Extensions/status/index.tsx
@@ -81,7 +81,7 @@ class StatusPopUp extends VDomRenderer<StatusModel> {
         {this.model.lastError?.title == FREE_TIER_LIMIT_REACHED_ERROR_TITLE && (
           <>
             <p>
-              ⚠️ You've used up your free Mito AI completions for this month. Upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> or supply your own Open AI Key to continue using Mito AI.
+              ⚠️ You&apos;ve used up your free Mito AI completions for this month. Upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> or supply your own Open AI Key to continue using Mito AI.
             </p>
             <TextButton
               title="Upgrade to Pro"

--- a/mito-ai/src/Extensions/status/index.tsx
+++ b/mito-ai/src/Extensions/status/index.tsx
@@ -81,7 +81,7 @@ class StatusPopUp extends VDomRenderer<StatusModel> {
         {this.model.lastError?.title == FREE_TIER_LIMIT_REACHED_ERROR_TITLE && (
           <>
             <p>
-              ⚠️ Your Mito AI free trial has ended. Upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> or supply your own Open AI Key to get access to more advanced models and continue using Mito AI.
+              ⚠️ You've used up your free Mito AI completions for this month. Upgrade to <a href="https://www.trymito.io/plans" target="_blank" rel="noreferrer">Mito Pro</a> or supply your own Open AI Key to continue using Mito AI.
             </p>
             <TextButton
               title="Upgrade to Pro"

--- a/mito-ai/style/ChatMessage.css
+++ b/mito-ai/style/ChatMessage.css
@@ -140,6 +140,7 @@
   border-radius: 5px;
   padding: 10px;
   border: 1px solid var(--purple-500);
+  color: var(--grey-900);
 }
 
 .chat-message-alert a {

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -381,7 +381,7 @@ const Plans: NextPage = () => {
                 <div className={plansStyles.plan_bullets_container}> 
                   <PlanBullet>
                     <p>
-                      One month trial with 500 Chats
+                      30 AI Chat and Agent Usages
                     </p>
                   </PlanBullet>
                   <PlanBullet>

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -381,7 +381,12 @@ const Plans: NextPage = () => {
                 <div className={plansStyles.plan_bullets_container}> 
                   <PlanBullet>
                     <p>
-                      30 AI Chat and Agent Usages
+                      50 AI Completions per month
+                    </p>
+                  </PlanBullet>
+                  <PlanBullet>
+                    <p>
+                      AI Chat, Agent, and Autocomplete
                     </p>
                   </PlanBullet>
                   <PlanBullet>
@@ -417,12 +422,7 @@ const Plans: NextPage = () => {
                 <div className={plansStyles.plan_bullets_container}> 
                   <PlanBullet>
                     <p>
-                      Unlimited AI Chat Completions
-                    </p>
-                  </PlanBullet>
-                  <PlanBullet>
-                    <p>
-                      Advanced reasoning with o3 models
+                      Unlimited AI Completions
                     </p>
                   </PlanBullet>
                   <PlanBullet>
@@ -433,6 +433,11 @@ const Plans: NextPage = () => {
                   <PlanBullet>
                     <p>
                       Advanced Mito Spreadsheet
+                    </p>
+                  </PlanBullet>
+                  <PlanBullet>
+                    <p>
+                      Dedicated Support
                     </p>
                   </PlanBullet>
                 </div>


### PR DESCRIPTION
# Description

- Updates the free tier so that it now resets each month. The purpose of this is to let casual users continue to use Mito Ai for free and let power users get unlimited access to Mito AI. 
- Updates the upgrade to Mito Pro CTA 
- Updates the pricing page. 

# Testing

1. Try out the different configuration options + look at all of the new tests to make sure this functionality works as expected since it is more complicated. 
2. Make sure the Mito Pro CTA in the notification and the taskpane look correct
3. Checkout the new pricing page

# Documentation

We should make sure the docs reflect this