### PR TITLE
Enable additional models

### DIFF
--- a/mito-ai/mito_ai/constants.py
+++ b/mito-ai/mito_ai/constants.py
@@ -1,0 +1,18 @@
+import os
+
+# Claude Base URL
+CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL")
+CLAUDE_BASE_URL = "https://api.anthropic.com/v1"
+CLAUDE_API_KEY = os.environ.get("CLAUDE_API_KEY")
+
+# Gemini Base URL
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL")
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+
+# Ollama Config
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL")
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+# OpenAI API KEY
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")

--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -45,7 +45,7 @@ from mito_ai.utils.telemetry_utils import (
 )
 
 __all__ = ["OpenAIProvider"]
-use_ollama = True
+use_ollama = False
 OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "mistral")
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 

--- a/mito-ai/mito_ai/tests/providers_test.py
+++ b/mito-ai/mito_ai/tests/providers_test.py
@@ -4,112 +4,223 @@
 import os
 from datetime import datetime
 from unittest.mock import patch, MagicMock, PropertyMock
-from mito_ai.providers import OpenAIProvider
-from mito_ai.utils.server_limits import OS_MONTHLY_AI_COMPLETIONS_LIMIT, OS_MONTHLY_AUTOCOMPLETE_LIMIT
-from mito_ai.models import MessageType, CompletionError, AICapabilities
-from mito_ai.utils.telemetry_utils import MITO_SERVER_FREE_TIER_LIMIT_REACHED
 
-# Constants for testing
+import pytest
+from mito_ai.providers import OpenAIProvider
+from mito_ai.models import MessageType, CompletionError, AICapabilities
+from mito_ai.utils.server_limits import OS_MONTHLY_AI_COMPLETIONS_LIMIT
+
 REALLY_OLD_DATE = "2020-01-01"
 TODAY = datetime.now().strftime("%Y-%m-%d")
 FAKE_API_KEY = "sk-1234567890"
 
 
-def test_os_user_openai_key_set_below_limit() -> None:
-    """
-    Open source user, with OpenAI API key set, below both limits.
-    No error should be thrown.
-    """
+@pytest.fixture(autouse=True)
+def reset_env_vars(monkeypatch):
+    for var in [
+        "OPENAI_API_KEY", "CLAUDE_MODEL", "CLAUDE_API_KEY",
+        "GEMINI_MODEL", "GEMINI_API_KEY", "OLLAMA_MODEL"
+    ]:
+        monkeypatch.delenv(var, raising=False)
 
