### PR TITLE
Fix issues with webscockets

### DIFF
--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -98,8 +98,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         if self.get_query_argument('check_availability', None) is not None:
             self.get_service_status()
             return
-            
-        # This is a WebSocket connection request
+
         await ensure_async(self.pre_get()) # type: ignore
 
         initialize_user()

--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -77,7 +77,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         """Handle a GET request for service availability check."""
         self.set_status(HTTPStatus.OK)
         self.finish()
-        
+
     async def pre_get(self) -> None:
         """Handles websocket authentication/authorization."""
         # authenticate the request before opening the websocket

--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -72,12 +72,6 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         """Use Mito AI logger"""
         return get_logger()
 
-    @tornado.web.authenticated
-    def get_service_status(self) -> None:
-        """Handle a GET request for service availability check."""
-        self.set_status(HTTPStatus.OK)
-        self.finish()
-
     async def pre_get(self) -> None:
         """Handles websocket authentication/authorization."""
         # authenticate the request before opening the websocket
@@ -96,6 +90,8 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         """Get an event to open a socket or check service availability."""
         # Check if this is just a service availability check
         if self.get_query_argument('check_availability', None) == 'true':
+            self.set_status(HTTPStatus.OK)
+            self.finish()
             return
 
         await ensure_async(self.pre_get()) # type: ignore

--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -95,8 +95,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
     async def get(self, *args: Any, **kwargs: dict[str, Any]) -> None:
         """Get an event to open a socket or check service availability."""
         # Check if this is just a service availability check
