### PR TITLE
Smart debug not creating new chat

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -330,8 +330,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         // Step 0: Reject the previous Ai generated code if they did not accept it
         rejectAICode()
 
-        // Step 1. Clear the chat when there is a new error to debug
-        const newChatHistoryManager = await startNewChat()
+        // Step 1: Add the smart debug message to the chat history
+        const newChatHistoryManager = getDuplicateChatHistoryManager()
 
         const smartDebugMetadata = newChatHistoryManager.addSmartDebugMessage(activeThreadIdRef.current, errorMessage)
         setChatHistoryManager(newChatHistoryManager);
@@ -371,8 +371,9 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         // Step 0: Reject the previous Ai generated code if they did not accept it
         rejectAICode()
 
-        // Step 1: Clear the chat history, and add the explain code message
-        const newChatHistoryManager = await startNewChat()
+        // Step 1: Add the code explain message to the chat history
+        const newChatHistoryManager = getDuplicateChatHistoryManager()
+
         const explainCodeMetadata = newChatHistoryManager.addExplainCodeMessage(activeThreadIdRef.current)
         setChatHistoryManager(newChatHistoryManager)
         setLoadingAIResponse(true)


### PR DESCRIPTION
# Description

Addresses https://github.com/mito-ds/mito/issues/1628.

Smart debug and code will now be added to the current chat history. This way you can continue to work and debug in the same thread. 

# Testing

Send a few messages, create an error, debug the error. You should see the smart debug message in the same chat. 

# Documentation

N/A