### PR TITLE
Agent output tool - dark mode fix

### DIFF
--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -155,7 +155,7 @@ This attribute is observed by the websocket provider to push the error to the cl
             )
 
         if self.api_key:
-            if self._models is None:
+            if self.models is None:
                 self._validate_api_key(self.api_key)
 
             return AICapabilities(

--- a/mito-ai/style/GetCellOutputToolUI.css
+++ b/mito-ai/style/GetCellOutputToolUI.css
@@ -8,10 +8,10 @@
     flex-direction: row;
     align-items: center;
     justify-content: start;
-    background-color: white;
+    background-color: transparent;
     padding: 10px;
     border-radius: 5px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--jp-ui-font-color2);
     margin: 10px 0;
     color: var(--jp-ui-font-color2);
 }


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1620. Updated the CSS for the agent output tool. 

Also, fixed a bug in `providers.py` --  we we're referencing a variable that does note exists (`_models`).  

# Testing

Send a message that will require the agent to confirm the output. For example, create a `name` variable, and ask the Agent to "print name and make sure it says..." 

Once you have the get output `GetCellOutputToolUI` component on screen, toggle between the different themes.   

# Documentation

N/A