### PR TITLE
Unit tests and Jest tests for the multi modal providers work.

### DIFF
--- a/mito-ai/mito_ai/tests/utils/test_anthropic_utils.py
+++ b/mito-ai/mito_ai/tests/utils/test_anthropic_utils.py
@@ -1,0 +1,154 @@
+import pytest
+import anthropic
+from typing import List, Dict, Any, Tuple, Union, cast
+from anthropic.types import MessageParam, ToolUnionParam, ToolParam
+from mito_ai.utils.anthropic_utils import _prepare_anthropic_request_data_and_headers
+from mito_ai.completions.models import MessageType
+from mito_ai.utils.schema import UJ_STATIC_USER_ID, UJ_USER_EMAIL
+from mito_ai.utils.db import get_user_field
+
+
+# Mock the get_user_field function
+@pytest.fixture(autouse=True)
+def mock_get_user_field(monkeypatch):
+    def mock_get_field(field):
+        if field == UJ_USER_EMAIL:
+            return "test@example.com"
+        elif field == UJ_STATIC_USER_ID:
+            return "test_user_id"
+        return None
+
+    monkeypatch.setattr("mito_ai.utils.anthropic_utils.get_user_field", mock_get_field)
+
+
+def test_basic_request_preparation():
+    """Test basic request preparation with minimal parameters"""
+    model = "claude-3-sonnet"
+    max_tokens = 100
+    temperature = 0.7
+    # Use NotGiven to ensure system is not included in inner_data
+    system = cast(Tuple[Union[str, anthropic.NotGiven]], (anthropic.NotGiven(),))
+    messages: List[MessageParam] = [{"role": "user", "content": "Hello"}]
+    message_type = MessageType.CHAT
+
+    data, headers = _prepare_anthropic_request_data_and_headers(
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        system=system,
+        messages=messages,
+        message_type=message_type,
+        tools=None,
+        tool_choice=None,
+        stream=None
+    )
+
+    assert headers == {"Content-Type": "application/json"}
+    assert data["timeout"] == 30
+    assert data["max_retries"] == 1
+    assert data["email"] == "test@example.com"
+    assert data["user_id"] == "test_user_id"
+
+    inner_data = data["data"]
+    assert inner_data["model"] == model
+    assert inner_data["max_tokens"] == max_tokens
+    assert inner_data["temperature"] == temperature
+    assert inner_data["messages"] == messages
+    # When system is NotGiven, it should not be included in inner_data
+    assert "system" not in inner_data
+
+
+def test_system_message_handling():
+    """Test handling of system message when provided"""
+    system = cast(Tuple[Union[str, anthropic.NotGiven]], ("You are a helpful assistant",))
+    messages: List[MessageParam] = [{"role": "user", "content": "Hello"}]
+
+    data, _ = _prepare_anthropic_request_data_and_headers(
+        model="claude-3-sonnet",
+        max_tokens=100,
+        temperature=0.7,
+        system=system,
+        messages=messages,
+        message_type=MessageType.CHAT,
+        tools=None,
+        tool_choice=None,
+        stream=None
+    )
+
+    assert data["data"]["system"] == system[0]
+
+
+def test_tools_and_tool_choice():
+    """Test handling of tools and tool_choice parameters"""
+    tools = cast(List[ToolUnionParam], [{
+        "type": "function",
+        "function": {
+            "name": "test_function",
+            "description": "A test function",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    }])
+    tool_choice: Dict[str, Any] = {"type": "function", "function": {"name": "test_function"}}
+
+    data, _ = _prepare_anthropic_request_data_and_headers(
+        model="claude-3-sonnet",
+        max_tokens=100,
+        temperature=0.7,
+        system=cast(Tuple[Union[str, anthropic.NotGiven]], (anthropic.NotGiven(),)),
+        messages=[{"role": "user", "content": "Hello"}],
+        message_type=MessageType.CHAT,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=None
+    )
+
+    assert data["data"]["tools"] == tools
+    assert data["data"]["tool_choice"] == tool_choice
+
+
+def test_stream_parameter():
+    """Test handling of stream parameter"""
+    data, _ = _prepare_anthropic_request_data_and_headers(
+        model="claude-3-sonnet",
+        max_tokens=100,
+        temperature=0.7,
+        system=cast(Tuple[Union[str, anthropic.NotGiven]], (anthropic.NotGiven(),)),
+        messages=[{"role": "user", "content": "Hello"}],
+        message_type=MessageType.CHAT,
+        tools=None,
+        tool_choice=None,
+        stream=True
+    )
+
+    assert data["data"]["stream"] is True
+
+
+def test_missing_user_info(monkeypatch):
+    """Test behavior when user email and ID are not available"""
+
+    def mock_get_field(field):
+        return None
+
+    # Override the autouse fixture for this specific test
+    monkeypatch.setattr("mito_ai.utils.anthropic_utils.get_user_field", mock_get_field)
+    monkeypatch.setattr("mito_ai.utils.anthropic_utils.__user_email", None)
+    monkeypatch.setattr("mito_ai.utils.anthropic_utils.__user_id", None)
+
+    data, _ = _prepare_anthropic_request_data_and_headers(
+        model="claude-3-sonnet",
+        max_tokens=100,
+        temperature=0.7,
+        system=cast(Tuple[Union[str, anthropic.NotGiven]], (anthropic.NotGiven(),)),
+        messages=[{"role": "user", "content": "Hello"}],
+        message_type=MessageType.CHAT,
+        tools=None,
+        tool_choice=None,
+        stream=None
+    )
+
+    assert data["email"] is None
+    assert data["user_id"] is None 

--- a/mito-ai/mito_ai/tests/utils/test_gemini_utils.py
+++ b/mito-ai/mito_ai/tests/utils/test_gemini_utils.py
@@ -1,0 +1,110 @@
+import pytest
+from mito_ai.utils.gemini_utils import _prepare_gemini_request_data_and_headers
+from mito_ai.completions.models import MessageType
+
+
+def test_basic_request_preparation():
+    """Test basic request preparation with minimal parameters."""
+    model = "gemini-pro"
+    contents = "test content"
+    message_type = MessageType.CHAT
+
+    data, headers = _prepare_gemini_request_data_and_headers(
+        model=model,
+        contents=contents,
+        message_type=message_type
+    )
+
+    assert headers == {"Content-Type": "application/json"}
+    assert data["timeout"] == 30
+    assert data["max_retries"] == 1
+    assert data["data"]["model"] == model
+    assert data["data"]["contents"] == contents
+    assert data["data"]["message_type"] == message_type.value
+    assert data["data"]["system_instructions"] == ""
+
+
+def test_request_with_system_instructions():
+    """Test request preparation with system instructions."""
+    model = "gemini-pro"
+    contents = "test content"
+    message_type = MessageType.CHAT
+    system_instructions = "You are a helpful assistant"
+
+    data, headers = _prepare_gemini_request_data_and_headers(
+        model=model,
+        contents=contents,
+        message_type=message_type,
+        system_instructions=system_instructions
+    )
+
+    assert data["data"]["system_instructions"] == system_instructions
+
+
+def test_request_with_config():
+    """Test request preparation with additional config parameters."""
+    model = "gemini-pro"
+    contents = "test content"
+    message_type = MessageType.CHAT
+    config = {
+        "temperature": 0.7,
+        "max_tokens": 100
+    }
+
+    data, headers = _prepare_gemini_request_data_and_headers(
+        model=model,
+        contents=contents,
+        message_type=message_type,
+        config=config
+    )
+
+    assert data["data"]["config"] == config
+
+
+def test_request_with_response_format():
+    """Test request preparation with response format info."""
+
+    class TestFormat:
+        name = "test_format"
+        format = "json"
+
+    model = "gemini-pro"
+    contents = "test content"
+    message_type = MessageType.CHAT
+    response_format_info = TestFormat()
+
+    data, headers = _prepare_gemini_request_data_and_headers(
+        model=model,
+        contents=contents,
+        message_type=message_type,
+        response_format_info=response_format_info
+    )
+
+    expected_format = {
+        "name": "test_format",
+        "format": "json"
+    }
+    assert data["data"]["response_format_info"] == '{"name": "test_format", "format": "json"}'
+
+
+def test_request_with_complex_config():
+    """Test request preparation with complex nested config."""
+    model = "gemini-pro"
+    contents = "test content"
+    message_type = MessageType.CHAT
+    config = {
+        "temperature": 0.7,
+        "nested": {
+            "key": "value",
+            "array": [1, 2, 3]
+        }
+    }
+
+    data, headers = _prepare_gemini_request_data_and_headers(
+        model=model,
+        contents=contents,
+        message_type=message_type,
+        config=config
+    )
+
+    assert data["data"]["config"] == config

--- a/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
+++ b/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import ModelSelector from '../../components/ModelSelector';
+
+describe('ModelSelector', () => {
+  const mockOnConfigChange = jest.fn();
+
+  beforeEach(() => {
+    // Clear mock calls before each test
+    mockOnConfigChange.mockClear();
+    // Clear localStorage before each test
+    localStorage.clear();
+  });
+
+  it('calls onConfigChange when a model is selected', () => {
+    render(<ModelSelector onConfigChange={mockOnConfigChange} />);
+    
+    // Open the dropdown
+    const dropdown = screen.getByText('GPT-4.1').closest('.model-selector-dropdown');
+    if (!dropdown) throw new Error('Dropdown element not found');
+    fireEvent.click(dropdown);
+
+    // Select a model (Claude 4 Opus)
+    const modelOption = screen.getByText('Claude 4 Opus');
+    fireEvent.click(modelOption);
+
+    // Verify onConfigChange was called with correct model
+    expect(mockOnConfigChange).toHaveBeenCalledWith({
+      model: 'claude-opus-4-20250514'
+    });
+  });
+
+  it('loads saved model from localStorage on mount', () => {
+    // Set up localStorage with a saved model
+    const savedConfig = {
+      model: 'claude-sonnet-4-20250514'
+    };
+    localStorage.setItem('llmModelConfig', JSON.stringify(savedConfig));
+
+    render(<ModelSelector onConfigChange={mockOnConfigChange} />);
+
+    // Verify onConfigChange was called with saved model on mount
+    expect(mockOnConfigChange).toHaveBeenCalledWith(savedConfig);
+  });
+}); 


### PR DESCRIPTION
# Description

- [x]  A basic jest test to make sure the model selector calls the update model on backend function
- [x]  Pytests for the `_extract_and_parse_json_response` for gemini, openai anthropic
- [x]  Pytests for `_prepare_gemini_request_data_and_headers` for gemini, openai, anthropic
- [x]  Basic pytests to make sure that the `request_completions` and `stream_completions` use the correct provider
- [x]  Extract_system_instruction_and_contents for gemini and anthropic

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

N.A