### PR TITLE
Enabling Ollama Support via Environment Variables

### DIFF
--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -45,7 +45,7 @@ from mito_ai.utils.telemetry_utils import (
 )
 
 __all__ = ["OpenAIProvider"]
-use_ollama = True
+use_ollama = False
 OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "mistral")
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -95,7 +95,6 @@ setup(
         "traitlets",
         "pydantic",
         "ollama",
-        "aiohttp",
     ],
     extras_require = {
         'deploy': [

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -94,7 +94,6 @@ setup(
         "tornado>=6.2.0",
         "traitlets",
         "pydantic",
-        "ollama",
     ],
     extras_require = {
         'deploy': [

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -94,6 +94,8 @@ setup(
         "tornado>=6.2.0",
         "traitlets",
         "pydantic",
+        "ollama",
+        "aiohttp",
     ],
     extras_require = {
         'deploy': [


### PR DESCRIPTION
# Description

Modified the `mito-ai/mito_ai/providers.py` to make calls to local LLMs running on Ollama. Modified the `OpenAIProvider` class to include new ollama properties also modified the `request_completions` and `stream_completions` methods to account for Ollama changes.


https://github.com/user-attachments/assets/865e8814-f654-49f3-a92d-9557fef643ab


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [x] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook. (N/A)

# Note

This can be followed up by a UI update where we allow users to chose Ollama models from a dropdown. This still needs to be worked on. 

Three new environment variables are introduced as part of this PR:

- `USE_OLLAMA`: This is a boolean flag that allows the user to Enable/Disable Ollama (This would have to be done in the UI in the future)

- `OLLAMA_MODEL`: Specifies the LLM that is to be chosen.
  
-  `OLLAMA_HOST` (Optional) : Specifies the Ollama Host URL where Ollama is running. This is set to `http://localhost:11434` by default and this env variable need not be set if it is running on the default port.


Note that I have not added unit tests yet 🫣 and plan to add them if this approach is approved.

# Documentation

