### PR TITLE
Agent mode can install packages

### DIFF
--- a/mito-ai/mito_ai/prompt_builders/agent_smart_debug_prompt.py
+++ b/mito-ai/mito_ai/prompt_builders/agent_smart_debug_prompt.py
@@ -53,6 +53,7 @@ ERROR CORRECTION:
 - Make the solution as simple as possible.
 - Reuse as much of the existing code as possible.
 - DO NOT ADD TEMPORARY COMMENTS like '# Fixed the typo here' or '# Added this line to fix the error'
+- If you encounter a ModuleNotFoundError, you can install the package by adding the the following line to the top of the code cell: `!pip install <package_name> --quiet`.
 
 <Example>
 

--- a/mito-ai/mito_ai/prompt_builders/smart_debug_prompt.py
+++ b/mito-ai/mito_ai/prompt_builders/smart_debug_prompt.py
@@ -155,6 +155,7 @@ Solution Requirements:
 - Reuse as much of the existing code as possible.
 - Do not add temporary comments like '# Fixed the typo here' or '# Added this line to fix the error'
 - The code in the SOLUTION section should be a python code block starting with ```python and ending with ```
+- If you encounter a ModuleNotFoundError, you can install the package by adding the the following line to the top of the code cell: `!pip install <package_name> --quiet`.
 
 Here is your task. 
 

--- a/mito-ai/mito_ai/providers.py
+++ b/mito-ai/mito_ai/providers.py
@@ -155,7 +155,7 @@ This attribute is observed by the websocket provider to push the error to the cl
             )
 
         if self.api_key:
-            if self._models is None:
+            if self.models is None:
                 self._validate_api_key(self.api_key)
 
             return AICapabilities(


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1627. Adds instructions on how the Agent can install packages it needs. 

# Testing

Uninstall matplotlib:

```bash
!pip uninstall matplotlib
```

Then ask the Agent to "make a chart." 

The Agent should assume matplotlib is already installed, and start to create a chart. When it runs the code you should get a ModuleNotFoundError. 

Alternatively, you could ask the Agent to use a library you don't have installed (seaborn, pytorch, etc). However, it may install the package before getting started. To avoid this behavior you may need to prompt it to not install anything until it hits an error. 

# Documentation

N/A