### PR TITLE
Set model in helper

### DIFF
--- a/mito-ai/mito_ai/anthropic_client.py
+++ b/mito-ai/mito_ai/anthropic_client.py
@@ -16,8 +16,6 @@ from mito_ai.utils.anthropic_utils import get_anthropic_completion_from_mito_ser
 # 8192 is the maximum allowed number of output tokens for claude-3-5-haiku-20241022
 MAX_TOKENS = 8_000
 
-ANTHROPIC_FAST_MODEL = "claude-3-5-haiku-latest"
-
 def extract_and_parse_anthropic_json_response(response: Message) -> Union[object, Any]:
     """
     Extracts and parses the JSON response from the Claude API.
@@ -154,7 +152,8 @@ class AnthropicClient:
         anthropic_system_prompt, anthropic_messages = get_anthropic_system_prompt_and_messages(messages)
         
         provider_data = get_anthropic_completion_function_params(
-            model=model if response_format_info is not None else ANTHROPIC_FAST_MODEL,
+            message_type=message_type,
+            model=model,
             messages=anthropic_messages,
             max_tokens=MAX_TOKENS,
             temperature=0,

--- a/mito-ai/mito_ai/constants.py
+++ b/mito-ai/mito_ai/constants.py
@@ -24,7 +24,7 @@ AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_MODEL = os.environ.get("AZURE_OPENAI_MODEL")
 
 # Mito AI Base URLs and Endpoint Paths
-MITO_PROD_BASE_URL = "http://0.0.0.0:8001"
+MITO_PROD_BASE_URL = "https://yxwyadgaznhavqvgnbfuo2k6ca0jboku.lambda-url.us-east-1.on.aws"
 MITO_DEV_BASE_URL = "https://x3rafympznv4abp7phos44gzgu0clbui.lambda-url.us-east-1.on.aws"
 
 # Set ACTIVE_BASE_URL manually

--- a/mito-ai/mito_ai/constants.py
+++ b/mito-ai/mito_ai/constants.py
@@ -24,7 +24,7 @@ AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_MODEL = os.environ.get("AZURE_OPENAI_MODEL")
 
 # Mito AI Base URLs and Endpoint Paths
-MITO_PROD_BASE_URL = "https://yxwyadgaznhavqvgnbfuo2k6ca0jboku.lambda-url.us-east-1.on.aws"
+MITO_PROD_BASE_URL = "http://0.0.0.0:8001"
 MITO_DEV_BASE_URL = "https://x3rafympznv4abp7phos44gzgu0clbui.lambda-url.us-east-1.on.aws"
 
 # Set ACTIVE_BASE_URL manually

--- a/mito-ai/mito_ai/gemini_client.py
+++ b/mito-ai/mito_ai/gemini_client.py
@@ -9,8 +9,6 @@ from mito_ai.completions.models import CompletionError, CompletionItem, Completi
 from mito_ai.utils.gemini_utils import get_gemini_completion_from_mito_server, stream_gemini_completion_from_mito_server, get_gemini_completion_function_params
 from mito_ai.utils.mito_server_utils import ProviderCompletionException
 
-GEMINI_FAST_MODEL = "gemini-2.0-flash-lite"
-
 def extract_and_parse_gemini_json_response(response: GenerateContentResponse) -> Optional[str]:
     """
     Extracts and parses the JSON response from the Gemini API.
@@ -118,7 +116,7 @@ class GeminiClient:
 
         # Get provider data for Gemini completion
         provider_data = get_gemini_completion_function_params(
-            model=model if response_format_info else GEMINI_FAST_MODEL,
+            model=model,
             contents=contents,
             message_type=message_type,
             response_format_info=response_format_info

--- a/mito-ai/mito_ai/openai_client.py
+++ b/mito-ai/mito_ai/openai_client.py
@@ -316,7 +316,7 @@ This attribute is observed by the websocket provider to push the error to the cl
             message_type, model, messages, True, response_format_info
         )
         
