### PR TITLE
Added Packages Endpoint

### DIFF
--- a/mito-ai/mito_ai/settings/handlers.py
+++ b/mito-ai/mito_ai/settings/handlers.py
@@ -3,6 +3,7 @@
 
 import json
 import tornado
+import pkg_resources
 from jupyter_server.base.handlers import APIHandler
 from mito_ai.settings.utils import (
     get_settings_field,
@@ -39,3 +40,16 @@ class SettingsHandler(APIHandler):
         self.finish(
             json.dumps({"status": "updated", "key": key, "value": data["value"]})
         )
+
+
+class PackageHandler(APIHandler):
+    """Handler for working with pip packages"""
+
+    @tornado.web.authenticated
+    def get(self):
+        """Get a list of all installed packages"""
+        packages = [
+            {"name": package.key, "version": package.version}
+            for package in sorted(pkg_resources.working_set, key=lambda x: x.key)
+        ]
+        self.finish(json.dumps({"packages": packages}))

--- a/mito-ai/mito_ai/settings/urls.py
+++ b/mito-ai/mito_ai/settings/urls.py
@@ -3,7 +3,7 @@
 
 from typing import Any, List, Tuple
 from jupyter_server.utils import url_path_join
-from mito_ai.settings.handlers import SettingsHandler
+from mito_ai.settings.handlers import SettingsHandler, PackageHandler
 
 def get_settings_urls(base_url: str) -> List[Tuple[str, Any, dict]]:
     """Get all settings related URL patterns.
@@ -17,4 +17,5 @@ def get_settings_urls(base_url: str) -> List[Tuple[str, Any, dict]]:
     BASE_URL = base_url + "/mito-ai"
     return [
         (url_path_join(BASE_URL, "settings/(.*)"), SettingsHandler, {}),
+        (url_path_join(BASE_URL, "packages"), PackageHandler, {}),
     ]

--- a/mito-ai/mito_ai/tests/settings/packages_test.py
+++ b/mito-ai/mito_ai/tests/settings/packages_test.py
@@ -1,0 +1,12 @@
+import requests
+from mito_ai.tests.conftest import TOKEN
+
+
+def test_get_packages(jp_base_url):
+    response = requests.get(
+        jp_base_url + "/mito-ai/packages",
+        headers={"Authorization": f"token {TOKEN}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["packages"] is not None
+    assert "mito-ai" in [package["name"] for package in response.json()["packages"]]


### PR DESCRIPTION
# Description

Added a new endpoint to get a list of all pip packages installed. This will let us remove all of the database drivers from setup.py and only install them when needed. 

# Testing

Test the new endpoint:

```
curl --request GET \
  --url http://localhost:8888/mito-ai/packages \
  --header 'authorization: token <YOUR_TOKEN>'
```

# Documentation

N/A