### PR TITLE
Modifying the label of button from 'Build App' to 'Deploy App'

### DIFF
--- a/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
+++ b/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
@@ -14,7 +14,7 @@ import { getSetting } from '../../restAPI/RestAPI';
 
 const ToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
     // Important: The Cell Toolbar Buttons are added to the toolbar registry via the schema/toolbar-buttons.json file.
-    // The id here must be mito-ai:toolbar-buttons otherwise the buttons are not successfull added. My understanding is that
+    // The id here must be mito-ai:toolbar-buttons otherwise the buttons are not successfully added. My understanding is that
     // the id must match the name of the package and `toolbar-buttons` must match the name of the .json file.
     id: 'mito_ai:toolbar-buttons',
     description: 'Adds an "explain code cell with AI" button to the cell toolbar',
@@ -70,7 +70,7 @@ const ToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
         });
 
         commands.addCommand('toolbar-button:convert-to-streamlit', {
-            label: 'Build App',
+            label: 'Deploy App',
             caption: 'Convert to Streamlit',
             className: 'text-button-mito-ai button-base button-purple button-small',
             execute: async () => {


### PR DESCRIPTION
# Description

This is a small change to the label of the `Build App` button which is used to convert the outputs to a streamlit dashboard.

# Testing

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.