-        if self.get_query_argument('check_availability', None) is not None:
-            self.get_service_status()
+        if self.get_query_argument('check_availability', None) == 'true':
             return
 
         await ensure_async(self.pre_get()) # type: ignore

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -254,9 +254,9 @@ export class CompletionWebsocketClient implements IDisposable {
 
     // Check if the service is available before attempting to connect
     const answer = await fetch(
-      URLExt.join(this.serverSettings.baseUrl, SERVICE_URL),
+      URLExt.join(this.serverSettings.baseUrl, `${SERVICE_URL}?check_availability=true`),
       {
-        method: 'HEAD',
+        method: 'GET',
       }
     );
 

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -160,10 +160,10 @@ export class CompletionWebsocketClient implements IDisposable {
           if (this._socket === null || this._socket.readyState !== WebSocket.OPEN) {
             try {
               console.log('Connection is closed, attempting to reconnect before sending message...');
-
+              
               // Reset the ready promise since we're going to reconnect
               this._ready = new PromiseDelegate<void>();
-              
+
               await this.reconnect();
               console.log('Successfully reconnected, now sending message');
             } catch (reconnectError) {

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -163,7 +163,7 @@ export class CompletionWebsocketClient implements IDisposable {
               
               // Reset the ready promise since we're going to reconnect
               this._ready = new PromiseDelegate<void>();
-
+              
               await this.reconnect();
               console.log('Successfully reconnected, now sending message');
             } catch (reconnectError) {

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -160,10 +160,10 @@ export class CompletionWebsocketClient implements IDisposable {
           if (this._socket === null || this._socket.readyState !== WebSocket.OPEN) {
             try {
               console.log('Connection is closed, attempting to reconnect before sending message...');
-              
+
               // Reset the ready promise since we're going to reconnect
               this._ready = new PromiseDelegate<void>();
-
+              
               await this.reconnect();
               console.log('Successfully reconnected, now sending message');
             } catch (reconnectError) {

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -140,7 +140,12 @@ export class CompletionWebsocketClient implements IDisposable {
    * must be awaited before calling any other method.
    */
   async initialize(): Promise<void> {
-    await this._initialize();
+    try {
+      await this._initialize();
+    } catch (error) {
+      console.error('Failed to initialize WebSocket:', error);
+      throw error;
+    }
   }
 
   /**
@@ -240,9 +245,36 @@ export class CompletionWebsocketClient implements IDisposable {
   }
 
   private async _initialize(): Promise<void> {
-    if (this.isDisposed || this._socket) {
+    if (this.isDisposed) {
       return;
     }
+    
+    // If we already have a pending initialization, return that
+    if (this._initializationInProgress) {
+      return this._ready.promise;
+    }
+    
+    // Mark that initialization is in progress to prevent multiple concurrent initializations
+    this._initializationInProgress = true;
+    
+    // Always create a new ready promise to ensure we're starting fresh
+    this._ready = new PromiseDelegate<void>();
+    
+    // Clean up any existing socket first
+    if (this._socket) {
+      const oldSocket = this._socket;
+      this._socket = null;
+      
+      // Clear handlers before closing to prevent triggering unintended events
+      oldSocket.onopen = () => undefined;
+      oldSocket.onerror = () => undefined;
+      oldSocket.onmessage = () => undefined;
+      oldSocket.onclose = () => undefined;
+      
+      // Close the socket
+      oldSocket.close();
+    }
+
     console.log(
       'Creating a new websocket connection for mito-ai completions...'
     );
@@ -253,58 +285,81 @@ export class CompletionWebsocketClient implements IDisposable {
     }
 
     // Check if the service is available before attempting to connect
-    const answer = await fetch(
-      URLExt.join(this.serverSettings.baseUrl, `${SERVICE_URL}?check_availability=true`),
-      {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Authorization': `token ${token}`
+    try {
+      const answer = await fetch(
+        URLExt.join(this.serverSettings.baseUrl, `${SERVICE_URL}?check_availability=true`),
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Authorization': `token ${token}`
+          }
         }
-      }
-    );
+      );
 
-    if (!answer.ok) {
-      const message =
-        answer.status == 404
-          ? 'Mito AI extension not enabled.'
-          : `Mito AI completion not available; error ${answer.status} ${answer.statusText}`;
-      const hint =
-        answer.status == 404
-          ? 'You can enable it by running in a cell `!jupyter server extension enable mito_ai`. Then restart the application.'
-          : undefined;
-      this._messages.emit({
-        type: 'error',
-        error_type: 'HTTPError',
-        title: message,
-        hint
-      });
-      this._ready.reject(
-        new MitoAIError(message, {
+      if (!answer.ok) {
+        const message =
+          answer.status == 404
+            ? 'Mito AI extension not enabled.'
+            : `Mito AI completion not available; error ${answer.status} ${answer.statusText}`;
+        const hint =
+          answer.status == 404
+            ? 'You can enable it by running in a cell `!jupyter server extension enable mito_ai`. Then restart the application.'
+            : undefined;
+        this._messages.emit({
+          type: 'error',
+          error_type: 'HTTPError',
+          title: message,
+          hint
+        });
+        
+        const error = new MitoAIError(message, {
           cause: answer,
           hint
-        })
-      );
-      return this._ready.promise;
-    }
-
-    const socket = (this._socket = new WebSocket(url));
-    socket.onopen = e => {
-      this._onOpen(e);
-    };
-    socket.onclose = e => {
-      this._onClose(e);
-    };
-    socket.onerror = e => {
-      this._ready.reject(e);
-    };
-    socket.onmessage = msg => {
-      if (msg.data) {
-        this._onMessage(JSON.parse(msg.data));
+        });
+        
+        this._ready.reject(error);
+        this._initializationInProgress = false;
+        return this._ready.promise;
       }
-    };
 
-    await this._ready.promise;
+      const socket = (this._socket = new WebSocket(url));
+      
+      // Set a timeout to detect stalled connections
+      const connectionTimeout = setTimeout(() => {
+        if (socket.readyState !== WebSocket.OPEN && socket === this._socket) {
+          console.error('WebSocket connection timed out');
+          socket.close();
+        }
+      }, 10000); // 10 second timeout
+      
+      socket.onopen = e => {
+        clearTimeout(connectionTimeout);
+        this._onOpen(e);
+        this._initializationInProgress = false;
+      };
+      socket.onclose = e => {
+        clearTimeout(connectionTimeout);
+        this._onClose(e);
+        this._initializationInProgress = false;
+      };
+      socket.onerror = e => {
+        clearTimeout(connectionTimeout);
+        this._ready.reject(e);
+        this._initializationInProgress = false;
+      };
+      socket.onmessage = msg => {
+        if (msg.data) {
+          this._onMessage(JSON.parse(msg.data));
+        }
+      };
+
+      return this._ready.promise;
+    } catch (error) {
+      this._initializationInProgress = false;
+      this._ready.reject(error);
+      throw error;
+    }
   }
 
   /**
@@ -336,13 +391,8 @@ export class CompletionWebsocketClient implements IDisposable {
     }
     
     if (this._reconnectAttempt >= this._maxReconnectAttempts) {
-      throw new Error(`Failed to reconnect after ${this._maxReconnectAttempts} attempts`);
-    }
-    
-    // Clean up any existing socket
-    if (this._socket) {
-      this._socket.close();
-      this._socket = null;
+      this._reconnectAttempt = 0; // Reset for future attempts
+      throw new MitoAIError(`Failed to reconnect after ${this._maxReconnectAttempts} attempts`);
     }
     
     // Calculate delay using exponential backoff
@@ -361,17 +411,26 @@ export class CompletionWebsocketClient implements IDisposable {
       await this._initialize();
       // Reset reconnect attempt counter on success
       this._reconnectAttempt = 0;
+      return;
     } catch (error) {
       console.error(`Reconnection attempt ${this._reconnectAttempt} failed:`, error);
       
       // If the error is a MitoAIError (like the extension not being enabled),
       // propagate it immediately instead of retrying
       if (error instanceof MitoAIError) {
+        this._reconnectAttempt = 0; // Reset for future attempts
         throw error;
       }
       
-      // Try again recursively with exponential backoff
-      return this.reconnect(false);
+      // If we haven't reached max attempts, try again
+      if (this._reconnectAttempt < this._maxReconnectAttempts) {
+        return this.reconnect(false);
+      } else {
+        this._reconnectAttempt = 0; // Reset for future attempts
+        throw new MitoAIError(`Failed to reconnect after ${this._maxReconnectAttempts} attempts`, {
+          cause: error
+        });
+      }
     }
   }
 
@@ -393,4 +452,9 @@ export class CompletionWebsocketClient implements IDisposable {
     PromiseDelegate<CompleterMessage>
   >();
   private _connectionStatus = new Stream<CompletionWebsocketClient, 'connected' | 'disconnected'>(this);
+  
+  /**
+   * Flag to track if initialization is in progress to prevent multiple concurrent initializations
+   */
+  private _initializationInProgress = false;
 }

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -163,7 +163,7 @@ export class CompletionWebsocketClient implements IDisposable {
 
               // Reset the ready promise since we're going to reconnect
               this._ready = new PromiseDelegate<void>();
-
+              
               await this.reconnect();
               console.log('Successfully reconnected, now sending message');
             } catch (reconnectError) {

--- a/mito-ai/src/utils/websocket/websocketClient.ts
+++ b/mito-ai/src/utils/websocket/websocketClient.ts
@@ -160,10 +160,10 @@ export class CompletionWebsocketClient implements IDisposable {
           if (this._socket === null || this._socket.readyState !== WebSocket.OPEN) {
             try {
               console.log('Connection is closed, attempting to reconnect before sending message...');
-              
+
               // Reset the ready promise since we're going to reconnect
               this._ready = new PromiseDelegate<void>();
-              
+
               await this.reconnect();
               console.log('Successfully reconnected, now sending message');
             } catch (reconnectError) {
@@ -257,6 +257,10 @@ export class CompletionWebsocketClient implements IDisposable {
       URLExt.join(this.serverSettings.baseUrl, `${SERVICE_URL}?check_availability=true`),
       {
         method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Authorization': `token ${token}`
+        }
       }
     );
 


### PR DESCRIPTION
# Description

## Replace HEAD request with query param on the main GET request
In situation where JupyterLab is running behind OAuth 2, like in JupyterHub with HTTPS enabled, the HEAD method is not supported. We use HEAD request to check the connection before opening a websocket. This PR replaces HEAD request with a query parameter in the main GET request thus enabling the extension to work with OAuth 2 flow.

## Fix websocket reconnection issues

1. Added error handling to the `initialize()` method to better report connection failures
2. Implemented a flag `_initializationInProgress` to prevent multiple concurrent initialization attempts
3. Added proper cleanup of existing sockets before creating new ones
4. Added a connection timeout to detect stalled connections
5. Reset reconnection counters after failures to ensure future attempts can succeed
6. Created a more robust error propagation