### PR TITLE
No Cell Preview in Agent Mode

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -26,7 +26,7 @@ interface ChatInputProps {
     notebookTracker: INotebookTracker;
     renderMimeRegistry: IRenderMimeRegistry;
     displayActiveCellCode?: boolean;
-    agentModeEnabled?: boolean;
+    agentModeEnabled: boolean;
 }
 
 export interface ExpandedVariable extends Variable {
@@ -182,7 +182,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             }}
         >
             {/* Show the active cell preview if the text area has focus or the user has started typing */}
-            {displayActiveCellCode && activeCellCodePreview.length > 0 
+            {displayActiveCellCode && activeCellCodePreview.length > 0 && !agentModeEnabled
                 && (isFocused || input.length > 0)
                 && <div className='active-cell-preview-container' data-testid='active-cell-preview-container'>
                     <div className='code-block-container'>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -106,6 +106,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                 notebookTracker={notebookTracker}
                 renderMimeRegistry={renderMimeRegistry}
                 displayActiveCellCode={true}
+                agentModeEnabled={false}
             />
         );
     }

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -151,6 +151,16 @@ describe('ChatInput Component', () => {
             // Preview should not be visible for empty cells
             expect(screen.queryByTestId('active-cell-preview-container')).not.toBeInTheDocument();
         });
+
+        it('does not show preview when agent mode is enabled', () => {
+            renderChatInput({ agentModeEnabled: true });
+
+            // Type in textarea
+            typeInTextarea(textarea, 'test input');
+
+            // Preview should not be visible
+            expect(screen.queryByTestId('active-cell-preview-container')).not.toBeInTheDocument();
+        });
     });
 
     describe('Keyboard Interactions', () => {

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -76,6 +76,7 @@ const createMockProps = (overrides = {}) => ({
         sanitizer: { sanitize: jest.fn() }
     } as unknown as IRenderMimeRegistry,
     displayActiveCellCode: true,
+    agentModeEnabled: false,
     ...overrides
 });
 


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1592. No code cell preview is shown in agent mode. 

# Testing

Create a cell with code in it. Then switch to agent mode, and start typing. You should notice that no active cell preview is shown.

# Documentation

N/A