### PR TITLE
mito-ai: do not add mito functions to context

### DIFF
--- a/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
+++ b/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
@@ -15,6 +15,7 @@ export type Variable = {
 // TODO: Use something like raw-loader to load an actual python file 
 // to make it easier to modify the script without creating syntax errors.
 const pythonVariableInspectionScript = `import json
+import inspect
 
 
 # We need to check if pandas is imported so we know if its safe
@@ -44,45 +45,68 @@ def get_dataframe_structure(df, sample_size=5):
         }
     return structure
 
+def is_from_mitosheet(obj):
+    """Check if an object is from any mitosheet module"""
+    try:
+        module = inspect.getmodule(obj)
+        if module and (module.__name__.startswith('mitosheet')):
+            return True
+
+        # if the dictionary contains all of the mito functions, then we can assume that the object is from mitosheet
+        mito_functions = ["STRIPTIMETOMONTHS", "GETNEXTVALUE", "FILLNAN"]
+        if isinstance(obj, dict) and all(key in obj for key in mito_functions):
+            return True
+
+
+    except Exception:
+        return False
+    return False
+
 def structured_globals():
     output = []
     for k, v in globals().items():
-            if not k.startswith("_") and k not in ("In", "Out", "json") and not callable(v):
-                if _is_pandas_imported and isinstance(v, pd.DataFrame):
 
-                    new_variable = {
-                        "variable_name": k,
-                        "type": "pd.DataFrame",
-                        "value": get_dataframe_structure(v)
-                    }
+        # Skip mitosheet functions
+        if is_from_mitosheet(v):
+            continue
 
-                    try:
-                        # Check if the variable can be converted to JSON.
-                        # If it can, add it to the outputs. If it can't, we just skip it.
-                        # We check each variable individually so that we don't crash
-                        # the entire variable inspection if just one variable cannot be serialized.
-                        json.dumps(new_variable["value"])
-                        output.append(new_variable)
-                    except:
-                        pass
+        if not k.startswith("_") and k not in ("In", "Out", "json") and not callable(v):
+            
+            if _is_pandas_imported and isinstance(v, pd.DataFrame):
 
-                else:
+                new_variable = {
+                    "variable_name": k,
+                    "type": "pd.DataFrame",
+                    "value": get_dataframe_structure(v)
+                }
 
-                    new_variable = {
-                        "variable_name": k,
-                        "type": str(type(v)),
-                        "value": repr(v)
-                    }
+                try:
+                    # Check if the variable can be converted to JSON.
+                    # If it can, add it to the outputs. If it can't, we just skip it.
+                    # We check each variable individually so that we don't crash
+                    # the entire variable inspection if just one variable cannot be serialized.
+                    json.dumps(new_variable["value"])
+                    output.append(new_variable)
+                except:
+                    pass
 
-                    try:
-                        # Check if the variable can be converted to JSON.
-                        # If it can, add it to the outputs. If it can't, we just skip it.
-                        # We check each variable individually so that we don't crash
-                        # the entire variable inspection if just one variable cannot be serialized.
-                        json.dumps(new_variable["value"])
-                        output.append(new_variable)
-                    except:
-                        pass
+            else:
+
+                new_variable = {
+                    "variable_name": k,
+                    "type": str(type(v)),
+                    "value": repr(v)
+                }
+
+                try:
+                    # Check if the variable can be converted to JSON.
+                    # If it can, add it to the outputs. If it can't, we just skip it.
+                    # We check each variable individually so that we don't crash
+                    # the entire variable inspection if just one variable cannot be serialized.
+                    json.dumps(new_variable["value"])
+                    output.append(new_variable)
+                except:
+                    pass
 
     return json.dumps(output)
 


### PR DESCRIPTION
# Description

Removes the Mito exported functions from the variables we pass to the LLM. These are mostly irrelevant and the LLM can probably figure it out if it needs too. 

Making the Defined Variables in my testing notebook go from 5608 to 993 characters 

In retrospect, not sure this was really worth the 35 mins it took... I don't think this is where users are running into messages being too long

# Testing

Try it out! 

# Documentation

No