### PR TITLE
Fix message editing

### DIFF
--- a/mito-ai/mito_ai/completion_handlers/agent_execution_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/agent_execution_handler.py
@@ -20,6 +20,13 @@ class AgentExecutionHandler(CompletionHandler[AgentExecutionMetadata]):
         message_history: GlobalMessageHistory
     ) -> str:
         """Get a chat completion from the AI provider."""
+
+        index = metadata.index
+
+        if index is not None:
+            message_history.truncate_histories(
+                index=index
+            )
         
         # Add the system message if it doens't alredy exist
         await append_agent_system_message(message_history, provider)

--- a/mito-ai/mito_ai/completion_handlers/chat_completion_handler.py
+++ b/mito-ai/mito_ai/completion_handlers/chat_completion_handler.py
@@ -20,6 +20,13 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
         message_history: GlobalMessageHistory
     ) -> str:
         """Get a chat completion from the AI provider."""
+
+        index = metadata.index
+
+        if index is not None:
+            message_history.truncate_histories(
+                index=index
+            )
         
         # Add the system message if it doens't alredy exist
         await append_chat_system_message(message_history, provider)

--- a/mito-ai/mito_ai/models.py
+++ b/mito-ai/mito_ai/models.py
@@ -69,6 +69,7 @@ class AgentExecutionMetadata():
     aiOptimizedCells: List[AIOptimizedCell]
     variables: Optional[List[str]] = None
     files: Optional[List[str]] = None
+    index: Optional[int] = None
     
 @dataclass(frozen=True)
 class AgentSmartDebugMetadata():

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -107,7 +107,7 @@ export class ChatHistoryManager {
 
         const aiOptimizedCells = getAIOptimizedCells(this.notebookTracker)
 
-        const agentExecutionMetatada: IAgentExecutionMetadata = {
+        const agentExecutionMetadata: IAgentExecutionMetadata = {
             promptType: 'agent:execution',
             variables: this.contextManager.variables,
             files: this.contextManager.files,
@@ -137,7 +137,7 @@ export class ChatHistoryManager {
             }
         )
 
-        return agentExecutionMetatada
+        return agentExecutionMetadata
     }
 
     dropMessagesStartingAtIndex(index: number): void {

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -385,14 +385,17 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             newChatHistoryManager.dropMessagesStartingAtIndex(messageIndex)
         }
 
-        const agentExecutionMetatada = newChatHistoryManager.addAgentExecutionMessage(input)
+        const agentExecutionMetadata = newChatHistoryManager.addAgentExecutionMessage(input)
+        if (messageIndex !== undefined) {
+            agentExecutionMetadata.index = messageIndex
+        }
         setChatHistoryManager(newChatHistoryManager)
 
         // Step 2: Send the message to the AI
         const completionRequest: IAgentExecutionCompletionRequest = {
             type: 'agent:execution',
             message_id: UUID.uuid4(),
-            metadata: agentExecutionMetatada,
+            metadata: agentExecutionMetadata,
             stream: false
         }
         await _sendMessageAndSaveResponse(completionRequest, newChatHistoryManager)
@@ -414,7 +417,9 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         }
         
         const chatMessageMetadata: IChatMessageMetadata = newChatHistoryManager.addChatInputMessage(input)
-        
+        if (messageIndex !== undefined) {
+            chatMessageMetadata.index = messageIndex
+        }
         setChatHistoryManager(newChatHistoryManager)
 
         const completionRequest: IChatCompletionRequest = {

--- a/mito-ai/src/utils/websocket/models.ts
+++ b/mito-ai/src/utils/websocket/models.ts
@@ -70,6 +70,7 @@ export interface IAgentExecutionMetadata {
   variables?: Variable[];
   files?: File[];
   input: string;
+  index?: number;
 }
 
 export interface IAgentSmartDebugMetadata {


### PR DESCRIPTION
# Description

Somewhere between the refactors, the extension lost the ability to properly edit the message. Message index was missing from the agent metadata and not transmitted for chat metadata; no action to truncate message history on the backend was taken. This PR fixes that issue by
- updating backend/frontend models to include message index where needed
- send message index when editing a message on the frontend
- call to truncate message function when index is present in the received message on the backend