### PR TITLE
mito-ai: fix remove double scrollbar on taskpane

### DIFF
--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -11,8 +11,7 @@
   --jp-sidebar-min-width: 350px;
   width: 100%;
   box-sizing: border-box;
-  overflow-y: scroll;
-
+  overflow-y: hidden;
   /* 
         Don't set padding on top from the taskpane so we can instead
         set the padding on the chat-taskpane-header instead to make 


### PR DESCRIPTION
# Description

Removes outer scrollbar on windows that serves no purpose. 
<img width="162" alt="Screenshot 2025-06-18 at 10 32 07 AM" src="https://github.com/user-attachments/assets/ec6635cb-3cba-47b7-ad7e-4dca8df63ab4" />
