### PR TITLE
Display Upgrade Message on Quota Hit (Streaming Fix)

### DIFF
--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -374,6 +374,9 @@ This attribute is observed by the websocket provider to push the error to the cl
                 message_id=message_id,
             ):
                 accumulated_response += str(chunk_from_mito_server)
+            
+            # Update quota after streaming is complete
+            update_mito_server_quota(message_type)
         
         # Log the successful completion 
         key_type = USER_KEY if self._openAI_async_client is not None else MITO_SERVER_KEY

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -539,8 +539,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                         true,
                         chunk.error.title
                     );
-
-                    return;
                 }
 
                 // Use a ref to accumulate the content properly

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -539,6 +539,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                         true,
                         chunk.error.title
                     );
+
+                    return;
                 }
 
                 // Use a ref to accumulate the content properly

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -189,6 +189,20 @@ describe('ChatMessage Component', () => {
             // Error message should be visible
             expect(screen.getByText('Connection error message')).toBeInTheDocument();
         });
+
+        it('renders free tier limit reached error correctly', () => {
+            renderChatMessage({
+                message: createMockMessage('assistant', 'Test error message'),
+                mitoAIConnectionError: true,
+                mitoAIConnectionErrorType: 'mito_server_free_tier_limit_reached'
+            });
+
+            // Check for the upgrade message
+            expect(screen.getByText(/You've used up your free trial of Mito AI for this month/i)).toBeInTheDocument();
+
+            // Check for the upgrade button
+            expect(screen.getByText(/Upgrade to Pro/i)).toBeInTheDocument();
+        });
     });
 
     describe('User Actions and UI Responses', () => {


### PR DESCRIPTION
# Description

- Fix for issue where upgrade message not shown when streaming.
- Updating Mito Server quota for streaming messages.

# Testing

Make sure you are using the server key, and open the user file. Next, send messages until you hit the limit.

You should notice that (1.) usage is incremented, and (2.) the upgrade message is shown when limit is reached. 

# Documentation

N/A