### PR TITLE
Messages show up in correct tab

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -179,7 +179,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         // Each thread only contains agent or chat messages. For now, we enforce this by clearing the chat 
         // when the user switches mode. When the user reloads a chat, we want to put them back into the same
         // chat mode so that we use the correct system message and preserve this one-type of message invariant.
-        let isAgentChat: boolean = true
+        let isAgentChat: boolean = false
 
         // Add messages to the ChatHistoryManager
         chatHistoryResponse.items.forEach(item => {


### PR DESCRIPTION
# Description

Since defaulting to agent mode, chat messages started to show up in the agent tab. However, this should fix that issue. We will still default to opening in agent mode, assuming there is no chat history, or the last thread was not a chat thread. 

# Testing

1. Delete all chat history, then start the server. You should notice that we still open to agent mode.
2. Create an agent message, and refresh. Should open in agent mode.
3. Send a chat message, and refresh. Should open in chat mode.  

# Documentation

N/A