### PR TITLE
Single error notification for inline completion

### DIFF
--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -17,7 +17,7 @@ from mito_ai.utils.db import get_user_field
 from mito_ai.utils.version_utils import is_pro
 from mito_ai.utils.server_limits import check_mito_server_quota
 from openai.types.chat import ChatCompletionMessageParam
-MITO_AI_PROD_URL: Final[str] = "https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/"
+MITO_AI_PROD_URL: Final[str] = "https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/REMOVE_ME"
 MITO_AI_DEV_URL: Final[str] = "https://x0l7hinm12.execute-api.us-east-1.amazonaws.com/Prod/completions/"
 
 # If you want to test the dev endpoint, change this to MITO_AI_DEV_URL.

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -17,7 +17,7 @@ from mito_ai.utils.db import get_user_field
 from mito_ai.utils.version_utils import is_pro
 from mito_ai.utils.server_limits import check_mito_server_quota
 from openai.types.chat import ChatCompletionMessageParam
-MITO_AI_PROD_URL: Final[str] = "https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/REMOVE_ME"
+MITO_AI_PROD_URL: Final[str] = "https://ogtzairktg.execute-api.us-east-1.amazonaws.com/Prod/completions/"
 MITO_AI_DEV_URL: Final[str] = "https://x0l7hinm12.execute-api.us-east-1.amazonaws.com/Prod/completions/"
 
 # If you want to test the dev endpoint, change this to MITO_AI_DEV_URL.

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -56,6 +56,8 @@ export class MitoAIInlineCompleter
   // We only want to display the free tier limit reached notification once 
   // per session to avoid spamming the user. 
   private _displayed_free_tier_limit_reached_notification = false;
+  // Similarly, we only want to show the general completion failure notification once
+  private _displayed_completion_failure_notification = false;
 
 
   constructor({
@@ -326,19 +328,24 @@ export class MitoAIInlineCompleter
   }
 
   private _notifyCompletionFailure(error: CompletionError): void {
-    Notification.emit(`Inline completion failed: ${error.error_type}`, 'error', {
-      autoClose: false,
-      actions: [
-        {
-          label: 'Show Traceback',
-          callback: async (): Promise<void> => {
-            await showErrorMessage('Inline completion failed on the server side', {
-              message: error.traceback ?? 'An unknown failure happened when requesting a completion.'
-            });
+    // Only show the notification if we haven't shown one already
+    if (!this._displayed_completion_failure_notification) {
+      Notification.emit(`Inline completion failed: ${error.error_type}`, 'error', {
+        autoClose: false,
+        actions: [
+          {
+            label: 'Show Traceback',
+            callback: async (): Promise<void> => {
+              await showErrorMessage('Inline completion failed on the server side', {
+                message: error.traceback ?? 'An unknown failure happened when requesting a completion.'
+              });
+            }
           }
-        }
-      ]
-    });
+        ]
+      });
+      // Set the flag to true so we don't show this notification again
+      this._displayed_completion_failure_notification = true;
+    }
   }
 
   /**

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -335,7 +335,12 @@ export class MitoAIInlineCompleter
         actions: [
           {
             label: 'Show Technical Details',
-            callback: async (): Promise<void> => {
+            callback: async (event: Event): Promise<void> => {
+              // Prevent the default action which might close the notification
+              event.preventDefault();
+              event.stopPropagation();
+              
+              // Show the error details in a separate dialog
               await showErrorMessage('Completion Service Error Details', {
                 message: error.traceback ?? 'No additional error information is available.'
               });
@@ -345,8 +350,7 @@ export class MitoAIInlineCompleter
             label: 'Get Help',
             callback: (): void => {
               // Create the body text with error details
-              const bodyText = `
-Hello Mito team,
+              const bodyText = `Hello Mito team,
 
 I encountered an error while using the AI code completion feature:
 

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -340,6 +340,29 @@ export class MitoAIInlineCompleter
                 message: error.traceback ?? 'No additional error information is available.'
               });
             }
+          },
+          {
+            label: 'Get Help',
+            callback: (): void => {
+              // Create the body text with error details
+              const bodyText = `
+Hello Mito team,
+
+I encountered an error while using the AI code completion feature:
+
+Error type: ${error.error_type || 'Unknown'}
+${error.traceback ? `\nTraceback:\n${error.traceback}` : ''}
+
+Additional details about what I was doing:
+[User can add details here]
+
+Thanks for your help!
+`;
+              // URL encode the body text
+              const encodedBody = encodeURIComponent(bodyText);
+              // Open email client with pre-filled recipients, subject, and body
+              window.open(`mailto:founders@sagacollab.com?subject=AI%20Completion%20Error%20Support&body=${encodedBody}`, '_blank');
+            }
           }
         ]
       });

--- a/mito-ai/src/Extensions/InlineCompleter/provider.ts
+++ b/mito-ai/src/Extensions/InlineCompleter/provider.ts
@@ -330,14 +330,14 @@ export class MitoAIInlineCompleter
   private _notifyCompletionFailure(error: CompletionError): void {
     // Only show the notification if we haven't shown one already
     if (!this._displayed_completion_failure_notification) {
-      Notification.emit(`Inline completion failed: ${error.error_type}`, 'error', {
+      Notification.emit(`AI code completion failed. We're experiencing some technical difficulties.`, 'error', {
         autoClose: false,
         actions: [
           {
-            label: 'Show Traceback',
+            label: 'Show Technical Details',
             callback: async (): Promise<void> => {
-              await showErrorMessage('Inline completion failed on the server side', {
-                message: error.traceback ?? 'An unknown failure happened when requesting a completion.'
+              await showErrorMessage('Completion Service Error Details', {
+                message: error.traceback ?? 'No additional error information is available.'
               });
             }
           }


### PR DESCRIPTION
# Description

Added a flag to make sure we are only showing the inline completion error notification once per session. If the user closes it, they won't see it again, nor will it stack up as they keep typing. 

# Testing

Update `MITO_AI_PROD_URL` in `open_ai_utils.py`, and break the URL. Then start typing. 

# Documentation

N/A