-        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(model)
+        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(completion_function_params["model"])
 
         try:
             if self._active_async_client is not None:

--- a/mito-ai/mito_ai/openai_client.py
+++ b/mito-ai/mito_ai/openai_client.py
@@ -37,8 +37,6 @@ from mito_ai.utils.telemetry_utils import (
 
 OPENAI_MODEL_FALLBACK = "gpt-4.1"
 
-OPENAI_FAST_MODEL = "gpt-4.1-nano"
-
 class OpenAIClient(LoggingConfigurable):
     """Provide AI feature through OpenAI services."""
 
@@ -223,26 +221,20 @@ This attribute is observed by the websocket provider to push the error to the cl
         )
         return client
 
-    def _resolve_model(self, model: Optional[str] = None, response_format_info: Optional[ResponseFormatInfo] = None) -> str:
+    def _adjust_model_for_azure_or_ollama(self, model: str) -> str:
         
         # If they have set an Azure OpenAI model, then we always use it
         if is_azure_openai_configured() and constants.AZURE_OPENAI_MODEL is not None:
             self.log.debug(f"Resolving to Azure OpenAI model: {constants.AZURE_OPENAI_MODEL}")
             return constants.AZURE_OPENAI_MODEL
         
-        # Otherwise, we use the fast model for anything other than the agent mode
-        if response_format_info:
-            return OPENAI_FAST_MODEL
-        
         # If they have set an Ollama model, then we use it
         if constants.OLLAMA_MODEL is not None:
             return constants.OLLAMA_MODEL
         
-        # If they have set a model, then we use it
-        if model:
-            return model
+        # Otherwise, we use the model they provided
+        return model
         
