### PR TITLE
mito-ai: turn off inline completions

### DIFF
--- a/mito-ai/src/index.ts
+++ b/mito-ai/src/index.ts
@@ -9,7 +9,6 @@ import ErrorMimeRendererPlugin from './Extensions/ErrorMimeRenderer/ErrorMimeRen
 import ToolbarButtonsPlugin from './Extensions/ToolbarButtons/ToolbarButtonsPlugin';
 import AppBuilderPlugin from './Extensions/AppBuilder/AppBuilderPlugin';
 import { emptyCellPlaceholder } from './Extensions/emptyCell/EmptyCellPlugin';
-import { completionPlugin } from './Extensions/InlineCompleter';
 import { statusItem } from './Extensions/status';
 import SettingsManagerPlugin from './Extensions/SettingsManager/SettingsManagerPlugin';
 import { versionCheckPlugin } from './Extensions/VersionCheck';
@@ -24,7 +23,6 @@ export default [
   AppBuilderPlugin,
   ToolbarButtonsPlugin,
   emptyCellPlaceholder,
-  completionPlugin,
   statusItem,
   SettingsManagerPlugin,
   versionCheckPlugin,

--- a/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
+++ b/tests/mitoai_ui_tests/aiInlineCompleter.spec.ts
@@ -16,8 +16,8 @@ import { PromiseDelegate } from "@lumino/coreutils";
 
 const GHOST_SELECTOR = ".jp-GhostText";
 
-test.describe("first time setup", () => {
-  test.skip("should ask the user to activate the inline completion", async ({
+test.describe.skip("first time setup", () => {
+  test("should ask the user to activate the inline completion", async ({
     page,
     request,
   }) => {
@@ -62,7 +62,7 @@ test.describe("first time setup", () => {
   });
 });
 
-test.describe("default inline completion", () => {
+test.describe.skip("default inline completion", () => {
   test.use({
     autoGoto: false,
     mockSettings: {
@@ -144,7 +144,7 @@ test.describe("default inline completion", () => {
   });
 });
 
-test.describe("default manual inline completion", () => {
+test.describe.skip("default manual inline completion", () => {
   test.use({
     autoGoto: false,
     mockSettings: {


### PR DESCRIPTION
# Description

Turns off inline completions for now. It is not providing any value to users in its current state. We will eventually improve it and turn it back on. 

# Testing

Make sure its off!

# Documentation

Yes, we should update our docs and website... 