### PR TITLE
Quota accounting

### DIFF
--- a/mito-ai/mito_ai/utils/server_limits.py
+++ b/mito-ai/mito_ai/utils/server_limits.py
@@ -98,6 +98,10 @@ def update_mito_server_quota(message_type: MessageType) -> None:
     or we will no longer be able to provide this free tier.
     """
     
+    if message_type == MessageType.CHAT_NAME_GENERATION:
+        # We do not count the Chat Name Generation message type towards the quota
+        return
+    
     current_date = datetime.now()
     first_usage_date = get_first_completion_date()
     last_reset_date_str = get_last_reset_date()


### PR DESCRIPTION
# Description

Don't count naming the chat against the user's quota. 

# Testing

Double check that when we automatically name the chat, we don't count that against the user's quota so they actually get a chance to use the tool :) 

# Documentation

Nope