### PR TITLE
Add model tracking to AI completion telemetry

### DIFF
--- a/mito-ai/mito_ai/completions/providers.py
+++ b/mito-ai/mito_ai/completions/providers.py
@@ -136,7 +136,8 @@ This attribute is observed by the websocket provider to push the error to the cl
                 last_message_content=last_message_content,
                 response={"completion": completion},
                 user_input=user_input or "",
-                thread_id=thread_id or ""
+                thread_id=thread_id or "",
+                model=model
             )
             return completion
 
@@ -215,7 +216,8 @@ This attribute is observed by the websocket provider to push the error to the cl
                 last_message_content=last_message_content,
                 response={"completion": accumulated_response},
                 user_input=user_input or "",
-                thread_id=thread_id
+                thread_id=thread_id,
+                model=model
             )
             return accumulated_response
 

--- a/mito-ai/mito_ai/utils/telemetry_utils.py
+++ b/mito-ai/mito_ai/utils/telemetry_utils.py
@@ -219,7 +219,8 @@ def log_ai_completion_success(
     last_message_content: str,
     user_input: str,
     response: Dict[str, Any],
-    thread_id: str
+    thread_id: str,
+    model: str
 ) -> None:
     """
     Logs AI completion success based on the input location.
@@ -228,13 +229,17 @@ def log_ai_completion_success(
         key_type: The type of key that was used to get the AI completion
         message_type: The type of message that was sent to the AI
         last_message_content: The last message sent to the AI
+        user_input: The user input that was sent to the AI
         response: The response received from the AI
+        thread_id: The thread ID for the conversation
+        model: The model that was used to get the AI completion
     """
 
     # Params that every log has
     base_params = {
         KEY_TYPE_PARAM: str(key_type),
         IS_DEV_MODE_PARAM: is_dev_mode(),
+        'model': model,
     }
 
     try:


### PR DESCRIPTION
## Summary
- Update `log_ai_completion_success` function to accept and log model parameter
- Add model field to telemetry data for tracking model popularity in Mixpanel dashboards
- Update all call sites in `providers.py` to pass model information

## Test plan
- [ ] Verify telemetry events include model information