### PR TITLE
mito-ai: switch citation structure

### DIFF
--- a/mito-ai/mito_ai/prompt_builders/agent_system_message.py
+++ b/mito-ai/mito_ai/prompt_builders/agent_system_message.py
@@ -190,16 +190,16 @@ RULES
 
 RULES FOR CITING YOUR WORK
 
-It is important that the user is able to verify any insights that you share with them about their data. To make this easy for the user, you must cite the lines of code that you are drawing the insight from. To provide a citation, use the following JSON format inline in your response:
+It is important that the user is able to verify any insights that you share with them about their data. To make this easy for the user, you must cite the lines of code that you are drawing the insight from. To provide a citation, use the following format inline in your response:
 
-{{"type": "citation", "cell_id": "<cell_id>", "line": "<line_number>"}}
+[MITO_CITATION:cell_id:line_number]
 
 Citation Rules:
 
 1. Every fact or statement derived from the user's notebook must include a citation. 
 2. When choosing the citation, select the code that will most help the user validate the ract or statement that you shared with them.
 3. Place the citation immediately after the statement it supports. Do not explain the citation with phrases like "See", "Derived from", etc. Just provide the citation object.
-4. For the "line" field, use the line number within the cell that is most relevant to the citation. The cell line number should be 0-indexed and should not skip comments.
+4. For the "line_number" field, use the line number within the cell that is most relevant to the citation. Important: The cell line number should be 0-indexed and should not skip comments.
 5. If you cannot find relevant information in the notebook to answer a question, clearly state this and do not provide a citation.
 6. You ONLY need to provide a citation when sharing an insight from the data in the message part of the response. If all you are doing is writing/updating code, then there is no need to provide a citation.
 7. Do not include the citation in the code block as a comment. ONLY include the citation in the message field of your response.
@@ -291,8 +291,7 @@ Your task:
 Output:
 {{
     is_finished: true, 
-    message: "The all time high tesla stock closing price was $265.91 {{"type": "citation", "cell_id": "9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8", "line": "1"}}
- on 2025-03-16 {{"type": "citation", "cell_id": "9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8", "line": "2"}}.",
+    message: "The all time high tesla stock closing price was $265.91 [MITO_CITATION:9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8:1] on 2025-03-16 [MITO_CITATION:9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8:2].",
     cell_update: null
 }}
 

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
@@ -74,20 +74,26 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
     // Extract citations from the markdown, returning the markdown with the JSON citations replaced with 
     // citation placeholders {{${id}}} and an array of citation objects.
     const extractCitations = useCallback((text: string): { processedMarkdown: string; citations: Citation[] } => {
-        // eslint-disable-next-line no-useless-escape
-        const citationRegex = /(\{\"type\"\:\s*\"citation\".*?\})/g;
+        // New regex to match [MITO_CITATION:cell_id:line_number] format
+        const citationRegex = /\[MITO_CITATION:([^:]+):(\d+)\]/g;
         const citations: Citation[] = [];
         let counter = 0;
 
         // Replace each citation with a placeholder
-        const processedMarkdown = text.replace(citationRegex, (match) => {
+        const processedMarkdown = text.replace(citationRegex, (match, cellId, line) => {
             try {
-                const citation = JSON.parse(match);
                 const id = `citation-${counter++}`;
-                citations.push({ id, data: { citation_index: counter, ...citation} });
+                citations.push({
+                    id,
+                    data: {
+                        citation_index: counter,
+                        cell_id: cellId,
+                        line: parseInt(line, 10)
+                    }
+                });
                 return `{{${id}}}`;
             } catch (e) {
-                console.error("Failed to parse citation JSON:", e);
+                console.error("Failed to parse citation:", e);
                 return match;
             }
         });


### PR DESCRIPTION
# Description

Switches the format of the citation to help the AI generate citations more consistently. Previously, we were asking for the citation in this format: `{"type": "citation", "cell_id": "<cell_id>", "line": "<line_number>"}`, but often the agent starts to send a citation the AI response ends at `{`. 

Switching to the format `[MITO_CITATION:cell_id:line_number]` seems to fix this issue. 

# Testing

Try it out. 

# Documentation

No. 