### PR TITLE
Use concurrency instead of styfle cancel action

### DIFF
--- a/.github/workflows/lint-mito-ai-typescript.yml
+++ b/.github/workflows/lint-mito-ai-typescript.yml
@@ -9,16 +9,16 @@ on:
     paths:
       - 'mito-ai/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-mito-ai-typescript:
     name: Run linters
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-          access_token: ${{ github.token }}
       - name: Check out Git repository
         uses: actions/checkout@v4
       - name: Set up Node.js

--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -9,16 +9,16 @@ on:
     paths:
       - 'mitosheet/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-mitosheet-typescript:
     name: Run linters
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-          access_token: ${{ github.token }}
       - name: Check out Git repository
         uses: actions/checkout@v4
       - name: Set up Node.js

--- a/.github/workflows/prerelease-tests.yml
+++ b/.github/workflows/prerelease-tests.yml
@@ -5,6 +5,10 @@ on:
         branches: 
             - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
     test-jupyterlab-demos:
         runs-on: ubuntu-24.04
@@ -15,10 +19,6 @@ jobs:
           fail-fast: false
     
         steps:
-        - name: Cancel Previous Runs
-          uses: styfle/cancel-workflow-action@0.7.0
-          with:
-            access_token: ${{ github.token }}
         - uses: actions/checkout@v4
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v5

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     paths:
       - 'mito-ai/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitoai-backend:
     runs-on: ubuntu-24.04
@@ -18,10 +23,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mito-ai-frontend.yml
+++ b/.github/workflows/test-mito-ai-frontend.yml
@@ -13,6 +13,11 @@ on:
       - 'tests/mitoai_ui_tests/**'
       - '.github/workflows/test-mito-ai.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitoai-frontend-jupyterlab:
     runs-on: ubuntu-24.04
@@ -24,10 +29,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mito-ai-jest.yml
+++ b/.github/workflows/test-mito-ai-jest.yml
@@ -14,17 +14,17 @@ on:
       - 'mito-ai/package.json'
       - 'mito-ai/jest.config.js'
       - 'mito-ai/src/tests/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitoai-frontend:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v4
 
     - name: Use Node.js 22.x

--- a/.github/workflows/test-mito-ai-mypy.yml
+++ b/.github/workflows/test-mito-ai-mypy.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'mito-ai/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mito-ai-mypy:
     runs-on: ubuntu-24.04
@@ -17,10 +21,6 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'mitoinstaller/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitoinstaller:
     strategy:
@@ -17,10 +21,6 @@ jobs:
         os: [ubuntu-24.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -14,6 +14,11 @@ on:
       - 'tests/**'
       - '.github/workflows/test-mitosheet-frontend.yml'
       - '!tests/mitoai_ui_tests/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitosheet-frontend-jupyterlab:
     runs-on: ubuntu-24.04
@@ -24,10 +29,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -75,10 +76,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -243,10 +240,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mitosheet-mypy.yml
+++ b/.github/workflows/test-mitosheet-mypy.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'mitosheet/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitosheet-mypy:
     runs-on: ubuntu-24.04
@@ -17,10 +21,6 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -11,6 +11,10 @@ on:
       - 'mitosheet/**'
       - '.github/workflows/test-mitosheet-python.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mitosheet-python:
     runs-on: ubuntu-24.04
@@ -24,10 +28,6 @@ jobs:
             pandas-version: '1.5.3'
             
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.7.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

This a maintenance PR that drops `styfle/cancel-workflow-action` in favor for builtin GitHub CI feature, [concurrency](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency)