### PR TITLE
BugFix: Get cell output was not actually getting the cell output

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1005,7 +1005,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             if (agentResponse.type === 'get_cell_output') {
                 // Mark that we should send the cell output to the agent 
                 // in the next loop iteration
-                sendCellIDOutput = agentResponse.cell_id
+                sendCellIDOutput = agentResponse.get_cell_output_cell_id
             }
         }
 

--- a/mito-ai/src/websockets/completions/CompletionModels.ts
+++ b/mito-ai/src/websockets/completions/CompletionModels.ts
@@ -44,7 +44,7 @@ export type AgentResponse = {
   type: 'cell_update' | 'get_cell_output' | 'finished_task'
   message: string,
   cell_update?: CellUpdate,
-  cell_id?: string,
+  get_cell_output_cell_id?: string,
   next_steps?: string[],
   analysis_assumptions?: string[]
 }


### PR DESCRIPTION
# Description

In the backend `(mito-ai/mito_ai/completions/models.py line 33)`, the field is defined as `get_cell_output_cell_id: Optional[str]`, but in the front end `(mito-ai/src/websockets/completions/CompletionModels.ts line 47)`, it's defined as `cell_id?: string`

This mismatch means that when the agent sends a get_cell_output response, the frontend is looking for `agentResponse.cell_id` but the backend is sending `get_cell_output_cell_id`.

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [x] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

## Evals

Before this PR, the evals failed:
 - 9/10 times for claude models
 - 4/10 times for gemini
 - 4/10 times for gpt
 
 After this PR, the evals failed:
 - 2/10 times for claude models
 - 1/10 times for gemini
 - 0/10 times for gpt


 
 
