### PR TITLE
More chat unit tests

### DIFF
--- a/mito-ai/src/tests/AiChat/AssistantCodeBlock.test.tsx
+++ b/mito-ai/src/tests/AiChat/AssistantCodeBlock.test.tsx
@@ -164,4 +164,30 @@ describe('AssistantCodeBlock Component', () => {
             expect(codeElement.textContent).toBe('```python\nline1\nline2\nline3\nline4\nline5\n```');
         });
     });
+
+    describe('Editability', () => {
+        it('does not show edit icon for assistant code block', () => {
+            const props = createMockProps();
+            render(<AssistantCodeBlock {...props} />);
+
+            // Verify no edit button/icon is present
+            expect(screen.queryByTitle('Edit message')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('edit-button')).not.toBeInTheDocument();
+        });
+
+        it('does not enable editing on double-click', () => {
+            const props = createMockProps();
+            render(<AssistantCodeBlock {...props} />);
+
+            const codeElement = screen.getByTestId('python-code');
+            
+            // Double-click the code element
+            fireEvent.doubleClick(codeElement);
+
+            // Verify no edit input or textarea appears
+            expect(screen.queryByTestId('chat-input')).not.toBeInTheDocument();
+            expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+            expect(screen.queryByRole('textarea')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -188,6 +188,41 @@ describe('ChatInput Component', () => {
             // Preview should not be visible
             expect(screen.queryByTestId('active-cell-preview-container')).not.toBeInTheDocument();
         });
+
+        it('updates preview when active cell code changes', () => {
+            // Clear and re-render to ensure clean state
+            document.body.innerHTML = '';
+            
+            // Mock getCellCodeByID to return initial code
+            const { getCellCodeByID } = require('../../utils/notebook');
+            getCellCodeByID.mockImplementation(() => TEST_CELL_CODE);
+            
+            renderChatInput();
+            const textarea = screen.getByRole('textbox');
+            
+            // Type in textarea to show preview
+            typeInTextarea(textarea, 'test input');
+            
+            // Verify initial preview shows the original code
+            const pythonCodeElement = screen.getByTestId('python-code');
+            expect(pythonCodeElement).toHaveTextContent(TEST_CELL_CODE);
+            
+            // Update the mock to return new code and re-render
+            const newCellCode = 'print("goodbye")';
+            getCellCodeByID.mockImplementation(() => newCellCode);
+            
+            // Re-render the component to simulate the active cell change
+            document.body.innerHTML = '';
+            renderChatInput();
+            
+            // Type in textarea again to show preview
+            const newTextarea = screen.getByRole('textbox');
+            typeInTextarea(newTextarea, 'test input');
+            
+            // Verify the preview now shows the new code
+            const updatedPythonCodeElement = screen.getByTestId('python-code');
+            expect(updatedPythonCodeElement).toHaveTextContent(newCellCode);
+        });
     });
 
     describe('Keyboard Interactions', () => {

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -21,6 +21,16 @@ jest.mock('../../restAPI/RestAPI', () => ({
   getRules: jest.fn().mockResolvedValue(['Data Analysis', 'Visualization', 'Machine Learning']) 
 }));
 
+// Mock the PythonCode component
+jest.mock('../../Extensions/AiChat/ChatMessage/PythonCode', () => {
+    return {
+        __esModule: true,
+        default: jest.fn(({ code }) => (
+            <div data-testid="python-code">{code}</div>
+        ))
+    };
+});
+
 // Mock data for test cases
 const TEST_CELL_CODE = 'print("Hello World")';
 const EMPTY_CELL_ID = 'empty-cell-id';
@@ -134,6 +144,11 @@ describe('ChatInput Component', () => {
 
             // Preview should become visible
             expect(screen.getByTestId('active-cell-preview-container')).toBeInTheDocument();
+            
+            // Verify that the active cell code content is displayed
+            // The mock cell has TEST_CELL_CODE = 'print("Hello World")'
+            const pythonCodeElement = screen.getByTestId('python-code');
+            expect(pythonCodeElement).toHaveTextContent('print("Hello World")');
         });
 
         it('does not show preview for empty cells', () => {

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -277,6 +277,33 @@ describe('ChatMessage Component', () => {
             expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', 'user');
         });
 
+        it('switches to edit mode when user message is double-clicked', () => {
+            const updateMessageMock = jest.fn();
+
+            renderChatMessage({
+                message: createMockMessage('user', 'Hello, can you help me with pandas?'),
+                onUpdateMessage: updateMessageMock
+            });
+
+            // Find the message text element
+            const messageText = screen.getByText('Hello, can you help me with pandas?');
+
+            // Double-click the message to trigger edit mode
+            act(() => {
+                fireEvent.dblClick(messageText);
+            });
+
+            // Should show the ChatInput component for editing
+            expect(screen.getByTestId('chat-input')).toBeInTheDocument();
+
+            // Simulate saving the edited message
+            act(() => {
+                (window as any).__chatInputCallbacks.onSave('Updated message content');
+            });
+
+            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', 'user');
+        });
+
         it('shows code action buttons for the last AI message with code', () => {
             renderChatMessage({
                 message: createMockMessage('assistant', '```python\nimport pandas as pd\n```'),


### PR DESCRIPTION
# Description

Added new unit tests:

- Make sure AssistantCodeBlock can not be edited.
- Double click to edit ChatMessage. 
- Checking for cell preview in ChatInput.
- Cell preview is updated when active cell is updated.

# Testing

Make sure Jests tests are passing.

# Documentation

N/A