### PR TITLE
Modifying commands to generate the correct requirements.txt file

### DIFF
--- a/mito-ai/src/Extensions/AppBuilder/requirementsUtils.tsx
+++ b/mito-ai/src/Extensions/AppBuilder/requirementsUtils.tsx
@@ -46,15 +46,36 @@ with tempfile.TemporaryDirectory() as temp_dir:
     with open(temp_file, "w") as f:
         f.write("""${codeContent}""")
     
-    # Make sure pipreqs is installed
+    # Make sure pipreqs is installed. Then
+    # 1. Create a requirements.in file
+    # 2. From the requirements.in file, generate the requirements.txt file with the canonical PyPI name of the packages
+    # and the versions as they exist on the user's terminal
     try:
         # Run pipreqs on the temporary directory
-        result = subprocess.run(
-            ['pipreqs', '--force', '--savepath', '-', temp_dir],
+        generate_req_in_file = subprocess.run(
+            ['pipreqs', '--savepath', 'requirements.in', '--force', temp_dir],
             capture_output=True, 
             text=True
         )
-        print(result.stdout)
+
+        command_for_generating_req_txt_file = r"""
+        cat requirements.in | while read line; do \\
+        pkg=$(echo $line | cut -d'=' -f1 | tr -d '[:space:]'); \\
+        version=$(pip show "$pkg" 2>/dev/null | grep -i '^Version:' | awk '{print $2}'); \\
+        name=$(pip show "$pkg" 2>/dev/null | grep -i '^Name:' | awk '{print $2}'); \\
+        if [[ -n "$name" && -n "$version" ]]; then echo "$name==$version"; else echo "$line"; fi; \\
+        done"""
+
+        generate_req_txt_file = subprocess.run(
+            command_for_generating_req_txt_file,
+            shell=True,
+            executable="/bin/bash",
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print(generate_req_txt_file.stdout)
+
     except Exception as e:
         print(f"Error running pipreqs: {e}")
 `;


### PR DESCRIPTION
# Description

This PR includes the change to generate the correct requirements.txt file from the code present in the notebook. 

# Testing


- [ ] I have tested this on real data that is reasonable
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation
The file is generated in 3 steps:
1. Create a temporary directory with the notebook code saved as a .py file
2. Run pipreqs to get the list of imports needed and save it in a requirements.in file
3. Since some package names dont match their canonical names which need to be used for import, match the packages in the requirements.in file with the packages and versions present in the user's terminal