### PR TITLE
Update wait for notebook

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1251,6 +1251,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
 
         notebook.widgets.forEach((cell, index) => {
             if (cell.model.type === 'code') {
+
                 const isActiveCodeCell = activeCellIndex === index
 
                 // TODO: Instead of casting, we should rely on the type system to make 

--- a/mito-ai/src/utils/waitForNotebookReady.ts
+++ b/mito-ai/src/utils/waitForNotebookReady.ts
@@ -32,6 +32,10 @@ export const waitForNotebookReady = async (notebookTracker: INotebookTracker): P
     await new Promise<void>(resolve => {
         const checkCellsReady = (): void => {
             const cells = notebook.content.widgets;
+
+            // In large notebooks, not all of the cells are attatched I think. 
+            // So instead we just wait for any cell to be ready and then give it 
+            // another 500ms to be ready.
             const anyCellReady = cells.some(cell => cell.isAttached && cell.model);
             
             if (anyCellReady && cells.length > 0) {


### PR DESCRIPTION
# Description

When using the website to start a conversation with mito-ai. There is still sometimes a race condition where we try to build the map of cells before the cells are loaded (is my understanding). This just makes sure that the cells are loaded before hand. 

# Testing

We don't have the infra to properly test this before releasing it because we don't have a dev JHuB set up right now. 

# Documentation

No. 