### PR TITLE
CI: Fix Python version should be string

### DIFF
--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -13,7 +13,7 @@ jobs:
   test-mitoinstaller:
     strategy:
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-24.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
# Description

`3.10` is interpreted as a float. Therefore it will result in installing Python 3.1 as seen in 
https://github.com/mito-ds/mito/actions/runs/14134579170/job/39603093834?pr=1595

Version should always be typed as string.