### PR TITLE
Disable Chat Input When Agent is Working

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -317,12 +317,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
                     disabled={agentExecutionStatus === 'working' || agentExecutionStatus === 'stopping'}
                     onChange={handleInputChange}
                     onKeyDown={(e) => {
-                        // If agent is working or stopping, prevent all input
-                        if (agentExecutionStatus === 'working' || agentExecutionStatus === 'stopping') {
-                            e.preventDefault();
-                            return;
-                        }
-
                         // If dropdown is visible, only handle escape to close it
                         if (isDropdownVisible) {
                             if (e.key === 'Escape') {

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -19,6 +19,7 @@ import { ChatDropdownOption } from './ChatDropdown';
 import SelectedContextContainer from '../../../components/SelectedContextContainer';
 import DatabaseButton from '../../../components/DatabaseButton';
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { AgentExecutionStatus } from '../ChatTaskpane';
 
 interface ChatInputProps {
     app: JupyterFrontEnd;
@@ -32,6 +33,7 @@ interface ChatInputProps {
     renderMimeRegistry: IRenderMimeRegistry;
     displayActiveCellCode?: boolean;
     agentModeEnabled: boolean;
+    agentExecutionStatus?: AgentExecutionStatus;
 }
 
 export interface ExpandedVariable extends Variable {
@@ -57,6 +59,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
     renderMimeRegistry,
     displayActiveCellCode = true,
     agentModeEnabled = false,
+    agentExecutionStatus = 'idle',
 }) => {
     const [input, setInput] = useState(initialContent);
     const [expandedVariables, setExpandedVariables] = useState<ExpandedVariable[]>([]);
@@ -311,8 +314,15 @@ const ChatInput: React.FC<ChatInputProps> = ({
                     className={classNames("message", "message-user", 'chat-input', {"agent-mode": agentModeEnabled})}
                     placeholder={placeholder}
                     value={input}
+                    disabled={agentExecutionStatus === 'working' || agentExecutionStatus === 'stopping'}
                     onChange={handleInputChange}
                     onKeyDown={(e) => {
+                        // If agent is working or stopping, prevent all input
+                        if (agentExecutionStatus === 'working' || agentExecutionStatus === 'stopping') {
+                            e.preventDefault();
+                            return;
+                        }
+
                         // If dropdown is visible, only handle escape to close it
                         if (isDropdownVisible) {
                             if (e.key === 'Escape') {

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -132,6 +132,7 @@ interface ICellStateBeforeDiff {
 }
 
 export type CodeReviewStatus = 'chatPreview' | 'codeCellPreview' | 'applied'
+export type AgentExecutionStatus = 'working' | 'stopping' | 'idle'
 
 const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     notebookTracker,
@@ -194,7 +195,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         2. stopping: the agent is stopping after it has received ai response it is waiting on
         3. idle: the agent is idle
     */
-    const [agentExecutionStatus, setAgentExecutionStatus] = useState<'working' | 'stopping' | 'idle'>('idle')
+    const [agentExecutionStatus, setAgentExecutionStatus] = useState<AgentExecutionStatus>('idle')
 
     // We use a ref to always access the most up-to-date value during a function's execution. Refs immediately reflect changes, 
     // unlike state variables, which are captured at the beginning of a function and may not reflect updates made during execution.
@@ -1495,6 +1496,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     notebookTracker={notebookTracker}
                     renderMimeRegistry={renderMimeRegistry}
                     agentModeEnabled={agentModeEnabled}
+                    agentExecutionStatus={agentExecutionStatus}
                 />
             </div>
             {agentExecutionStatus !== 'working' && agentExecutionStatus !== 'stopping' && (

--- a/mito-ai/style/ChatInput.css
+++ b/mito-ai/style/ChatInput.css
@@ -82,3 +82,20 @@
 .context-button:hover {
   background-color: var(--jp-layout-color3);
 }
+
+/* Disabled state styles */
+.chat-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--jp-layout-color2);
+}
+
+.context-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--jp-layout-color2);
+}
+
+.context-button:disabled:hover {
+  background-color: var(--jp-layout-color2);
+}


### PR DESCRIPTION
# Description

Passing the agent execution status to `ChatInput` and using the status to disable the input when the agent is working. 

# Testing

Send a message in Agent mode, make sure you can't type while the agent is working. 

# Documentation

N/A