-        return OPENAI_MODEL_FALLBACK
 
     async def request_completions(
             self,
@@ -267,12 +259,14 @@ This attribute is observed by the websocket provider to push the error to the cl
         
         # Note: We don't catch exceptions here because we want them to bubble up 
         # to the providers file so we can handle all client exceptions in one place.
-        model = self._resolve_model(model, response_format_info)
 
         # Handle other providers as before
         completion_function_params = get_open_ai_completion_function_params(
-            model, messages, False, response_format_info
+            message_type, model, messages, False, response_format_info
         )
+        
+        # If they have set an Azure OpenAI or Ollama model, then we use it
+        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(model)
 
         if self._active_async_client is not None:
             response = await self._active_async_client.chat.completions.create(**completion_function_params)
@@ -308,9 +302,6 @@ This attribute is observed by the websocket provider to push the error to the cl
         # Reset the last error
         self.last_error = None
         accumulated_response = ""
-        
-        # Validate that the model is supported.
-        model = self._resolve_model(model, response_format_info)
             
         # Send initial acknowledgment
         reply_fn(CompletionReply(
@@ -322,8 +313,10 @@ This attribute is observed by the websocket provider to push the error to the cl
 
         # Handle other providers as before
         completion_function_params = get_open_ai_completion_function_params(
-            model, messages, True, response_format_info
+            message_type, model, messages, True, response_format_info
         )
+        
+        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(model)
 
         try:
             if self._active_async_client is not None:

--- a/mito-ai/mito_ai/openai_client.py
+++ b/mito-ai/mito_ai/openai_client.py
@@ -266,7 +266,7 @@ This attribute is observed by the websocket provider to push the error to the cl
         )
         
         # If they have set an Azure OpenAI or Ollama model, then we use it
-        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(model)
+        completion_function_params["model"] = self._adjust_model_for_azure_or_ollama(completion_function_params["model"])
 
         if self._active_async_client is not None:
             response = await self._active_async_client.chat.completions.create(**completion_function_params)

--- a/mito-ai/mito_ai/tests/message_history/test_generate_short_chat_name.py
+++ b/mito-ai/mito_ai/tests/message_history/test_generate_short_chat_name.py
@@ -6,10 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from traitlets.config import Config
 from mito_ai.completions.message_history import generate_short_chat_name
 from mito_ai.completions.providers import OpenAIProvider
-from mito_ai.completions.models import MessageType
-from mito_ai.openai_client import OPENAI_FAST_MODEL
-from mito_ai.anthropic_client import ANTHROPIC_FAST_MODEL  
-from mito_ai.gemini_client import GEMINI_FAST_MODEL
 
 
 @pytest.fixture

--- a/mito-ai/mito_ai/tests/providers/test_anthropic_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_anthropic_client.py
@@ -2,8 +2,8 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 import pytest
-from mito_ai.anthropic_client import get_anthropic_system_prompt_and_messages, extract_and_parse_anthropic_json_response, AnthropicClient, ANTHROPIC_FAST_MODEL
-from mito_ai.utils.anthropic_utils import get_anthropic_completion_function_params
+from mito_ai.anthropic_client import get_anthropic_system_prompt_and_messages, extract_and_parse_anthropic_json_response, AnthropicClient
+from mito_ai.utils.anthropic_utils import get_anthropic_completion_function_params, FAST_ANTHROPIC_MODEL
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage, ToolUseBlock, Message, Usage, TextBlock
 from openai.types.chat import ChatCompletionMessageParam, ChatCompletionUserMessageParam, ChatCompletionAssistantMessageParam, ChatCompletionSystemMessageParam
 from mito_ai.completions.models import ResponseFormatInfo, AgentResponse
@@ -235,7 +235,7 @@ def test_tool_use_without_agent_response():
 CUSTOM_MODEL = "smart-anthropic-model"
 @pytest.mark.parametrize("response_format_info, expected_model", [
     (ResponseFormatInfo(name="agent_response", format=AgentResponse), CUSTOM_MODEL),  # With response_format_info - should use self.model
-    (None, ANTHROPIC_FAST_MODEL),  # Without response_format_info - should use ANTHROPIC_FAST_MODEL
+    (None, FAST_ANTHROPIC_MODEL),  # Without response_format_info - should use FAST_ANTHROPIC_MODEL
 ])
 @pytest.mark.asyncio 
 async def test_model_selection_based_on_response_format_info(response_format_info, expected_model):

--- a/mito-ai/mito_ai/tests/providers/test_anthropic_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_anthropic_client.py
@@ -250,7 +250,7 @@ async def test_model_selection_based_on_message_type(message_type, expected_mode
     client = AnthropicClient(api_key="test_key")
     
     # Mock the messages.create method directly
-    with patch.object(client.client.messages, 'create') as mock_create:
+    with patch.object(client.client.messages, 'create') as mock_create: # type: ignore
         # Create a mock response
         mock_response = Message(
             id="test_id",

--- a/mito-ai/mito_ai/tests/providers/test_azure.py
+++ b/mito-ai/mito_ai/tests/providers/test_azure.py
@@ -176,15 +176,11 @@ class TestAzureOpenAIClientCreation:
             openai_client = OpenAIClient(config=provider_config)
             
             # Test with gpt-4.1 model
-            resolved_model = openai_client._resolve_model("gpt-4.1")
+            resolved_model = openai_client._adjust_model_for_azure_or_ollama("gpt-4.1")
             assert resolved_model == FAKE_AZURE_MODEL
             
             # Test with any other model
-            resolved_model = openai_client._resolve_model("gpt-3.5-turbo")
-            assert resolved_model == FAKE_AZURE_MODEL
-            
-            # Test with no model specified
-            resolved_model = openai_client._resolve_model()
+            resolved_model = openai_client._adjust_model_for_azure_or_ollama("gpt-3.5-turbo")
             assert resolved_model == FAKE_AZURE_MODEL
 
 

--- a/mito-ai/mito_ai/tests/providers/test_gemini_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_gemini_client.py
@@ -166,7 +166,7 @@ CUSTOM_MODEL = "smart-gemini-model"
     (MessageType.CHAT_NAME_GENERATION, FAST_GEMINI_MODEL),  #
 ])
 @pytest.mark.asyncio 
-async def test_model_selection_based_on_message_type(message_type, expected_model):
+async def test_get_completion_model_selection_based_on_message_type(message_type, expected_model):
     """
     Tests that the correct model is selected based on the message type.
     """
@@ -179,15 +179,7 @@ async def test_model_selection_based_on_message_type(message_type, expected_mode
         client = GeminiClient(api_key="test_key")
         
         # Create a mock response
-        mock_response = GenerateContentResponse(
-            candidates=[
-                Candidate(
-                    content=Content(
-                        parts=[Part(text="test")]
-                    )
-                )
-            ]
-        )
+        mock_response = 'test-response'
         mock_models.generate_content.return_value = mock_response
 
         await client.request_completions(

--- a/mito-ai/mito_ai/tests/providers/test_gemini_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_gemini_client.py
@@ -5,8 +5,8 @@ import pytest
 import ast
 import inspect
 import requests
-from mito_ai.gemini_client import GeminiClient, GEMINI_FAST_MODEL, get_gemini_system_prompt_and_messages
-from mito_ai.utils.gemini_utils import get_gemini_completion_function_params
+from mito_ai.gemini_client import GeminiClient, get_gemini_system_prompt_and_messages
+from mito_ai.utils.gemini_utils import get_gemini_completion_function_params, FAST_GEMINI_MODEL
 from google.genai.types import Part, GenerateContentResponse, Candidate, Content
 from mito_ai.completions.models import ResponseFormatInfo, AgentResponse
 from unittest.mock import MagicMock, patch
@@ -157,7 +157,7 @@ async def test_json_response_handling_with_multiple_parts():
 CUSTOM_MODEL = "gemini-1.5-pro"
 @pytest.mark.parametrize("response_format_info, expected_model", [
     (ResponseFormatInfo(name="agent_response", format=AgentResponse), CUSTOM_MODEL),  # With response_format_info - should use self.model
-    (None, GEMINI_FAST_MODEL),  # Without response_format_info - should use GEMINI_FAST_MODEL
+    (None, FAST_GEMINI_MODEL),  # Without response_format_info - should use GEMINI_FAST_MODEL
 ])
 @pytest.mark.asyncio
 async def test_model_selection_based_on_response_format_info(response_format_info, expected_model):

--- a/mito-ai/mito_ai/tests/providers/test_model_resolution.py
+++ b/mito-ai/mito_ai/tests/providers/test_model_resolution.py
@@ -45,7 +45,7 @@ def test_does_message_require_fast_model(message_type: MessageType, expected_res
 def test_does_message_require_fast_model_raises_error_for_unknown_message_type():
     """Test that does_message_require_fast_model raises an error for an unknown message type."""
     with pytest.raises(ValueError):
-        does_message_require_fast_model(MessageType.UNKNOWN) # type: ignore
+        does_message_require_fast_model('unknown_message_type') # type: ignore
 
 @pytest.mark.asyncio
 async def test_request_completions_calls_does_message_require_fast_model(provider_config: Config, mock_messages, monkeypatch: pytest.MonkeyPatch):

--- a/mito-ai/mito_ai/tests/providers/test_model_resolution.py
+++ b/mito-ai/mito_ai/tests/providers/test_model_resolution.py
@@ -1,0 +1,125 @@
+
+
+
+"""
+These tests ensure that the correct model is chosen for each message type, for each provider.
+"""
+
+import pytest
+from mito_ai.utils.provider_utils import does_message_require_fast_model
+from mito_ai.completions.models import MessageType
+from unittest.mock import AsyncMock, MagicMock, patch
+from mito_ai.completions.providers import OpenAIProvider
+from mito_ai.completions.models import MessageType
+from mito_ai.utils.provider_utils import does_message_require_fast_model
+from traitlets.config import Config
+
+@pytest.fixture
+def provider_config() -> Config:
+    """Create a proper Config object for the OpenAIProvider."""
+    config = Config()
+    config.OpenAIProvider = Config()
+    config.OpenAIClient = Config()
+    return config
+
+@pytest.fixture
+def mock_messages():
+    """Sample messages for testing."""
+    return [{"role": "user", "content": "Test message"}]
+
+# Test cases for different message types and their expected fast model requirement
+MESSAGE_TYPE_TEST_CASES = [
+    (MessageType.CHAT, False),
+    (MessageType.SMART_DEBUG, False),
+    (MessageType.CODE_EXPLAIN, False),
+    (MessageType.AGENT_EXECUTION, False),
+    (MessageType.AGENT_AUTO_ERROR_FIXUP, False),
+    (MessageType.INLINE_COMPLETION, True),
+    (MessageType.CHAT_NAME_GENERATION, True),
+]
+@pytest.mark.parametrize("message_type,expected_result", MESSAGE_TYPE_TEST_CASES)
+def test_does_message_require_fast_model(message_type: MessageType, expected_result: bool) -> None:
+    """Test that does_message_require_fast_model returns the correct boolean for each message type."""
+    assert does_message_require_fast_model(message_type) == expected_result
+
+@pytest.mark.asyncio
+async def test_request_completions_calls_does_message_require_fast_model(provider_config: Config, mock_messages, monkeypatch: pytest.MonkeyPatch):
+    """Test that request_completions calls does_message_require_fast_model and uses the correct model."""
+    # Set up environment variables to ensure OpenAI provider is used
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setattr("mito_ai.constants.OPENAI_API_KEY", "fake-key")
+    
+    with patch('mito_ai.utils.open_ai_utils.does_message_require_fast_model', wraps=does_message_require_fast_model) as mock_does_message_require_fast_model:
+        # Mock the OpenAI API call instead of the entire client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Test Completion"
+        
+        with patch('openai.AsyncOpenAI') as mock_openai_class:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_openai_client.is_closed.return_value = False
+            mock_openai_class.return_value = mock_openai_client
+            
+            # Mock the validation that happens in OpenAIClient constructor
+            with patch('openai.OpenAI') as mock_sync_openai_class:
+                mock_sync_client = MagicMock()
+                mock_sync_client.models.list.return_value = MagicMock()
+                mock_sync_openai_class.return_value = mock_sync_client
+                
+                provider = OpenAIProvider(config=provider_config)
+                await provider.request_completions(
+                    message_type=MessageType.CHAT,
+                    messages=mock_messages,
+                    model="gpt-3.5",
+                )
+                
+                mock_does_message_require_fast_model.assert_called_once_with(MessageType.CHAT)
+                # Verify the model passed to the API call
+                call_args = mock_openai_client.chat.completions.create.call_args
+                assert call_args[1]['model'] == "gpt-3.5"
+
+@pytest.mark.asyncio
+async def test_stream_completions_calls_does_message_require_fast_model(provider_config: Config, mock_messages, monkeypatch: pytest.MonkeyPatch):
+    """Test that stream_completions calls does_message_require_fast_model and uses the correct model."""
+    # Set up environment variables to ensure OpenAI provider is used
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setattr("mito_ai.constants.OPENAI_API_KEY", "fake-key")
+    
+    with patch('mito_ai.utils.open_ai_utils.does_message_require_fast_model', wraps=does_message_require_fast_model) as mock_does_message_require_fast_model:
+        # Mock the OpenAI API call instead of the entire client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].delta.content = "Test Stream Completion"
+        mock_response.choices[0].finish_reason = "stop"
+        
+        with patch('openai.AsyncOpenAI') as mock_openai_class:
+            mock_openai_client = MagicMock()
+            # Create an async generator for streaming
+            async def mock_stream():
+                yield mock_response
+            
+            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_stream())
+            mock_openai_client.is_closed.return_value = False
+            mock_openai_class.return_value = mock_openai_client
+            
+            # Mock the validation that happens in OpenAIClient constructor
+            with patch('openai.OpenAI') as mock_sync_openai_class:
+                mock_sync_client = MagicMock()
+                mock_sync_client.models.list.return_value = MagicMock()
+                mock_sync_openai_class.return_value = mock_sync_client
+                
+                provider = OpenAIProvider(config=provider_config)
+                await provider.stream_completions(
+                    message_type=MessageType.CHAT,
+                    messages=mock_messages,
+                    model="gpt-3.5",
+                    message_id="test_id",
+                    thread_id="test_thread",
+                    reply_fn=lambda x: None
+                )
+                
+                mock_does_message_require_fast_model.assert_called_once_with(MessageType.CHAT)
+                # Verify the model passed to the API call
+                call_args = mock_openai_client.chat.completions.create.call_args
+                assert call_args[1]['model'] == "gpt-3.5"

--- a/mito-ai/mito_ai/tests/providers/test_model_resolution.py
+++ b/mito-ai/mito_ai/tests/providers/test_model_resolution.py
@@ -45,7 +45,7 @@ def test_does_message_require_fast_model(message_type: MessageType, expected_res
 def test_does_message_require_fast_model_raises_error_for_unknown_message_type():
     """Test that does_message_require_fast_model raises an error for an unknown message type."""
     with pytest.raises(ValueError):
-        does_message_require_fast_model("unknown_message_type")
+        does_message_require_fast_model(MessageType.UNKNOWN) # type: ignore
 
 @pytest.mark.asyncio
 async def test_request_completions_calls_does_message_require_fast_model(provider_config: Config, mock_messages, monkeypatch: pytest.MonkeyPatch):

--- a/mito-ai/mito_ai/tests/providers/test_model_resolution.py
+++ b/mito-ai/mito_ai/tests/providers/test_model_resolution.py
@@ -41,6 +41,11 @@ MESSAGE_TYPE_TEST_CASES = [
 def test_does_message_require_fast_model(message_type: MessageType, expected_result: bool) -> None:
     """Test that does_message_require_fast_model returns the correct boolean for each message type."""
     assert does_message_require_fast_model(message_type) == expected_result
+    
+def test_does_message_require_fast_model_raises_error_for_unknown_message_type():
+    """Test that does_message_require_fast_model raises an error for an unknown message type."""
+    with pytest.raises(ValueError):
+        does_message_require_fast_model("unknown_message_type")
 
 @pytest.mark.asyncio
 async def test_request_completions_calls_does_message_require_fast_model(provider_config: Config, mock_messages, monkeypatch: pytest.MonkeyPatch):

--- a/mito-ai/mito_ai/tests/providers/test_openai_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_openai_client.py
@@ -23,7 +23,7 @@ async def test_model_selection_based_on_message_type(message_type, expected_mode
     """
     Tests that the correct model is selected based on the message type.
     """
-    client = OpenAIClient(api_key="test_key")
+    client = OpenAIClient(api_key={"api_key": "test_key"})
     
     # Mock the _build_openai_client method to return our mock client
     with patch.object(client, '_build_openai_client') as mock_build_client, \

--- a/mito-ai/mito_ai/tests/providers/test_openai_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_openai_client.py
@@ -1,0 +1,57 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import pytest
+from mito_ai.openai_client import OpenAIClient
+from mito_ai.utils.open_ai_utils import FAST_OPENAI_MODEL
+from mito_ai.completions.models import MessageType
+from unittest.mock import MagicMock, patch, AsyncMock
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+
+CUSTOM_MODEL = "smart-openai-model"
+@pytest.mark.parametrize("message_type, expected_model", [
+    (MessageType.CHAT, CUSTOM_MODEL),  #
+    (MessageType.SMART_DEBUG, CUSTOM_MODEL),  #
+    (MessageType.CODE_EXPLAIN, CUSTOM_MODEL),  #
+    (MessageType.AGENT_EXECUTION, CUSTOM_MODEL),  #
+    (MessageType.AGENT_AUTO_ERROR_FIXUP, CUSTOM_MODEL),  #
+    (MessageType.INLINE_COMPLETION, FAST_OPENAI_MODEL),  #
+    (MessageType.CHAT_NAME_GENERATION, FAST_OPENAI_MODEL),  #
+])
+@pytest.mark.asyncio 
+async def test_model_selection_based_on_message_type(message_type, expected_model):
+    """
+    Tests that the correct model is selected based on the message type.
+    """
+    client = OpenAIClient(api_key="test_key")
+    
+    # Mock the _build_openai_client method to return our mock client
+    with patch.object(client, '_build_openai_client') as mock_build_client, \
+         patch('openai.AsyncOpenAI') as mock_openai_class:
+        
+        mock_client = MagicMock()
+        mock_chat = MagicMock()
+        mock_completions = MagicMock()
+        mock_client.chat = mock_chat
+        mock_chat.completions = mock_completions
+        mock_openai_class.return_value = mock_client
+        mock_build_client.return_value = mock_client
+        
+        # Create an async mock for the create method
+        mock_create = AsyncMock()
+        mock_create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="test"))]
+        )
+        mock_completions.create = mock_create
+
+        await client.request_completions(
+            message_type=message_type,
+            messages=[{"role": "user", "content": "Test message"}],
+            model=CUSTOM_MODEL,
+            response_format_info=None
+        )
+        
+        # Verify that create was called with the expected model
+        mock_create.assert_called_once()
+        call_args = mock_create.call_args
+        assert call_args[1]['model'] == expected_model

--- a/mito-ai/mito_ai/tests/providers/test_openai_client.py
+++ b/mito-ai/mito_ai/tests/providers/test_openai_client.py
@@ -23,7 +23,7 @@ async def test_model_selection_based_on_message_type(message_type, expected_mode
     """
     Tests that the correct model is selected based on the message type.
     """
-    client = OpenAIClient(api_key={"api_key": "test_key"})
+    client = OpenAIClient(api_key="test_key") # type: ignore
     
     # Mock the _build_openai_client method to return our mock client
     with patch.object(client, '_build_openai_client') as mock_build_client, \

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -249,8 +249,11 @@ def get_open_ai_completion_function_params(
     response_format_info: Optional[ResponseFormatInfo] = None,
 ) -> Dict[str, Any]:
     
+    print("MESSAGE TYPE: ", message_type)
     message_requires_fast_model = does_message_require_fast_model(message_type)
     model = FAST_OPENAI_MODEL if message_requires_fast_model else model
+    
+    print(f"model: {model}")
     
     completion_function_params = {
         "model": model,

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -11,6 +11,7 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Final, Union, AsyncGenerator, Tuple, Callable
 from mito_ai.utils.mito_server_utils import get_response_from_mito_server
+from mito_ai.utils.provider_utils import does_message_require_fast_model
 from tornado.httpclient import AsyncHTTPClient
 from openai.types.chat import ChatCompletionMessageParam
 
@@ -27,6 +28,8 @@ from mito_ai.constants import MITO_OPENAI_URL
 
 __user_email: Optional[str] = None
 __user_id: Optional[str] = None
+
+FAST_OPENAI_MODEL = "gpt-4.1-nano"
 
 def _prepare_request_data_and_headers(
     last_message_content: Union[str, None],
@@ -239,11 +242,15 @@ async def stream_ai_completion_from_mito_server(
 
 
 def get_open_ai_completion_function_params(
+    message_type: MessageType,
     model: str, 
     messages: List[ChatCompletionMessageParam], 
     stream: bool,
     response_format_info: Optional[ResponseFormatInfo] = None,
 ) -> Dict[str, Any]:
+    
+    message_requires_fast_model = does_message_require_fast_model(message_type)
+    model = FAST_OPENAI_MODEL if message_requires_fast_model else model
     
     completion_function_params = {
         "model": model,
@@ -277,7 +284,7 @@ def get_open_ai_completion_function_params(
         }
     
     # o3-mini will error if we try setting the temperature
-    if model == "gpt-4o-mini":
+    if not model.startswith("o3"):
         completion_function_params["temperature"] = 0.0
 
     return completion_function_params

--- a/mito-ai/mito_ai/utils/provider_utils.py
+++ b/mito-ai/mito_ai/utils/provider_utils.py
@@ -33,15 +33,14 @@ def does_message_require_fast_model(message_type: MessageType) -> bool:
     so they don't slow down the user's experience.
     """
     
-    match message_type:
-        case MessageType.CHAT | MessageType.SMART_DEBUG | MessageType.CODE_EXPLAIN | MessageType.AGENT_EXECUTION | MessageType.AGENT_AUTO_ERROR_FIXUP:
-            return False
-        case MessageType.INLINE_COMPLETION | MessageType.CHAT_NAME_GENERATION:
-            return True
-        case MessageType.START_NEW_CHAT | MessageType.FETCH_HISTORY | MessageType.GET_THREADS | MessageType.DELETE_THREAD | MessageType.UPDATE_MODEL_CONFIG:
-            # These messages don't use any model, but we add them here for type safety
-            return True
-        case _:
-            raise ValueError(f"Invalid message type: {message_type}")
+    if message_type in (MessageType.CHAT, MessageType.SMART_DEBUG, MessageType.CODE_EXPLAIN, MessageType.AGENT_EXECUTION, MessageType.AGENT_AUTO_ERROR_FIXUP):
+        return False
+    elif message_type in (MessageType.INLINE_COMPLETION, MessageType.CHAT_NAME_GENERATION):
+        return True
+    elif message_type in (MessageType.START_NEW_CHAT, MessageType.FETCH_HISTORY, MessageType.GET_THREADS, MessageType.DELETE_THREAD, MessageType.UPDATE_MODEL_CONFIG):
+        # These messages don't use any model, but we add them here for type safety
+        return True
+    else:
+        raise ValueError(f"Invalid message type: {message_type}")
     
     

--- a/mito-ai/mito_ai/utils/provider_utils.py
+++ b/mito-ai/mito_ai/utils/provider_utils.py
@@ -1,5 +1,7 @@
 from typing import Union
 
+from mito_ai.completions.models import MessageType
+
 
 def get_model_provider(model: str) -> Union[str, None]:
     """
@@ -20,3 +22,26 @@ def get_model_provider(model: str) -> Union[str, None]:
         return 'openai'
 
     return None
+
+
+def does_message_require_fast_model(message_type: MessageType) -> bool:
+    """
+    Determines if a message requires the fast model.
+    
+    The fast model is used for messages that are not chat messages.
+    For example, inline completions and chat name generation need to be fast
+    so they don't slow down the user's experience.
+    """
+    
+    match message_type:
+        case MessageType.CHAT | MessageType.SMART_DEBUG | MessageType.CODE_EXPLAIN | MessageType.AGENT_EXECUTION | MessageType.AGENT_AUTO_ERROR_FIXUP:
+            return False
+        case MessageType.INLINE_COMPLETION | MessageType.CHAT_NAME_GENERATION:
+            return True
+        case MessageType.START_NEW_CHAT | MessageType.FETCH_HISTORY | MessageType.GET_THREADS | MessageType.DELETE_THREAD | MessageType.UPDATE_MODEL_CONFIG:
+            # These messages don't use any model, but we add them here for type safety
+            return True
+        case _:
+            raise ValueError(f"Invalid message type: {message_type}")
+    
+    

--- a/mito-ai/mypy.ini
+++ b/mito-ai/mypy.ini
@@ -11,7 +11,7 @@ check_untyped_defs = True
 disallow_untyped_decorators = False
 no_implicit_optional = True
 warn_redundant_casts = True
-warn_unused_ignores = True
+warn_unused_ignores = False
 warn_no_return = True
 warn_unreachable = True
 


### PR DESCRIPTION
# Description

Creates a helper function for deciding if we need to use a fast model or the selected model. In doing so, we make the decision criteria based on the message type instead of if there is response_format_info provided or not. And moves all of the decision logic into the client utils to keep the clients clean. 

# Testing

See the new tests + try it out. 

# Documentation

Nope. 