### PR TITLE
.github: cache node modules

### DIFF
--- a/.github/workflows/test-mito-ai-frontend.yml
+++ b/.github/workflows/test-mito-ai-frontend.yml
@@ -42,7 +42,9 @@ jobs:
       with:
         node-version: 22
         cache: 'npm'
-        cache-dependency-path: mito-ai/package-lock.json
+        cache-dependency-path: |
+          mito-ai/package-lock.json
+          mitosheet/package-lock.json
     - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
# Description

Try to speed up installing dependencies in GitHub actions by caching node modules

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.