### PR TITLE
Full code cell response in chat mode

### DIFF
--- a/mito-ai/mito_ai/completions/prompt_builders/chat_prompt.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_prompt.py
@@ -4,6 +4,7 @@
 from typing import List, Optional
 from mito_ai.completions.prompt_builders.prompt_constants import (
     ACTIVE_CELL_ID_SECTION_HEADING,
+    CHAT_CODE_FORMATTING_RULES,
     FILES_SECTION_HEADING,
     VARIABLES_SECTION_HEADING,
     CODE_SECTION_HEADING,
@@ -27,6 +28,9 @@ def create_chat_prompt(
     prompt = f"""{rules_str}
     
 Help me complete the following task. I will provide you with a set of variables, existing code, and a task to complete.
+
+{CHAT_CODE_FORMATTING_RULES}
+
 <Example>
 
 {FILES_SECTION_HEADING}

--- a/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
@@ -46,6 +46,12 @@ Notice in the example above that the citation uses line number 2 because citatio
 {get_database_rules()}
 
 ==== 
+CRITICAL CODE UPDATE RULES:
+- COMPLETE REPLACEMENT: When you provide a code update, your code will COMPLETELY REPLACE the entire contents of the active code cell. 
+- INCLUDE ALL CODE: You MUST return the COMPLETE, FULL contents of the entire code cell - including ALL existing code that should remain plus your modifications.
+- NEVER PARTIAL CODE: NEVER return only a portion, snippet, or subset of the code cell. Partial responses will break the user's notebook by deleting important code.
+- PRESERVE EXISTING CODE: Always preserve imports, variable definitions, and other code that the user needs, even if you're only modifying one small part.
+
 IMPORTANT RULES:
 - Do not recreate variables that already exist
 - Keep as much of the original code as possible

--- a/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 from mito_ai.completions.prompt_builders.prompt_constants import (
+    CHAT_CODE_FORMATTING_RULES,
     CITATION_RULES, 
     ACTIVE_CELL_ID_SECTION_HEADING, 
     CODE_SECTION_HEADING,
@@ -46,11 +47,7 @@ Notice in the example above that the citation uses line number 2 because citatio
 {get_database_rules()}
 
 ==== 
-CRITICAL CODE UPDATE RULES:
-- COMPLETE REPLACEMENT: When you provide a code update, your code will COMPLETELY REPLACE the entire contents of the active code cell. 
-- INCLUDE ALL CODE: You MUST return the COMPLETE, FULL contents of the entire code cell - including ALL existing code that should remain plus your modifications.
-- NEVER PARTIAL CODE: NEVER return only a portion, snippet, or subset of the code cell. Partial responses will break the user's notebook by deleting important code.
-- PRESERVE EXISTING CODE: Always preserve imports, variable definitions, and other code that the user needs, even if you're only modifying one small part.
+{CHAT_CODE_FORMATTING_RULES}
 
 IMPORTANT RULES:
 - Do not recreate variables that already exist

--- a/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
@@ -136,3 +136,11 @@ Here is the schema:
         DATABASE_RULES = ""
 
     return DATABASE_RULES
+
+
+CHAT_CODE_FORMATTING_RULES = """CRITICAL CODE UPDATE RULES:
+- COMPLETE REPLACEMENT: Your code will COMPLETELY REPLACE the entire contents of the active code cell. 
+- INCLUDE ALL CODE: You MUST return the COMPLETE, FULL contents of the entire code cell - including ALL existing code that should remain plus your modifications.
+- NEVER PARTIAL CODE: NEVER return only a portion, snippet, or subset of the code cell. Partial responses will break the user's notebook by deleting important code.
+- PRESERVE EXISTING CODE: Always preserve imports, variable definitions, and other code that the user needs, even if you're only modifying one small part.
+"""


### PR DESCRIPTION
# Description

This is an effort to fix: https://github.com/mito-ds/mito/issues/1790

Added "CRITICAL CODE UPDATE RULES" section - This creates a prominent, separate section that stands out from other instructions

# Testing

This is not entirely bulletproof (again, as it's a prompt engineering method).

# Implementation notes

- The current chat prompt already mentions returning "the full code cell" but the language may not be emphatic enough about the replacement behavior
- Occam's Razor: The simplest solution is often the best
- The fact that Agent mode doesn't have this issue suggests it's primarily a prompting problem, not an architectural one.
- Multiple reinforcing statements ensure the message is clear from different angles

