### PR TITLE
mito-ai: fix is pro logging

### DIFF
--- a/mito-ai/mito_ai/handlers.py
+++ b/mito-ai/mito_ai/handlers.py
@@ -66,7 +66,8 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         self.log.debug("Initializing websocket connection %s", self.request.path)
         self._llm = llm
         self.is_pro = is_pro()
-
+        initialize_user(llm.key_type)
+        
     @property
     def log(self) -> logging.Logger:
         """Use Mito AI logger"""

--- a/mito-ai/mito_ai/utils/create.py
+++ b/mito-ai/mito_ai/utils/create.py
@@ -57,7 +57,7 @@ def try_create_user_json_file() -> None:
             set_user_field(UJ_USER_EMAIL, GITHUB_ACTION_EMAIL)
 
 
-def initialize_user(key_type: Optional[Literal['mito_server_key', 'user_key']]=None) -> None:
+def initialize_user(key_type: Optional[str] = None) -> None:
     """
     Internal helper function that gets called whenever a ai completion is requested.
 

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -40,7 +40,7 @@ MITO_SERVER_NUM_USAGES = 'mito_server_num_usages'
 MITO_SERVER_FREE_TIER_LIMIT_REACHED = 'mito_server_free_tier_limit_reached'
 #################################
 
-def telemetry_turned_on(key_type: Optional[Literal['mito_server_key', 'user_key']]=None) -> bool:
+def telemetry_turned_on(key_type: Optional[str] = None) -> bool:
     """
     Helper function that tells you if logging is turned on or
     turned off on the entire Mito instance
@@ -66,14 +66,17 @@ def telemetry_turned_on(key_type: Optional[Literal['mito_server_key', 'user_key'
     
     return bool(telemetry)
 
-def identify(key_type: Optional[Literal['mito_server_key', 'user_key']]=None) -> None:
+def identify(key_type: Optional[str] = None) -> None:
     """
     Helper function for identifying a user. We just take
     their python version, mito version, and email.
     """
     if not telemetry_turned_on(key_type):
+        print(f"telemetry turned off for {key_type}")
         return
 
+
+    print("I AM HERE!")
     static_user_id = get_user_field(UJ_STATIC_USER_ID)
     user_email = get_user_field(UJ_USER_EMAIL)
     feedbacks_v2 = get_user_field(UJ_FEEDBACKS_V2)

--- a/mito-ai/mito_ai/utils/version_utils.py
+++ b/mito-ai/mito_ai/utils/version_utils.py
@@ -38,13 +38,17 @@ def is_pro() -> bool:
     Helper function for returning if this is a
     pro deployment of mito
     """
+    
+    print("IN IS PRO")
 
     # This package overides the user.json
     if MITOSHEET_HELPER_PRO:
+        print('here')
         return True
 
     # This package overides the user.json
     if MITOSHEET_PRIVATE:
+        print('here2')
         return True
 
     # Check if the config is set
@@ -53,12 +57,15 @@ def is_pro() -> bool:
 
     # If you're on Mito Enterprise, then you get all Mito Pro features
     if is_enterprise():
+        print('here3')
         return True
 
     pro = get_user_field(UJ_MITOSHEET_PRO)
     if pro is None:
+        print('here4')
         return False
     
+    print('here5')
     return bool(pro)
 
 def is_enterprise() -> bool:


### PR DESCRIPTION
# Description

Fixes is_pro logging. Now makes sure that the identify call happens once the key type is determined. We only log when using the mito server. 

# Testing

1. Turn on Pro
2. Make sure you are using the mito server
3. Send an AI chat
4. Check that your identify in mix panel shows that you are `is_pro` = `True`

# Documentation

Note if any new documentation needs to addressed or reviewed.