### PR TITLE
Fix yarn and python caching

### DIFF
--- a/.github/workflows/lint-mito-ai-typescript.yml
+++ b/.github/workflows/lint-mito-ai-typescript.yml
@@ -21,16 +21,20 @@ jobs:
           access_token: ${{ github.token }}
       - name: Check out Git repository
         uses: actions/checkout@v4
+      # Needed to enable proper yarn in setup-node for correct caching
+      - run: corepack enable
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
-          cache-dependency-path: mito-ai/package-lock.json
+          cache: 'yarn'
+          cache-dependency-path: mito-ai/yarn.lock
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+          cache: pip
+          cache-dependency-path: mito-ai/setup.py
       - name: Install JupyterLab
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -21,12 +21,14 @@ jobs:
           access_token: ${{ github.token }}
       - name: Check out Git repository
         uses: actions/checkout@v4
+      # Needed to enable proper yarn in setup-node for correct caching
+      - run: corepack enable
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
-          cache-dependency-path: mitosheet/package-lock.json
+          cache: 'yarn'
+          cache-dependency-path: mito-ai/yarn.lock
       - name: Install Node.js dependencies
         run: | 
           cd mitosheet

--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
-          cache-dependency-path: mito-ai/yarn.lock
+          cache-dependency-path: mitosheet/yarn.lock
       - name: Install Node.js dependencies
         run: | 
           cd mitosheet

--- a/.github/workflows/prerelease-tests.yml
+++ b/.github/workflows/prerelease-tests.yml
@@ -28,11 +28,13 @@ jobs:
             cache-dependency-path: |
               mitosheet/setup.py
               tests/requirements.txt
+        # Needed to enable proper yarn in setup-node for correct caching
+        - run: corepack enable
         - uses: actions/setup-node@v4
           with:
             node-version: 22
-            cache: 'npm'
-            cache-dependency-path: mitosheet/package-lock.json
+            cache: 'yarn'
+            cache-dependency-path: mitosheet/yarn.lock
         - name: Install dependencies
           run: |
             cd tests
@@ -89,11 +91,13 @@ jobs:
             mitosheet/setup.py
             tests/requirements.txt
             tests/extra-requirements.txt
+      # Needed to enable proper yarn in setup-node for correct caching
+      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
-          cache-dependency-path: mitosheet/package-lock.json
+          cache: 'yarn'
+          cache-dependency-path: mitosheet/yarn.lock
       - name: Install dependencies (ubuntu, macos)
         if: matrix.os != 'windows-latest-l'
         run: |

--- a/.github/workflows/test-mito-ai-frontend.yml
+++ b/.github/workflows/test-mito-ai-frontend.yml
@@ -37,11 +37,13 @@ jobs:
         cache-dependency-path: |
           mito-ai/setup.py
           tests/requirements.txt
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mito-ai/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mito-ai/yarn.lock
     - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-mito-ai-jest.yml
+++ b/.github/workflows/test-mito-ai-jest.yml
@@ -26,18 +26,21 @@ jobs:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v4
-
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - name: Use Node.js 22.x
       uses: actions/setup-node@v4
       with:
         node-version: 22.x
-        cache: 'npm'
-        cache-dependency-path: mito-ai/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mito-ai/yarn.lock
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: pip
+        cache-dependency-path: mito-ai/setup.py
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -37,11 +37,13 @@ jobs:
         cache-dependency-path: |
           mitosheet/setup.py
           tests/requirements.txt
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mitosheet/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mitosheet/yarn.lock
     - name: Install dependencies
       run: |
         cd tests
@@ -88,11 +90,13 @@ jobs:
         cache-dependency-path: |
           mitosheet/setup.py
           tests/requirements.txt
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mitosheet/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mitosheet/yarn.lock
     - name: Install dependencies
       run: |
         cd tests
@@ -163,11 +167,13 @@ jobs:
           mitosheet/setup.py
           tests/requirements.txt
           tests/extra-requirements.txt
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mitosheet/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mitosheet/yarn.lock
     - name: Install dependencies (ubuntu, macos)
       if: matrix.os != 'windows-latest-l'
       run: |
@@ -257,11 +263,13 @@ jobs:
           mitosheet/setup.py
           tests/requirements.txt
           tests/extra-requirements.txt
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mitosheet/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mitosheet/yarn.lock
     - name: Install dependencies
       run: |
         cd tests

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -35,11 +35,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: mitosheet/setup.py
+    # Needed to enable proper yarn in setup-node for correct caching
+    - run: corepack enable
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
-        cache-dependency-path: mitosheet/package-lock.json
+        cache: 'yarn'
+        cache-dependency-path: mitosheet/yarn.lock
     - name: Install dependencies
       run: |
         cd mitosheet

--- a/mito-ai/package.json
+++ b/mito-ai/package.json
@@ -56,6 +56,7 @@
     "watch:src": "npx tsc -w",
     "watch:labextension": "jupyter labextension watch ."
   },
+  "packageManager": "yarn@3.5.0",
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.9.6",
@@ -228,6 +229,5 @@
       "selector-no-vendor-prefix": null,
       "value-no-vendor-prefix": null
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/mitosheet/package.json
+++ b/mitosheet/package.json
@@ -24,6 +24,7 @@
     "type": "git"
   },
   "version": "0.2.1",
+  "packageManager": "yarn@3.5.0",
   "dependencies": {
     "@jupyterlab/application": "^4.0.0",
     "@jupyterlab/notebook": "^4.2.4",


### PR DESCRIPTION
# Description

This fixes the workflow configuration to activate caching especially for yarn as it is currently almost not working as seen in the cache sizes for node-cache: https://github.com/mito-ds/mito/actions/caches

This implies ensuring `actions/setup-node` uses yarn 3 (by default it is using v1). To achieve that, the `packageManager` is set in the package.json files and `corepack` is enable prior to the setup node action.