### PR TITLE
mito-ai: move preview app back to beta

### DIFF
--- a/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
+++ b/mito-ai/src/Extensions/ToolbarButtons/ToolbarButtonsPlugin.tsx
@@ -93,9 +93,8 @@ const ToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
             execute: async () => {
                 void app.commands.execute('mito-ai:preview-as-streamlit');
             },
-            isEnabled: () => {
-                // TODO: We should check if there is an open notebook
-                return true;
+            isVisible: () => {
+                return app.commands.hasCommand(COMMAND_MITO_AI_BETA_MODE_ENABLED);
             }
         });
 
@@ -107,6 +106,7 @@ const ToolbarButtonsPlugin: JupyterFrontEndPlugin<void> = {
                 commands.addCommand(COMMAND_MITO_AI_BETA_MODE_ENABLED, { execute: () => { /* no-op */ } });
                 commands.notifyCommandChanged('toolbar-button:convert-to-streamlit');
                 commands.notifyCommandChanged('toolbar-button:toggle-include-cell-in-app');
+                commands.notifyCommandChanged('toolbar-button:preview-as-streamlit');
             }
         }).catch(error => {
             console.error('Error checking beta mode:', error);

--- a/tests/mitoai_ui_tests/app_builder.spec.ts
+++ b/tests/mitoai_ui_tests/app_builder.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../jupyter_utils/jupyterlab_utils';
 
 test.describe('App Builder Integration Test', () => {
-  test('Preview as Streamlit', async ({ page }) => {
+  test.skip('Preview as Streamlit', async ({ page }) => {
     const notebookCode = 'x = 10'
     await createAndRunNotebookWithCells(page, [notebookCode]);
     await waitForIdle(page);


### PR DESCRIPTION
# Description

I want to do a release today, but the preview app feature needs more testing, so moving it back to beta mode. 

# Testing

Make sure only available in beta mode. 