### PR TITLE
Slightly improved error tracking

### DIFF
--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -272,7 +272,14 @@ This attribute is observed by the websocket provider to push the error to the cl
         except BaseException as e:
             self.last_error = CompletionError.from_exception(e)
             key_type = MITO_SERVER_KEY if self.api_key is None else USER_KEY
-            log(MITO_AI_COMPLETION_ERROR, params={KEY_TYPE_PARAM: key_type}, error=e)
+            log(
+                MITO_AI_COMPLETION_ERROR, 
+                params={
+                    KEY_TYPE_PARAM: key_type,
+                    'message_type': message_type.value,
+                },
+                error=e
+            )
             raise
 
 
@@ -323,7 +330,14 @@ This attribute is observed by the websocket provider to push the error to the cl
             
         except BaseException as e:
             self.last_error = CompletionError.from_exception(e)
-            log(MITO_AI_COMPLETION_ERROR, params={KEY_TYPE_PARAM: USER_KEY}, error=e)
+            log(
+                MITO_AI_COMPLETION_ERROR, 
+                params={
+                    KEY_TYPE_PARAM: USER_KEY,
+                    'message_type': message_type.value,
+                },
+                error=e
+            )
             raise
 
         async for chunk in stream:

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -139,6 +139,7 @@ def log(
     if not is_running_test() and telemetry_turned_on():
         # TODO: If the user is in JupyterLite, we need to do some extra work.
         # You can see this in the mitosheet package. 
+        
         try:
             analytics.track(
                 get_user_field(UJ_STATIC_USER_ID), 


### PR DESCRIPTION
# Description

Just makes it so when an error occurs, it also ways what the attempted operation was. 

# Testing

Just raise an exception in `request_completions`

# Documentation

Nope