### PR TITLE
fix/Scroll to cell

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
@@ -4,9 +4,10 @@
  */
 
 import React from 'react';
-import { scrollToCell, getCellCodeByID } from '../../../utils/notebook';
+import { getCellCodeByID, getCellByID, setActiveCellByID } from '../../../utils/notebook';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import '../../../../style/Citation.css';
+import { WindowedList } from '@jupyterlab/ui-components';
 
 // Citation component props interface
 export interface CitationProps {
@@ -17,6 +18,7 @@ export interface CitationProps {
 }
 
 // Citation button component
+// Citation button component
 export const Citation: React.FC<CitationProps> = ({ citationIndex, cellId, line, notebookTracker }): JSX.Element => {
   const handleClick = (): void => {
     // To determine how we should handle scrolling, 
@@ -25,9 +27,21 @@ export const Citation: React.FC<CitationProps> = ({ citationIndex, cellId, line,
     // we set the scroll position to "start," otherwise we set it to "end."
     const code = getCellCodeByID(notebookTracker, cellId);
     const relativeLinePosition = line / (code?.split('\n').length || 1);
-    const position = relativeLinePosition < 0.5 ? 'start' : 'end';
 
-    scrollToCell(notebookTracker, cellId, line, position);
+    // These positions must be of type BaseScrollToAlignment defined in @jupyterlab/ui-components
+    const position: WindowedList.BaseScrollToAlignment = relativeLinePosition < 0.5 ? 'start' : 'end';
+
+    const cell = getCellByID(notebookTracker, cellId);
+
+    if (cell == null) {
+      console.log('cell is null');
+      return
+    }
+
+    console.log('position', position);
+    setActiveCellByID(notebookTracker, cellId);
+    notebookTracker.currentWidget?.content.scrollToCell(cell, position);
+    console.log('scrolled to cell', cell);
   };
 
   return (

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/Citation.tsx
@@ -4,10 +4,9 @@
  */
 
 import React from 'react';
-import { getCellCodeByID, getCellByID, setActiveCellByID } from '../../../utils/notebook';
+import { scrollToCell } from '../../../utils/notebook';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import '../../../../style/Citation.css';
-import { WindowedList } from '@jupyterlab/ui-components';
 
 // Citation component props interface
 export interface CitationProps {
@@ -21,27 +20,7 @@ export interface CitationProps {
 // Citation button component
 export const Citation: React.FC<CitationProps> = ({ citationIndex, cellId, line, notebookTracker }): JSX.Element => {
   const handleClick = (): void => {
-    // To determine how we should handle scrolling, 
-    // we need to first count the number of lines in the cell.
-    // If the line is closer to the top, 
-    // we set the scroll position to "start," otherwise we set it to "end."
-    const code = getCellCodeByID(notebookTracker, cellId);
-    const relativeLinePosition = line / (code?.split('\n').length || 1);
-
-    // These positions must be of type BaseScrollToAlignment defined in @jupyterlab/ui-components
-    const position: WindowedList.BaseScrollToAlignment = relativeLinePosition < 0.5 ? 'start' : 'end';
-
-    const cell = getCellByID(notebookTracker, cellId);
-
-    if (cell == null) {
-      console.log('cell is null');
-      return
-    }
-
-    console.log('position', position);
-    setActiveCellByID(notebookTracker, cellId);
-    notebookTracker.currentWidget?.content.scrollToCell(cell, position);
-    console.log('scrolled to cell', cell);
+    scrollToCell(notebookTracker, cellId, line);
   };
 
   return (

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -8,6 +8,7 @@ import { Cell, CodeCell } from '@jupyterlab/cells';
 import { removeMarkdownCodeFormatting } from './strings';
 import { AIOptimizedCell } from '../websockets/completions/CompletionModels';
 import { captureNode } from './nodeToPng';
+import { WindowedList } from '@jupyterlab/ui-components';
 
 const INCLUDE_CELL_IN_APP = 'include-cell-in-app'
 
@@ -300,11 +301,8 @@ export const scrollToCell = (
     notebookTracker: INotebookTracker, 
     cellID: string, 
     lineNumber?: number,
-    position: ScrollLogicalPosition = 'center'
+    position: WindowedList.BaseScrollToAlignment = 'center'
 ): void => {
-
-    // First activate the cell
-    setActiveCellByID(notebookTracker, cellID);
 
     // Get the cell
     const cell = getCellByID(notebookTracker, cellID);
@@ -312,23 +310,26 @@ export const scrollToCell = (
         return;
     }
 
-    // Get the cell's editor
-    const editor = cell.editor;
-    if (!editor) {
-        return;
+    // If a line number is provided, figure out what position to scroll to 
+    // in order to display that line by counting the number of lines in the cell.
+    // we need to first count the number of lines in the cell.
+    if (lineNumber !== undefined) {
+        const code = getCellCodeByID(notebookTracker, cellID);
+        const relativeLinePosition = lineNumber / (code?.split('\n').length || 1);
+
+        // These positions must be of type BaseScrollToAlignment defined in @jupyterlab/ui-components
+        position = relativeLinePosition < 0.5 ? 'start' : 'end';
     }
 
-    // Make the cell node visible by scrolling to it
-    const cellNode = cell.node;
-    if (cellNode) {
-        cellNode.scrollIntoView({ behavior: 'smooth', block: position });
+    // If the cell is not the active cell, the scrolling does not work. 
+    // It scrolls to the cell and then flashes back to the active cell.
+    setActiveCellByID(notebookTracker, cellID);
+  
+    notebookTracker.currentWidget?.content.scrollToCell(cell, position);
 
-        // Wait for the scroll animation to complete before highlighting the line
-        // The default smooth scroll takes about 300-500ms to complete
-        setTimeout(() => {
-            if (lineNumber !== undefined) {
-                highlightLineOfCodeInCodeCell(notebookTracker, cellID, lineNumber);
-            }
-        }, 500);
-    }
+    setTimeout(() => {
+        if (lineNumber !== undefined) {
+            highlightLineOfCodeInCodeCell(notebookTracker, cellID, lineNumber);
+        }
+    }, 500);
 }

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -325,7 +325,7 @@ export const scrollToCell = (
     // It scrolls to the cell and then flashes back to the active cell.
     setActiveCellByID(notebookTracker, cellID);
   
-    notebookTracker.currentWidget?.content.scrollToCell(cell, position);
+    void notebookTracker.currentWidget?.content.scrollToCell(cell, position);
 
     setTimeout(() => {
         if (lineNumber !== undefined) {


### PR DESCRIPTION
# Description

I discovered the Jupyter API for scrolling to a cell while investigating something else. Tried it out for fixing https://github.com/mito-ds/mito/issues/1789 and it looks like it works!

# Testing

Steps:
- Make a notebook that has a bunch of cells
- Scroll to the bottom of the notebook (Jupyter will not render the cells at the top to the DOM at this point)
- Get the agent to build a citation that references the first cell. 
- Click on the citation and make sure it scrolls you to the top and highlights the line. 

# Documentation

Nope. 