### PR TITLE
Oracle Support

### DIFF
--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -48,6 +48,7 @@ jobs:
         docker compose -f mito_ai/docker/postgres/compose.yml up -d
         docker compose -f mito_ai/docker/mysql/compose.yml up -d
         docker compose -f mito_ai/docker/mssql/compose.yml up -d
+        docker compose -f mito-ai/docker/oracle/compose.yml up -d
     - name: Run tests
       run: |
         cd mito-ai
@@ -64,6 +65,7 @@ jobs:
         docker compose -f mito_ai/docker/postgres/compose.yml down -v
         docker compose -f mito_ai/docker/mysql/compose.yml down -v
         docker compose -f mito_ai/docker/mssql/compose.yml down -v
+        docker compose -f mito-ai/docker/oracle/compose.yml down -v
     - name: Upload test-results
       uses: actions/upload-artifact@v4
       if: failure()

--- a/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
@@ -120,6 +120,11 @@ If the user has requested data that you believe is stored in the database:
 connections[connection_name]["username"]
 ```
 
+- When connecting to an Oracle database, use the following format:
+```
+conn_str = f"oracle+oracledb://username:password@host:port?service_name=service_name"
+```
+
 - The user may colloquially ask for a "list of x", always assume they want a pandas DataFrame. 
 - When working with dataframes created from an SQL query, ALWAYS use lowercase column names. 
 - If you think the requested data is stored in the database, but you are unsure, then ask the user for clarification.

--- a/mito-ai/mito_ai/db/crawlers/constants.py
+++ b/mito-ai/mito_ai/db/crawlers/constants.py
@@ -21,6 +21,11 @@ SUPPORTED_DATABASES: Dict[str, DatabaseConfig] = {
         "tables_query": "SHOW TABLES",
         "columns_query": "SHOW COLUMNS FROM {table}",
     },
+    "oracle": {
+        "drivers": ["oracledb"],
+        "tables_query": "SELECT table_name FROM user_tables",
+        "columns_query": "SELECT column_name, data_type FROM user_tab_columns WHERE table_name = :table",
+    },
     "postgres": {
         "drivers": ["psycopg2-binary"],
         "tables_query": "SELECT table_name FROM information_schema.tables WHERE table_schema = :schema",

--- a/mito-ai/mito_ai/db/utils.py
+++ b/mito-ai/mito_ai/db/utils.py
@@ -125,6 +125,9 @@ def crawl_and_store_schema(
         odbc_driver_version = connection_details["odbc_driver_version"]
         conn_str = f"mssql+pyodbc://{connection_details['username']}:{connection_details['password']}@{connection_details['host']}:{connection_details['port']}/{connection_details['database']}?driver=ODBC+Driver+{odbc_driver_version}+for+SQL+Server"
         schema = base_crawler.crawl_db(conn_str, "mssql")
+    elif connection_details["type"] == "oracle":
+        conn_str = f"oracle+oracledb://{connection_details['username']}:{connection_details['password']}@{connection_details['host']}:{connection_details['port']}?service_name={connection_details['service_name']}"
+        schema = base_crawler.crawl_db(conn_str, "oracle")
 
     if schema["error"]:
         return {

--- a/mito-ai/mito_ai/docker/oracle/compose.yml
+++ b/mito-ai/mito_ai/docker/oracle/compose.yml
@@ -1,0 +1,17 @@
+services:
+  db:
+    image: gvenzl/oracle-xe:21.3.0-slim
+    container_name: oracle_test_db
+    ports:
+      - "1521:1521"
+    environment:
+      ORACLE_PASSWORD: test_pass
+      APP_USER: test_user
+      APP_USER_PASSWORD: test_pass
+    volumes:
+      - oracle_data:/opt/oracle/oradata
+      - ./init:/container-entrypoint-startdb.d
+    restart: unless-stopped
+
+volumes:
+  oracle_data:

--- a/mito-ai/mito_ai/docker/oracle/init/setup.sql
+++ b/mito-ai/mito_ai/docker/oracle/init/setup.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) Saga Inc.
+-- Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+connect  test_user/test_pass@xepdb1;
+
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table department (id integer not null, name varchar(255), primary key (id));
+
+create table employee (id integer not null, email varchar(255), first_name varchar(255), gender varchar(255), last_name varchar(255), salary numeric(19,2), department_id integer, primary key (id));
+
+insert into department (id, name) values (1, 'IT');
+insert into department (id, name) values (2, 'HR');
+insert into department (id, name) values (3, 'Finance');
+
+insert into employee (id, email, first_name, gender, last_name, salary, department_id) values (1, 'john.doe@example.com', 'John', 'M', 'Doe', 50000, 1);
+insert into employee (id, email, first_name, gender, last_name, salary, department_id) values (2, 'jane.smith@example.com', 'Jane', 'F', 'Smith', 55000, 2);
+insert into employee (id, email, first_name, gender, last_name, salary, department_id) values (3, 'jim.beam@example.com', 'Jim', 'M', 'Beam', 60000, 3);
+
+COMMIT;

--- a/mito-ai/mito_ai/tests/db/oracle_test.py
+++ b/mito-ai/mito_ai/tests/db/oracle_test.py
@@ -1,0 +1,29 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import requests
+from mito_ai.tests.db.test_db_constants import ORACLE_CONNECTION_DETAILS
+from mito_ai.tests.conftest import TOKEN
+
+# To create a postgres database, run the following command:
+# docker-compose -f mito_ai/docker/postgres/compose.yml up
+# and then, to delete the database, run the following command:
+# docker-compose -f mito_ai/docker/postgres/compose.yml down -v
+
+
+def test_add_oracle_connection(jp_base_url: str) -> None:
+    response = requests.post(
+        jp_base_url + "/mito-ai/db/connections",
+        headers={"Authorization": f"token {TOKEN}"},
+        json=ORACLE_CONNECTION_DETAILS,
+    )
+    assert response.status_code == 200
+
+    # Get the schemas
+    response = requests.get(
+        jp_base_url + f"/mito-ai/db/schemas",
+        headers={"Authorization": f"token {TOKEN}"},
+    )
+    assert response.status_code == 200
+    # Esnure that there is one scema dict in the response
+    assert len(response.json()) == 1

--- a/mito-ai/mito_ai/tests/db/test_db_constants.py
+++ b/mito-ai/mito_ai/tests/db/test_db_constants.py
@@ -26,6 +26,14 @@ MYSQL_CONNECTION_DETAILS = {
     "port": "3306",
     "database": "test_db",
 }
+ORACLE_CONNECTION_DETAILS = {
+    "type": "oracle",
+    "username": "test_user",
+    "password": "test_pass",
+    "host": "localhost",
+    "port": "1521",
+    "service_name": "xepdb1",
+}
 POSTGRES_CONNECTION_DETAILS = {
     "type": "postgres",
     "username": "test_user",

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -3,7 +3,7 @@
 
 [build-system]
 requires = [
-    "hatchling>=1.5.0",
+    "hatchling>=1.27.0",
     "jupyterlab>=4.1.0,<5",
     "hatch-nodejs-version>=0.3.2",
     "hatch-jupyter-builder>=0.5"
@@ -55,7 +55,7 @@ test = [
 ]
 deploy = [
     "twine>=4.0.0",
-    "hatchling>=1.5.0",
+    "hatchling>=1.27.0",
     "hatch-nodejs-version>=0.3.2",
     "hatch-jupyter-builder>=0.5"
 ]

--- a/mito-ai/src/Extensions/SettingsManager/database/model.ts
+++ b/mito-ai/src/Extensions/SettingsManager/database/model.ts
@@ -119,6 +119,47 @@ export const databaseConfigs: Record<string, DatabaseConfig> = {
             }
         ]
     },
+    oracle: {
+        type: 'oracle',
+        displayName: 'Oracle',
+        fields: [
+            {
+                name: 'username',
+                type: 'text',
+                label: 'Username',
+                placeholder: 'john.doe',
+                required: true
+            },
+            {
+                name: 'password',
+                type: 'password',
+                label: 'Password',
+                placeholder: 'Enter your password',
+                required: true
+            },
+            {
+                name: 'host',
+                type: 'text',
+                label: 'Host',
+                placeholder: 'localhost',
+                required: true
+            },
+            {
+                name: 'port',
+                type: 'number',
+                label: 'Port',
+                placeholder: '1521',
+                required: true
+            },
+            {
+                name: 'service_name',
+                type: 'text',
+                label: 'Service Name',
+                placeholder: 'xe',
+                required: true
+            }
+        ]
+    },
     postgres: {
         type: 'postgres',
         displayName: 'PostgreSQL',


### PR DESCRIPTION
# Description

Added support for Oracle databases.

# Testing

Run

```bash
docker-compose -f mito_ai/docker/oracle/compose.yml up
```

Then try to connect using the following:

```python
ORACLE_CONNECTION_DETAILS = {
    "type": "oracle",
    "username": "test_user",
    "password": "test_pass",
    "host": "localhost",
    "port": "1521",
    "service_name": "xepdb1",
}
```

# Documentation

Yes, see https://docs.trymito.io/mito-ai/database-connectors/database-drivers