### PR TITLE
mito-ai: update jupyterlab version requirements

### DIFF
--- a/mito-ai/setup.py
+++ b/mito-ai/setup.py
@@ -88,7 +88,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "jinja2>=3.0.3",
-        "jupyterlab>=4.0.0,<5",
+        "jupyterlab>=4.1.0,<5",
         "openai>=1.0.0",
         'analytics-python',
         "tornado>=6.2.0",


### PR DESCRIPTION
# Description

This resolves this bug we were seeing. 
<img width="1226" alt="Screenshot 2025-05-12 at 1 06 10 PM" src="https://github.com/user-attachments/assets/68791906-5aea-468b-a12b-28da4a4cf280" />
