### PR TITLE
Apply when code is generated

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -127,6 +127,11 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
         return <></>
     }
 
+    // While the code is streaming back we don't want to show the overwrite button. 
+    // Users end up applying the code in the middle of streaming and it gets very confusing
+    // very quickly for users. 
+    let isCodeComplete = false;
+
     return (
         <div className={classNames(
             "message",
@@ -135,6 +140,9 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
         )}>
             {messageContentParts.map((messagePart, index) => {
                 if (messagePart.startsWith(PYTHON_CODE_BLOCK_START_WITHOUT_NEW_LINE)) {
+                    
+                    isCodeComplete = messagePart.endsWith('```');
+
                     // Make sure that there is actually code in the message. 
                     // An empty code will look like this '```python  ```'
                     if (messagePart.length > 14) {
@@ -143,6 +151,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                 <CodeBlock
                                     key={index + messagePart}
                                     code={messagePart}
+                                    isCodeComplete={isCodeComplete}
                                     role={message.role}
                                     renderMimeRegistry={renderMimeRegistry}
                                     previewAICode={previewAICode}
@@ -152,7 +161,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                     codeReviewStatus={codeReviewStatus}
                                 />
 
-                                {isLastAiMessage && codeReviewStatus === 'chatPreview' && 
+                                {isLastAiMessage && isCodeComplete && codeReviewStatus === 'chatPreview' && 
                                     <div className='chat-message-buttons'>
                                         <TextAndIconButton 
                                             onClick={() => {previewAICode()}}
@@ -172,7 +181,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                         />
                                     </div>
                                 }
-                                {isLastAiMessage && codeReviewStatus === 'codeCellPreview' && 
+                                {isLastAiMessage && isCodeComplete && codeReviewStatus === 'codeCellPreview' && 
                                     <div className='chat-message-buttons'>
                                         <TextButton 
                                             onClick={() => {acceptAICode()}}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/CodeBlock.tsx
@@ -19,6 +19,7 @@ import ExpandIcon from '../../../icons/ExpandIcon';
 
 interface ICodeBlockProps {
     code: string,
+    isCodeComplete: boolean,
     role: 'user' | 'assistant'
     renderMimeRegistry: IRenderMimeRegistry
     previewAICode: () => void
@@ -30,6 +31,7 @@ interface ICodeBlockProps {
 
 const CodeBlock: React.FC<ICodeBlockProps> = ({
     code,
+    isCodeComplete,
     role,
     renderMimeRegistry,
     previewAICode,
@@ -77,7 +79,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
             <div className='code-block-container'>
                 <>
                     {/* The code block toolbar for the last AI message */}
-                    {isLastAiMessage && 
+                    {isLastAiMessage && isCodeComplete && 
                         <div className='code-block-toolbar'>
                             {codeReviewStatus === 'chatPreview' && 
                                 <IconButton 

--- a/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
+++ b/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
@@ -79,6 +79,7 @@ const ToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
             isVisible: () => {
                 // Default to hidden, will be updated after async check since we are not allowed to 
                 // use async commands in isVisible.
+                return true;
                 return app.commands.hasCommand('mito-ai:beta-mode-enabled');
             }
         });

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -361,21 +361,19 @@ describe('ChatMessage Component', () => {
 
         it('does not show overwrite button when code is still generating (incomplete)', () => {
             renderChatMessage({
-                message: createMockMessage('assistant', 'Here is some code:\n```python\nimport pandas as pd\ndf = pd.DataFrame({"A": [1, 2, 3]})'),
+                message: createMockMessage('assistant', '```python\nimport pandas as pd\ndf = pd.DataFrame({"A": [1, 2, 3]})'),
                 isLastAiMessage: true,
                 codeReviewStatus: 'chatPreview'
             });
 
-            // Find all buttons on the page
-            const buttons = screen.getAllByRole('button');
-            const buttonTexts = buttons.map(button => button.textContent || '');
+            const buttons = screen.queryAllByRole('button');
 
-            // Verify that the "Overwrite" button is NOT present when code is incomplete
-            expect(buttonTexts.some(text => text.includes('Overwrite') || text.includes('Active'))).toBe(false);
-            expect(buttonTexts.some(text => text.includes('Copy'))).toBe(false);
+            // Verify that no buttons are present when code is incomplete
+            expect(buttons).toHaveLength(0);
 
-            // Verify that the chat-message-buttons container is not present
+            // Also verify that the specific button texts are not present
             expect(screen.queryByText('Overwrite Active Cell')).not.toBeInTheDocument();
+            expect(screen.queryByText('Copy')).not.toBeInTheDocument();
         });
     });
 }); 

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -358,5 +358,24 @@ describe('ChatMessage Component', () => {
             expect(screen.getByTestId('get-cell-output-tool')).toBeInTheDocument();
             expect(screen.getByText('Taking a look at the cell output')).toBeInTheDocument();
         });
+
+        it('does not show overwrite button when code is still generating (incomplete)', () => {
+            renderChatMessage({
+                message: createMockMessage('assistant', 'Here is some code:\n```python\nimport pandas as pd\ndf = pd.DataFrame({"A": [1, 2, 3]})'),
+                isLastAiMessage: true,
+                codeReviewStatus: 'chatPreview'
+            });
+
+            // Find all buttons on the page
+            const buttons = screen.getAllByRole('button');
+            const buttonTexts = buttons.map(button => button.textContent || '');
+
+            // Verify that the "Overwrite" button is NOT present when code is incomplete
+            expect(buttonTexts.some(text => text.includes('Overwrite') || text.includes('Active'))).toBe(false);
+            expect(buttonTexts.some(text => text.includes('Copy'))).toBe(false);
+
+            // Verify that the chat-message-buttons container is not present
+            expect(screen.queryByText('Overwrite Active Cell')).not.toBeInTheDocument();
+        });
     });
 }); 

--- a/mito-ai/src/tests/AiChat/CodeBlock.test.tsx
+++ b/mito-ai/src/tests/AiChat/CodeBlock.test.tsx
@@ -102,4 +102,42 @@ describe('CodeBlock Component', () => {
             expect(renderedLines[6]).toBe('line7');
         });
     });
+
+    describe('Assistant Code Actions', () => {
+        it('does not show action buttons when code is incomplete', () => {
+            const props = createMockProps({
+                role: 'assistant',
+                isLastAiMessage: true,
+                isCodeComplete: false,
+                codeReviewStatus: 'chatPreview'
+            });
+            render(<CodeBlock {...props} />);
+
+            // Verify that action buttons are not present when code is incomplete
+            expect(screen.queryByTitle('Overwrite Active Cell')).not.toBeInTheDocument();
+            expect(screen.queryByTitle('Copy')).not.toBeInTheDocument();
+            expect(screen.queryByTitle('Accept AI Generated Code')).not.toBeInTheDocument();
+            expect(screen.queryByTitle('Reject AI Generated Code')).not.toBeInTheDocument();
+
+            // Verify that the toolbar container is not present
+            expect(document.querySelector('.code-block-toolbar')).not.toBeInTheDocument();
+        });
+
+        it('shows action buttons when code is complete and is last AI message', () => {
+            const props = createMockProps({
+                role: 'assistant',
+                isLastAiMessage: true,
+                isCodeComplete: true,
+                codeReviewStatus: 'chatPreview'
+            });
+            render(<CodeBlock {...props} />);
+
+            // Verify that action buttons are present when code is complete
+            expect(screen.getByTitle('Overwrite Active Cell')).toBeInTheDocument();
+            expect(screen.getByTitle('Copy')).toBeInTheDocument();
+
+            // Verify that the toolbar container is present
+            expect(document.querySelector('.code-block-toolbar')).toBeInTheDocument();
+        });
+    });
 });

--- a/mito-ai/src/tests/AiChat/CodeBlock.test.tsx
+++ b/mito-ai/src/tests/AiChat/CodeBlock.test.tsx
@@ -23,6 +23,7 @@ jest.mock('../../Extensions/AiChat/ChatMessage/PythonCode', () => {
 // Create base props for the component
 const createMockProps = (overrides = {}) => ({
     code: 'line1\nline2\nline3\nline4\nline5\nline6\nline7',
+    isCodeComplete: true,
     role: 'user' as const,
     renderMimeRegistry: {} as IRenderMimeRegistry,
     previewAICode: jest.fn(),


### PR DESCRIPTION
# Description

Updates the taskpane so that it does not show the `Overwrite` or `Copy` button until the entire code cell is generated by the AI. This is useful for streaming when where we don't want the user to apply the code to the cell before it's done generating. If they do, it leads to pretty confusing behavior. 

I saw a user do this yesterday where they:
1. Pressed apply before the code was done generating
2. Ran the code and it errored
3. Pressed the `fix in ai chat` button
4. Got the AI response and the the original code was still rendering at the same time, leading to a bunch of unstyled code that was just very hard for them to understand what was going on. 

Note: Sometimes the Ai generated code is displayed in markdown instead of the code cell until the entire code cell is done rendering. We should fix that in a future PR too. 

# Testing

Try it out + see the new jest tests. 

# Documentation

No
