### PR TITLE
Citation scroll position dynamically set

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { scrollToCell } from '../../../utils/notebook';
+import { scrollToCell, getCellCodeByID } from '../../../utils/notebook';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import '../../../../style/Citation.css';
 
@@ -19,7 +19,15 @@ export interface CitationProps {
 // Citation button component
 export const Citation: React.FC<CitationProps> = ({ citationIndex, cellId, line, notebookTracker }): JSX.Element => {
   const handleClick = (): void => {
-    scrollToCell(notebookTracker, cellId, line);
+    // To determine how we should handle scrolling, 
+    // we need to first count the number of lines in the cell.
+    // If the line is closer to the top, 
+    // we set the scroll position to "start," otherwise we set it to "end."
+    const code = getCellCodeByID(notebookTracker, cellId);
+    const relativeLinePosition = line / (code?.split('\n').length || 1);
+    const position = relativeLinePosition < 0.5 ? 'start' : 'end';
+
+    scrollToCell(notebookTracker, cellId, line, position);
   };
 
   return (


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1653

Before we used to scroll to the center of the cell. This would get the highlighted line in focus most of the time. 

This PR introduces a way of dynamically determine the scroll position by determining where the line is located within the cell. If the line is above the halfway mark, we scroll to the start of the cell, and if the line is below the half way mark, we scroll to the end. 

# Testing

Create a few cells with lots of content, make sure you need to scroll to see cells. Then ask a question that will return a citation. If the cell is higher up in the cell, the window should scroll so that the top of the cell is reached.

# Documentation

N/A