### PR TITLE
Added Files in Dropdown

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -33,6 +33,7 @@ interface ChatInputProps {
 
 export interface ExpandedVariable extends Variable {
     parent_df?: string;
+    file_name?: string;
 }
 
 const ChatInput: React.FC<ChatInputProps> = ({
@@ -178,10 +179,17 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         value: "replace_me",
                         parent_df: df.variable_name,
                     }))
-                ) || [])
+                ) || []),
+            // Add files
+            ...(contextManager?.files.map(file => ({
+                variable_name: file.file_name,
+                type: file.file_name.split('.').pop()?.toLowerCase() || '',
+                value: file.file_name,
+                file_name: file.file_name
+            })) || [])
         ];
         setExpandedVariables(expandedVariables);
-    }, [contextManager?.variables]);
+    }, [contextManager?.variables, contextManager?.files]);
 
     // If there are more than 8 lines, show the first 8 lines and add a "..."
     const activeCellCode = getCellCodeByID(notebookTracker, activeCellID) || ''


### PR DESCRIPTION
# Description

Addresses https://github.com/mito-ds/mito/issues/1540

Files from the Context Manager are now included in the `@` dropdown in chat task pane. 

# Testing

Add a csv file, then use the `@` feature in the chat task pane. From the dropdown menu, you should see the csv file.  

# Documentation

Yes, can we can add to https://docs.trymito.io/mito-ai/chat#using-variable-mentions