### PR TITLE
Update GitHub Actions to use Ubuntu 24.04 and latest action versions

### DIFF
--- a/.github/workflows/deploy-mito-ai.yml
+++ b/.github/workflows/deploy-mito-ai.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy-mito-ai:
     name: Deploy mito-ai
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.11]
@@ -17,16 +17,16 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - name: Setup Auth for PyPi
         run: |
           echo -e "[distutils]" >> ~/.pypirc

--- a/.github/workflows/deploy-mitosheet-mitoinstaller.yml
+++ b/.github/workflows/deploy-mitosheet-mitoinstaller.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy-mitosheet:
     name: Deploy mitosheet
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -17,16 +17,16 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - name: Setup Auth for PyPi
         run: |
           echo -e "[distutils]" >> ~/.pypirc
@@ -68,11 +68,11 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Auth for PyPi

--- a/.github/workflows/lint-mito-ai-typescript.yml
+++ b/.github/workflows/lint-mito-ai-typescript.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint-mito-ai-typescript:
     name: Run linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel Previous Runs
@@ -20,15 +20,15 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: mito-ai/package-lock.json
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install JupyterLab

--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint-mitosheet-typescript:
     name: Run linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel Previous Runs
@@ -20,11 +20,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: mitosheet/package-lock.json
       - name: Install Node.js dependencies

--- a/.github/workflows/prerelease-tests.yml
+++ b/.github/workflows/prerelease-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     test-jupyterlab-demos:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         timeout-minutes: 60
         strategy:
           matrix:
@@ -19,18 +19,18 @@ jobs:
           uses: styfle/cancel-workflow-action@0.7.0
           with:
             access_token: ${{ github.token }}
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python-version }}
             cache: pip
             cache-dependency-path: |
               mitosheet/setup.py
               tests/requirements.txt
-        - uses: actions/setup-node@v3
+        - uses: actions/setup-node@v4
           with:
-            node-version: 16
+            node-version: 22
             cache: 'npm'
             cache-dependency-path: mitosheet/package-lock.json
         - name: Install dependencies
@@ -79,9 +79,9 @@ jobs:
       runs-on: ${{ matrix.os }}
   
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -89,9 +89,9 @@ jobs:
             mitosheet/setup.py
             tests/requirements.txt
             tests/extra-requirements.txt
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: mitosheet/package-lock.json
       - name: Install dependencies (ubuntu, macos)

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -10,7 +10,7 @@ on:
       - 'mito-ai/**'
 jobs:
   test-mitoai-backend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       matrix:
@@ -22,9 +22,9 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test-mito-ai-frontend.yml
+++ b/.github/workflows/test-mito-ai-frontend.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 jobs:
   test-mitoai-frontend-jupyterlab:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       matrix:
@@ -28,18 +28,18 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
           mito-ai/setup.py
           tests/requirements.txt
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mito-ai/package-lock.json
     - name: Upgrade pip

--- a/.github/workflows/test-mito-ai-jest.yml
+++ b/.github/workflows/test-mito-ai-jest.yml
@@ -16,7 +16,7 @@ on:
       - 'mito-ai/src/tests/**'
 jobs:
   test-mitoai-frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:
@@ -25,17 +25,17 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Use Node.js 18.x
-      uses: actions/setup-node@v2
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: 'npm'
         cache-dependency-path: mito-ai/package-lock.json
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/test-mito-ai-mypy.yml
+++ b/.github/workflows/test-mito-ai-mypy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-mito-ai-mypy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -21,9 +21,9 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -14,16 +14,16 @@ jobs:
     strategy:
       matrix:
         python-version: [3.10, 3.11]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-24.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -16,7 +16,7 @@ on:
       - '!tests/mitoai_ui_tests/**'
 jobs:
   test-mitosheet-frontend-jupyterlab:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       matrix:
@@ -28,18 +28,18 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
           mitosheet/setup.py
           tests/requirements.txt
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mitosheet/package-lock.json
     - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
         retention-days: 14
 
   test-mitosheet-frontend-jupyternotebook:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       matrix:
@@ -79,18 +79,18 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
           mitosheet/setup.py
           tests/requirements.txt
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mitosheet/package-lock.json
     - name: Install dependencies
@@ -153,9 +153,9 @@ jobs:
     name: Test ${{ matrix.testfiles }} on ${{ matrix.os }} ${{ matrix.project.test-name }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -163,9 +163,9 @@ jobs:
           mitosheet/setup.py
           tests/requirements.txt
           tests/extra-requirements.txt
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mitosheet/package-lock.json
     - name: Install dependencies (ubuntu, macos)
@@ -235,7 +235,7 @@ jobs:
         retention-days: 14
 
   test-mitosheet-frontend-dash:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       matrix:
@@ -247,9 +247,9 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -257,9 +257,9 @@ jobs:
           mitosheet/setup.py
           tests/requirements.txt
           tests/extra-requirements.txt
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mitosheet/package-lock.json
     - name: Install dependencies

--- a/.github/workflows/test-mitosheet-mypy.yml
+++ b/.github/workflows/test-mitosheet-mypy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-mitosheet-mypy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -21,9 +21,9 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test-mitosheet-python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -28,16 +28,16 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: mitosheet/setup.py
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
         cache-dependency-path: mitosheet/package-lock.json
     - name: Install dependencies

--- a/mitosheet/mitosheet/scheduling/schedule_utils.py
+++ b/mitosheet/mitosheet/scheduling/schedule_utils.py
@@ -240,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python {python_version}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: {python_version}
       - name: Get the current timestamp


### PR DESCRIPTION
# Description

This PR:
- bumps Ubuntu image in actions from 20.04 to 24.04. The motivation is that 20.04 support in actions in going away starting  4/1/25: https://github.com/actions/runner-images/issues/11101.
- update GitHub Actions versions to to latest versions