### PR TITLE
.github: add CI testing for 3.13

### DIFF
--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -19,9 +19,9 @@ jobs:
   test-mitosheet-python:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.13"]
-        pandas-version: ['2.2.0']
         optional_feature_dependencies: [False, True] 
             
     steps:
@@ -40,7 +40,6 @@ jobs:
     - name: Install dependencies
       run: |
         cd mitosheet
-        pip install "pandas==${{ matrix.pandas-version }}"
         pip install -e ".[test]"
     - name: Install optional feature dependencies
       if: ${{ matrix.optional_feature_dependencies }}

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.9", "3.13"]
         pandas-version: ['1.5.3', '2.2.0']
         optional_feature_dependencies: [False, True] 
         exclude:

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -24,7 +24,7 @@ jobs:
         pandas-version: ['1.5.3', '2.2.0']
         optional_feature_dependencies: [False, True] 
         exclude:
-          - python-version: "3.12"
+          - python-version: "3.13"
             pandas-version: '1.5.3'
             
     steps:

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -21,11 +21,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.13"]
-        pandas-version: ['1.5.3', '2.2.0']
+        pandas-version: ['2.2.0']
         optional_feature_dependencies: [False, True] 
-        exclude:
-          - python-version: "3.13"
-            pandas-version: '1.5.3'
             
     steps:
     - uses: actions/checkout@v4

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -124,6 +124,8 @@ setup_args = dict(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Jupyter",
         "Framework :: Jupyter :: JupyterLab",
         "Framework :: Jupyter :: JupyterLab :: 4",

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -79,9 +79,7 @@ setup_args = dict(
     data_files               = data_files,
     install_requires=[        
         "jupyterlab~=4.0",
-        # We allow users to have many versions of pandas installed. All functionality should
-        # work, with the exception of Excel import, which might require additonal dependencies
-        'pandas>=0.24.2',
+        'pandas>=2.0.0',
         'analytics-python',
         # Graphing libraries
         'plotly>=4.14.3,<6.0.0',


### PR DESCRIPTION
# Description

Update the CI to test Python 3.13 also drops support for old pandas versions that are no longer maintained.

# Testing

See that the tests pass + try using Python 3.13 with mitosheet + mito-ai

# Documentation

No