### PR TITLE
mitosheet: supress streamlit warnings from mitosheet

### DIFF
--- a/mitosheet/mitosheet/__init__.py
+++ b/mitosheet/mitosheet/__init__.py
@@ -16,6 +16,12 @@ If running the mitosheet.sheet() call does not work, try restarting your Jupyter
 If it still does not work, please email jake@sagacollab.com
 """
 
+# Suppress Streamlit ScriptRunContext warnings that occur when mitosheet is imported
+# outside of a proper Streamlit script execution context
+import warnings
+warnings.filterwarnings("ignore", message=r".*missing ScriptRunContext.*")
+warnings.filterwarnings("ignore", message=r".*bare mode.*")
+
 # Public interface we want users to rely on
 from mitosheet.mito_backend import sheet
 from mitosheet._version import __version__

--- a/mitosheet/mitosheet/api/get_defined_df_names.py
+++ b/mitosheet/mitosheet/api/get_defined_df_names.py
@@ -43,7 +43,7 @@ def get_df_names_ipython() -> List[str]:
 
 def get_df_names_streamlit_or_dash() -> List[str]:
     # Get dataframes defined in any calling frames above this one
-    import inspect
+    import inspect    
     import streamlit as st
     import pandas as pd
 

--- a/mitosheet/mitosheet/user/location.py
+++ b/mitosheet/mitosheet/user/location.py
@@ -132,7 +132,7 @@ def is_streamlit() -> bool:
         # TODO: have to handle versions of streamlit that don't have this
         # or it's in different places: https://discuss.streamlit.io/t/how-to-check-if-code-is-run-inside-streamlit-and-not-e-g-ipython/23439/8
         from streamlit.runtime.scriptrunner import get_script_run_ctx
-        return get_script_run_ctx() is not None
+        return get_script_run_ctx(suppress_warning=True) is not None
     except ModuleNotFoundError:
         return False
     

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -638,7 +638,7 @@ def is_snowflake_connector_python_installed() -> bool:
         return False
     
 def is_streamlit_installed() -> bool:
-    try:
+    try:        
         import streamlit
         return True
     except ImportError:


### PR DESCRIPTION
# Description

When we had mitosheet and streamlit in the same environment, you would get this warnings when launching mitosheet. Even the warning says it can be ignored. This cleans it up so the user doesn't have to see that warning! 

<img width="1297" height="638" alt="Screenshot 2025-08-01 at 9 49 01 AM" src="https://github.com/user-attachments/assets/91ccd0db-3daa-422e-8fc2-9144c00ab989" />

# Testing

Launch a mitosheet in an environment with streamlit in it. 

# Documentation

No. 