### PR TITLE
mito-ai: bring back streamlit loading indicator

### DIFF
--- a/mito-ai/mito_ai/streamlit_conversion/streamlit_system_prompt.py
+++ b/mito-ai/mito_ai/streamlit_conversion/streamlit_system_prompt.py
@@ -34,7 +34,6 @@ st.markdown(\"\"\"
     <style>
         #MainMenu {visibility: hidden;}
         .stAppDeployButton {display:none;}
-        .stAppHeader {display:none;}
         footer {visibility: hidden;}
         .stMainBlockContainer {padding: 2rem 1rem 2rem 1rem;}
     </style>


### PR DESCRIPTION
# Description

When you make a configuration change in the app, it will now show the streamlit loading indicator in the top right so you know the app is loading and not just broken! 
.