### PR TITLE
selectedRules Bug Fix

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -24,7 +24,7 @@ interface ChatInputProps {
     app: JupyterFrontEnd;
     initialContent: string;
     placeholder: string;
-    onSave: (content: string, index?: number, selectedRules?: Array<{type: string, value: string}>) => void;
+    onSave: (content: string, index?: number, additionalContext?: Array<{type: string, value: string}>) => void;
     onCancel?: () => void;
     isEditing: boolean;
     contextManager?: IContextManager;

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -222,6 +222,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
         setIsDropdownFromButton(false);
     };
 
+    const mapAdditionalContext = (): Array<{type: string, value: string}> => {
+        return additionalContext.map(context => {
+            if (context.type === 'db') {
+                return {
+                    type: context.type,
+                    value: context.value
+                };
+            }
+            return context;
+        });
+    };
+
     // Update the expandedVariables arr when the variable manager changes
     useEffect(() => {
         const expandedVariables: ExpandedVariable[] = [
@@ -327,7 +339,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         if (e.key === 'Enter' && !e.shiftKey) {
                             e.preventDefault();
                             adjustHeight(true)
-                            onSave(input, undefined, additionalContext.map(ctx => ctx.type === 'db' ? {type: ctx.type, value: ctx.value} : ctx))
+                            onSave(input, undefined, mapAdditionalContext())
 
                             // Reset
                             setInput('')
@@ -357,7 +369,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             
             {isEditing &&
                 <div className="message-edit-buttons">
-                    <button onClick={() => onSave(input, undefined, additionalContext.map(ctx => ctx.type === 'db' ? {type: ctx.type, value: ctx.value} : ctx))}>Save</button>
+                    <button onClick={() => onSave(input, undefined, mapAdditionalContext())}>Save</button>
                     <button onClick={onCancel}>Cancel</button>
                 </div>
             }

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -25,7 +25,6 @@ import PlayButtonIcon from '../../../icons/PlayButtonIcon';
 import CopyIcon from '../../../icons/CopyIcon';
 import copyToClipboard from '../../../utils/copyToClipboard';
 import TextButton from '../../../components/TextButton';
-import { IDisplayOptimizedChatItem } from '../ChatHistoryManager';
 import '../../../../style/ChatMessage.css';
 import '../../../../style/MarkdownMessage.css'
 import { AgentResponse } from '../../../websockets/completions/CompletionModels';
@@ -36,7 +35,6 @@ import SelectedContextContainer from '../../../components/SelectedContextContain
 interface IChatMessageProps {
     app: JupyterFrontEnd;
     message: OpenAI.Chat.ChatCompletionMessageParam
-    messageType: IDisplayOptimizedChatItem['type']
     codeCellID: string | undefined
     agentResponse: AgentResponse | undefined
     messageIndex: number
@@ -62,7 +60,6 @@ interface IChatMessageProps {
 const ChatMessage: React.FC<IChatMessageProps> = ({
     app,
     message,
-    messageType,
     promptType,
     agentResponse,
     messageIndex,

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -101,7 +101,6 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
     const handleSave = (
         content: string,
         _index?: number,
-        _selectedRules?: Array<{ type: string, value: string }>,
         _additionalContext?: Array<{ type: string, value: string }>
     ): void => {
         onUpdateMessage(messageIndex, content, messageType);

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -19,7 +19,7 @@ import PencilIcon from '../../../icons/Pencil';
 import ChatInput from './ChatInput';
 import { IContextManager } from '../../ContextManager/ContextManagerPlugin';
 import { CodeReviewStatus } from '../ChatTaskpane';
-import { ChatMessageType, PromptType } from '../ChatHistoryManager';
+import { PromptType } from '../ChatHistoryManager';
 import TextAndIconButton from '../../../components/TextAndIconButton';
 import PlayButtonIcon from '../../../icons/PlayButtonIcon';
 import CopyIcon from '../../../icons/CopyIcon';
@@ -51,7 +51,7 @@ interface IChatMessageProps {
     previewAICode: () => void
     acceptAICode: () => void
     rejectAICode: () => void
-    onUpdateMessage: (messageIndex: number, newContent: string, messageType: ChatMessageType) => void
+    onUpdateMessage: (messageIndex: number, newContent: string, additionalContext?: Array<{ type: string, value: string }>) => void
     contextManager?: IContextManager
     codeReviewStatus: CodeReviewStatus
     setNextSteps: (nextSteps: string[]) => void
@@ -101,9 +101,9 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
     const handleSave = (
         content: string,
         _index?: number,
-        _additionalContext?: Array<{ type: string, value: string }>
+        additionalContext?: Array<{ type: string, value: string }>
     ): void => {
-        onUpdateMessage(messageIndex, content, messageType);
+        onUpdateMessage(messageIndex, content, additionalContext);
         setIsEditing(false);
     };
 

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1406,7 +1406,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                                 key={index}
                                 message={displayOptimizedChat.message}
                                 promptType={displayOptimizedChat.promptType}
-                                messageType={displayOptimizedChat.type}
                                 agentResponse={displayOptimizedChat.agentResponse}
                                 codeCellID={displayOptimizedChat.codeCellID}
                                 mitoAIConnectionError={displayOptimizedChat.type === 'connection error'}

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -675,13 +675,14 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     const handleUpdateMessage = async (
         messageIndex: number,
         newContent: string,
+        additionalContext?: Array<{type: string, value: string}>
     ): Promise<void> => {
 
         // Then send the new message to replace it
         if (agentModeEnabled) {
-            await startAgentExecution(newContent, messageIndex)
+            await startAgentExecution(newContent, messageIndex, additionalContext)
         } else {
-            await sendChatInputMessage(newContent, messageIndex)
+            await sendChatInputMessage(newContent, messageIndex, additionalContext)
         }
     };
 

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -274,7 +274,7 @@ describe('ChatMessage Component', () => {
                 (window as any).__chatInputCallbacks.onSave('Updated message content');
             });
 
-            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', 'user');
+            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', undefined);
         });
 
         it('switches to edit mode when user message is double-clicked', () => {
@@ -301,7 +301,7 @@ describe('ChatMessage Component', () => {
                 (window as any).__chatInputCallbacks.onSave('Updated message content');
             });
 
-            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', 'user');
+            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', undefined);
         });
 
         it('shows code action buttons for the last AI message with code', () => {

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -304,6 +304,65 @@ describe('ChatMessage Component', () => {
             expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', undefined);
         });
 
+        it('passes additionalContext when editing a message with context', () => {
+            const updateMessageMock = jest.fn();
+            const mockAdditionalContext = [
+                { type: 'variable', value: 'df' },
+                { type: 'file', value: 'data.csv' }
+            ];
+
+            renderChatMessage({
+                message: createMockMessage('user', 'Hello, can you help me with pandas?'),
+                onUpdateMessage: updateMessageMock,
+                additionalContext: mockAdditionalContext
+            });
+
+            // Find the message text element
+            const messageText = screen.getByText('Hello, can you help me with pandas?');
+
+            // Double-click the message to trigger edit mode
+            act(() => {
+                fireEvent.dblClick(messageText);
+            });
+
+            // Should show the ChatInput component for editing
+            expect(screen.getByTestId('chat-input')).toBeInTheDocument();
+
+            // Simulate saving the edited message with additional context
+            act(() => {
+                (window as any).__chatInputCallbacks.onSave('Updated message content', undefined, mockAdditionalContext);
+            });
+
+            // Verify that onUpdateMessage was called with the additional context
+            expect(updateMessageMock).toHaveBeenCalledWith(0, 'Updated message content', mockAdditionalContext);
+        });
+
+        it('displays additionalContext containers in user messages', () => {
+            const mockAdditionalContext = [
+                { type: 'variable', value: 'df' },
+                { type: 'file', value: 'data.csv' },
+                { type: 'rule', value: 'Use pandas for data manipulation' }
+            ];
+
+            renderChatMessage({
+                message: createMockMessage('user', 'Hello, can you help me with pandas?\n```python\nimport pandas as pd\n```'),
+                additionalContext: mockAdditionalContext
+            });
+
+            // Check that the message content is displayed
+            expect(screen.getByText('Hello, can you help me with pandas?')).toBeInTheDocument();
+
+            // Check that SelectedContextContainer components are rendered for each context item
+            // The SelectedContextContainer renders the title as text content
+            expect(screen.getByText('Variable: df')).toBeInTheDocument();
+            expect(screen.getByText('File: data.csv')).toBeInTheDocument();
+            expect(screen.getByText('Rule: Use pandas for data manipulation')).toBeInTheDocument();
+
+            // Check that the containers have the correct test IDs
+            const contextContainers = screen.getAllByTestId('selected-context-container');
+            expect(contextContainers).toHaveLength(3);
+        });
+
         it('shows code action buttons for the last AI message with code', () => {
             renderChatMessage({
                 message: createMockMessage('assistant', '```python\nimport pandas as pd\n```'),


### PR DESCRIPTION
# Description

Trying to fix an error where a user is seeing:

```python
builtins.TypeError: AgentExecutionMetadata.__init__() got an unexpected keyword argument 'selectedRules'"
```

I can not recreate this issue without manually editing `agentExecutionMetadata` in the ChatHistoryManager, and adding a `selectedRules` field. 

However, I did notice that there are a few areas where `selectedRules` was being used as a variable name, when it should have been called `additionalContext`. The changes in this PR should not affect functionality, I've only renamed the variables for the sake of clarity. 

Also fixed a bug that was removing any context added on edit. 

# Testing

- Send an agent message with a rule.
- Edit an agent message with a rule. 

# Documentation

No, behind the scenes change. 