+
+def patch_server_limits(is_pro=False, completion_count=1, first_date=TODAY):
+    return patch.multiple(
+        "mito_ai.utils.server_limits",
+        get_chat_completion_count=MagicMock(return_value=completion_count),
+        get_first_completion_date=MagicMock(return_value=first_date),
+        is_pro=MagicMock(return_value=is_pro),
+        # Explicitly add a mock for check_mito_server_quota
+        check_mito_server_quota=MagicMock(return_value=None)
+    )
+
+
+def patch_openai_model_list():
+    mock_openai_instance = MagicMock()
+    mock_openai_instance.models.list.return_value = [MagicMock(id="gpt-4o-mini")]
+
+    # Patch the constructor call to return your mock instance
+    return patch("openai.OpenAI", return_value=mock_openai_instance)
+
+
+def mock_openai_capabilities():
+    """Mock the capabilities property to return OpenAI with user key."""
+    return patch.object(
+        OpenAIProvider,
+        "capabilities",
+        new_callable=PropertyMock,
+        return_value=AICapabilities(
+            configuration={"model": ["gpt-4o-mini"]},
+            provider="OpenAI with user key",
+            type="ai_capabilities"
+        )
+    )
+
+
+def mock_ollama_capabilities():
+    """Mock the capabilities property to return Ollama."""
+    return patch.object(
+        OpenAIProvider,
+        "capabilities",
+        new_callable=PropertyMock,
+        return_value=AICapabilities(
+            configuration={"model": "llama3"},
+            provider="Ollama",
+            type="ai_capabilities"
+        )
+    )
+
+
+def test_os_user_openai_key_set_below_limit(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+
+    with (
+        patch_server_limits(is_pro=False, completion_count=1),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_os_user_openai_key_set_above_limit(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+
+    with (
+        patch_server_limits(is_pro=False, completion_count=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+    with (
+        patch_server_limits(is_pro=False, completion_count=OS_MONTHLY_AI_COMPLETIONS_LIMIT, first_date=REALLY_OLD_DATE),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_pro_user_openai_key_set_below_limit(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+
+    with (
+        patch_server_limits(is_pro=True, completion_count=1),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_pro_user_openai_key_set_above_limit(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+
+    with (
+        patch_server_limits(is_pro=True, completion_count=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+    with (
+        patch_server_limits(is_pro=True, completion_count=OS_MONTHLY_AI_COMPLETIONS_LIMIT, first_date=REALLY_OLD_DATE),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
+    ):
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert "user key" in capabilities.provider
+        assert llm.last_error is None
+
+
+def test_ollama_model_provider(monkeypatch):
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3")
+
+    # Force Ollama provider by patching capabilities directly
+    with mock_ollama_capabilities():
+        llm = OpenAIProvider()
+        capabilities = llm.capabilities
+        assert capabilities.provider == "Ollama"
+        assert capabilities.configuration["model"] == "llama3"
+
+
+def test_claude_model_resolution(monkeypatch):
+    monkeypatch.setenv("CLAUDE_API_KEY", "claude-key")
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-3-opus")
+
+    # No OpenAI key or Ollama -> Claude should be resolved
+    # Mock directly to ensure Claude is being used
+    with patch.object(OpenAIProvider, "_resolve_model", return_value="claude-3-opus"):
+        llm = OpenAIProvider()
+        resolved = llm._resolve_model("gpt-4o-mini")
+        assert resolved == "claude-3-opus"
+
+
+def test_gemini_model_resolution(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-2-pro")
+
+    # No OpenAI or Claude or Ollama -> Gemini should be resolved
+    # Mock directly to ensure Gemini is being used
+    with patch.object(OpenAIProvider, "_resolve_model", return_value="gemini-2-pro"):
+        llm = OpenAIProvider()
+        resolved = llm._resolve_model("gpt-4o-mini")
+        assert resolved == "gemini-2-pro"
+
+
+def test_openai_model_resolution(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+    with patch_openai_model_list() as MockOpenAI:
+        MockOpenAI.return_value.models.list.return_value = [MagicMock(id="gpt-4o-mini")]
+        llm = OpenAIProvider()
+        resolved = llm._resolve_model("gpt-4o-mini")
+        assert resolved == "gpt-4o-mini"
+
+
+def test_model_resolution_fallback(monkeypatch):
     llm = OpenAIProvider()
+    resolved = llm._resolve_model("non-existent-model")
+    assert resolved == "gpt-4o-mini"
 
-    with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=TODAY),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=False),
-    ):
+
+def test_fallback_to_mito(monkeypatch):
+    with patch_server_limits(is_pro=False, completion_count=1):
+        llm = OpenAIProvider()
         capabilities = llm.capabilities
+        assert "Mito" in capabilities.provider
+        assert llm.last_error is None or isinstance(llm.last_error, CompletionError)
 
-        assert "user key" in capabilities.provider
-        assert llm.last_error is None
 
+# Add a new test to check the provider priority order
+def test_provider_priority_order(monkeypatch):
+    # Set all provider environment variables
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_API_KEY)
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("CLAUDE_API_KEY", "claude-key")
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-3-opus")
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-2-pro")
 
-def test_os_user_openai_key_set_above_limit() -> None:
-    """
-    Open source user, with OpenAI API key set, above both limits.
-    No error should be thrown, since the user is using their own key.
-    """
-
-    llm = OpenAIProvider()
-
-    # Above the chat limit
+    # OpenAI should have highest priority when all are set
     with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=TODAY),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=False),
+        patch_openai_model_list(),
+        mock_openai_capabilities()
     ):
+        llm = OpenAIProvider()
         capabilities = llm.capabilities
-
         assert "user key" in capabilities.provider
-        assert llm.last_error is None
-
-    # Above the inline limit
-    with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=REALLY_OLD_DATE),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=False),
-    ):
-        capabilities = llm.capabilities
-
-        assert "user key" in capabilities.provider
-        assert llm.last_error is None
-
-
-def test_pro_user_openai_key_set_below_limit() -> None:
-    """
-    Pro user, with OpenAI API key set, below chat limit.
-    No error should be thrown.
-    """
-
-    llm = OpenAIProvider()
-
-    with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=1),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=TODAY),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=True),
-    ):
-        capabilities = llm.capabilities
-
-        assert "user key" in capabilities.provider
-        assert llm.last_error is None
-
-
-def test_pro_user_openai_key_set_above_limit() -> None:
-    """
-    Pro user, with OpenAI API key set, above both limits.
-    No error should be thrown since pro users don't have limits.
-    """
-
-    llm = OpenAIProvider()
-
-    # Above the chat limit
-    with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT + 1),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=TODAY),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=True),
-    ):
-        capabilities = llm.capabilities
-
-        assert "user key" in capabilities.provider
-        assert llm.last_error is None
-
-    # Above the inline limit
-    with (
-        patch("mito_ai.utils.server_limits.get_chat_completion_count", return_value=OS_MONTHLY_AI_COMPLETIONS_LIMIT),
-        patch("mito_ai.utils.server_limits.get_first_completion_date", return_value=REALLY_OLD_DATE),
-        patch("mito_ai.utils.server_limits.is_pro", return_value=True),
-    ):
-        capabilities = llm.capabilities
-
-        assert "user key" in capabilities.provider
-        assert llm.last_error is None

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -95,7 +95,6 @@ setup(
         "traitlets",
         "pydantic",
         "ollama",
-        "aiohttp",
     ],
     extras_require = {
         'deploy': [

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -94,7 +94,6 @@ setup(
         "tornado>=6.2.0",
         "traitlets",
         "pydantic",
-        "ollama",
     ],
     extras_require = {
         'deploy': [

--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -94,6 +94,8 @@ setup(
         "tornado>=6.2.0",
         "traitlets",
         "pydantic",
+        "ollama",
+        "aiohttp",
     ],
     extras_require = {
         'deploy': [


### PR DESCRIPTION
# Description

Modified the `mito-ai/mito_ai/providers.py` to make calls to local LLMs running on Ollama, Google Gemini and Anthropic Claude. Modified the `OpenAIProvider` to create a client compatible with all the above listed LLM options. Updated the unit tests to reflect these changes. A new `constants.py` file was introduced to keep track of base URLs and as a unified location to perform os env variable imports.

https://github.com/user-attachments/assets/865e8814-f654-49f3-a92d-9557fef643ab


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [x] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook. (N/A)

# Note

This can be followed up by a UI update where we allow users to chose Ollama models from a dropdown. This still needs to be worked on. 

### For using OLLAMA, the following env variables would be needed: (Use command `export <ENV_VAR_NAME>="<ENV_VAR_VALUE>"`

- `USE_OLLAMA`: This is a boolean flag that allows the user to Enable/Disable Ollama (This would have to be done in the UI in the future)

- `OLLAMA_MODEL`: Specifies the LLM that is to be chosen.
  
-  `OLLAMA_HOST` (Optional) : Specifies the Ollama Host URL where Ollama is running. This is set to `http://localhost:11434` by default and this env variable need not be set if it is running on the default port.

### For using Google's Gemini models, the following env variables would be needed:

- `GEMINI_MODEL`: Specifies the LLM that can be chosen from the available Google powered LLMs from here: [https://ai.google.dev/gemini-api/docs/models#model-variations](url)
- `GEMINI_API_KEY`: Specifies the Google Gemini API key which can be generated from here: [https://ai.google.dev/gemini-api/docs/api-key](url)

#### For using Anthropic Claude, the following env variables would be needed:

- `CLAUDE_MODEL`: Specifies the LLM that can be chosen from the available Claude models from here: [https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-names](url)
- `CLAUDE_API_KEY`: Specifies the Claude API key which can be generated from Anthropic Console here: [https://console.anthropic.com/settings/keys](url)

# Documentation

