### PR TITLE
Fix cta on small screens

### DIFF
--- a/trymito.io/components/CTAButtons/CTAButtons.tsx
+++ b/trymito.io/components/CTAButtons/CTAButtons.tsx
@@ -34,13 +34,26 @@ const CTAButtons = (props: {
             )}
             style={props.style}
         > 
+
             {props.variant === 'download' && 
-                <TextButton 
-                    text={props.ctaText || 'Install Mito'}
-                    href={MITO_INSTALLATION_DOCS_LINK}
-                    className={props.textButtonClassName}
-                    variant='purple'
-                />
+                <>
+                    <div className={'only-on-desktop'}>
+                        <TextButton 
+                            text={props.ctaText || 'Install Mito for Jupyter'}
+                            href={MITO_INSTALLATION_DOCS_LINK}
+                            className={props.textButtonClassName}
+                            variant='purple'
+                        />
+                    </div>
+                    <div className={classNames('only-on-mobile-block')}>
+                        <TextButton 
+                            text={props.ctaText || 'Install Mito'}
+                            href={MITO_INSTALLATION_DOCS_LINK}
+                            className={props.textButtonClassName}
+                            variant='purple'
+                        />
+                    </div>
+                </>
             }
             {props.variant === 'scroll-to-install' && 
                 <TextButton 

--- a/trymito.io/pages/index.tsx
+++ b/trymito.io/pages/index.tsx
@@ -69,7 +69,6 @@ const Home: NextPage = () => {
               <div className={homeStyles.cta_buttons_homepage_container}>
                 <CTAButtons 
                   variant='download' 
-                  ctaText='Install Mito for Jupyter'
                   align='center' 
                   displaySecondaryCTA={false} 
                   textButtonClassName={PLAUSIBLE_INSTALL_DOCS_CTA_LOCATION_TITLE_CARD}
@@ -97,24 +96,6 @@ const Home: NextPage = () => {
 
           <section>
             <CaseStudies />
-          </section>
-
-          <section>
-            <div className={classNames(pageStyles.subsection, pageStyles.subsection_column, 'center')}>
-                <h2>
-                  Upgrade Python scripts to interactive Streamlit Dashboards
-                </h2>
-                <p>
-                  Turn one hour of automation savings into tens of hours by sharing automation scripts through Streamlit dashboards.
-                </p>
-                <p className={pageStyles.link}>
-                  <Link href="/data-app" >
-                    Learn more about Mito in Streamlit →
-                  </Link>
-                </p>
-            </div>
-            <StreamlitAppGallery />
-                
           </section>
 
           <section className={pageStyles.background_card}>


### PR DESCRIPTION
# Description

- Fix the cta on small screens. It used to overflow like this: 
<img width="530" alt="Screenshot 2025-06-26 at 2 14 53 PM" src="https://github.com/user-attachments/assets/d39bd77a-ae03-4217-86b3-8555577d1fd3" />

- Removes the streamlit app gallery since that is not what we want users paying attention to. 

# Testing

Try it out! 
