### PR TITLE
Active Cell Context Card

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -305,8 +305,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
                             title={context.type === 'db' && context.display ? context.display : context.value}
                             type={context.type}
                             onRemove={() => setAdditionalContext(additionalContext.filter((_, i) => i !== index))}
-                            notebookTracker={context.type === 'active_cell' ? notebookTracker : undefined}
-                            activeCellID={context.type === 'active_cell' ? activeCellID : undefined}
+                            notebookTracker={notebookTracker}
+                            activeCellID={activeCellID}
                         />
                     ))}  
                 </div>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -262,7 +262,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
     // Automatically add active cell context when in Chat mode and there's active cell code
     useEffect(() => {
-        if (!agentModeEnabled && activeCellCode && activeCellCode.trim().length > 0) {
+        if (!agentModeEnabled) {
             // Check if active cell context is already present
             const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
             

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -326,6 +326,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
                             title={context.type === 'db' && context.display ? context.display : context.value}
                             type={context.type}
                             onRemove={() => setAdditionalContext(additionalContext.filter((_, i) => i !== index))}
+                            notebookTracker={context.type === 'active_cell' ? notebookTracker : undefined}
+                            activeCellID={context.type === 'active_cell' ? activeCellID : undefined}
                         />
                     ))}  
                 </div>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -271,6 +271,22 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const activeCellCodePreview = activeCellCode.split('\n').slice(0, 8).join('\n') + (
         activeCellCode.split('\n').length > 8 ? '\n\n# Rest of active cell code...' : '')
 
+    // Automatically add active cell context when in Chat mode and there's active cell code
+    useEffect(() => {
+        if (!agentModeEnabled && activeCellCode && activeCellCode.trim().length > 0) {
+            // Check if active cell context is already present
+            const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
+            
+            if (!hasActiveCellContext) {
+                setAdditionalContext(prev => [...prev, { 
+                    type: 'active_cell', 
+                    value: 'Active Cell',
+                    display: 'Active Cell'
+                }]);
+            }
+        }
+    }, [agentModeEnabled, activeCellCode, additionalContext]);
+
             return (
             <div 
                 className={classNames("chat-input-container")}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -23,7 +23,7 @@ interface ChatInputProps {
     app: JupyterFrontEnd;
     initialContent: string;
     placeholder: string;
-    onSave: (content: string, index?: number, additionalContext?: Array<{type: string, value: string}>) => void;
+    onSave: (content: string, index?: number, additionalContext?: Array<{ type: string, value: string }>) => void;
     onCancel?: () => void;
     isEditing: boolean;
     contextManager?: IContextManager;
@@ -72,19 +72,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }, 100);
 
     useEffect(() => {
-        const activeCellChangedListener = (): void => { 
+        const activeCellChangedListener = (): void => {
             const newActiveCellID = getActiveCellID(notebookTracker);
             debouncedSetActiveCellID(newActiveCellID);
         };
 
         // Connect the listener once when the component mounts
         notebookTracker.activeCellChanged.connect(activeCellChangedListener);
-    
+
         // Cleanup: disconnect the listener when the component unmounts
         return () => {
             notebookTracker.activeCellChanged.disconnect(activeCellChangedListener);
         };
-    
+
     }, [notebookTracker, activeCellID, debouncedSetActiveCellID]);
 
     // TextAreas cannot automatically adjust their height based on the content that they contain, 
@@ -95,7 +95,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
         textarea.style.minHeight = 'auto';
         textarea.style.height = !textarea.value || resetHeight
-            ? '80px' 
+            ? '80px'
             : `${Math.max(80, textarea.scrollHeight)}px`;
     };
 
@@ -129,7 +129,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             // When triggered by "Add Context" button, add to SelectedContextContainer
             if (option.type === 'variable') {
                 // For variables, we'll add them as a special context type
-                const contextName = option.variable.parent_df 
+                const contextName = option.variable.parent_df
                     ? `${option.variable.parent_df}.${option.variable.variable_name}`
                     : option.variable.variable_name;
                 setAdditionalContext(prev => [...prev, { type: 'variable', value: contextName }]);
@@ -140,15 +140,15 @@ const ChatInput: React.FC<ChatInputProps> = ({
             } else if (option.type === 'db') {
                 setAdditionalContext(prev => [
                     ...prev,
-                    { 
-                        type: 'db', 
-                        value: option.variable.value, 
-                        display: option.variable.variable_name 
+                    {
+                        type: 'db',
+                        value: option.variable.value,
+                        display: option.variable.variable_name
                     }
                 ]);
             }
             setDropdownVisible(false);
-            
+
             // Use setTimeout to ensure this happens after React's state update cycle
             setTimeout(() => {
                 textAreaRef.current?.focus();
@@ -168,7 +168,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         let contextChatRepresentation: string = ''
 
         if (option.type === 'variable') {
-            
+
             if (option.variable.parent_df) {
                 contextChatRepresentation = `\`${option.variable.variable_name}\``
             } else {
@@ -219,7 +219,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         setIsDropdownFromButton(false);
     };
 
-    const mapAdditionalContext = (): Array<{type: string, value: string}> => {
+    const mapAdditionalContext = (): Array<{ type: string, value: string }> => {
         return additionalContext.map(context => {
             if (context.type === 'db') {
                 return {
@@ -265,10 +265,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
         if (!agentModeEnabled) {
             // Check if active cell context is already present
             const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
-            
+
             if (!hasActiveCellContext) {
-                setAdditionalContext(prev => [...prev, { 
-                    type: 'active_cell', 
+                setAdditionalContext(prev => [...prev, {
+                    type: 'active_cell',
                     value: 'Active Cell',
                     display: 'Active Cell'
                 }]);
@@ -282,35 +282,35 @@ const ChatInput: React.FC<ChatInputProps> = ({
         }
     }, [agentModeEnabled, additionalContext, activeCellCode]);
 
-            return (
-            <div 
-                className={classNames("chat-input-container")}
-            >
-                <div className='context-container'>
-                    <DatabaseButton app={app} />
-                    <button 
-                        className="context-button"
-                        onClick={() => {
-                            setDropdownVisible(true);
-                            setDropdownFilter('');
-                            setIsDropdownFromButton(true);
-                            textAreaRef.current?.focus();
-                        }}
-                    >
-                        ＠ Add Context
-                    </button>    
-                    {additionalContext.map((context, index) => (
-                        <SelectedContextContainer
-                            key={`${context.type}-${context.value}-${index}`}
-                            title={context.type === 'db' && context.display ? context.display : context.value}
-                            type={context.type}
-                            onRemove={() => setAdditionalContext(additionalContext.filter((_, i) => i !== index))}
-                            notebookTracker={notebookTracker}
-                            activeCellID={activeCellID}
-                        />
-                    ))}  
-                </div>
-            
+    return (
+        <div
+            className={classNames("chat-input-container")}
+        >
+            <div className='context-container'>
+                <DatabaseButton app={app} />
+                <button
+                    className="context-button"
+                    onClick={() => {
+                        setDropdownVisible(true);
+                        setDropdownFilter('');
+                        setIsDropdownFromButton(true);
+                        textAreaRef.current?.focus();
+                    }}
+                >
+                    ＠ Add Context
+                </button>
+                {additionalContext.map((context, index) => (
+                    <SelectedContextContainer
+                        key={`${context.type}-${context.value}-${index}`}
+                        title={context.type === 'db' && context.display ? context.display : context.value}
+                        type={context.type}
+                        onRemove={() => setAdditionalContext(additionalContext.filter((_, i) => i !== index))}
+                        notebookTracker={notebookTracker}
+                        activeCellID={activeCellID}
+                    />
+                ))}
+            </div>
+
             {/* 
                 Create a relative container for the text area and the dropdown so that when we 
                 render the dropdown, it is relative to the text area instead of the entire 
@@ -320,7 +320,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             <div className='chat-input-text-area-container'>
                 <textarea
                     ref={textAreaRef}
-                    className={classNames("message", "message-user", 'chat-input', {"agent-mode": agentModeEnabled})}
+                    className={classNames("message", "message-user", 'chat-input', { "agent-mode": agentModeEnabled })}
                     placeholder={placeholder}
                     value={input}
                     disabled={agentExecutionStatus === 'working' || agentExecutionStatus === 'stopping'}
@@ -355,7 +355,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         }
                     }}
                 />
-                {isDropdownVisible  && (
+                {isDropdownVisible && (
                     <ChatDropdown
                         options={expandedVariables}
                         onSelect={handleOptionSelect}
@@ -366,7 +366,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                     />
                 )}
             </div>
-            
+
             {isEditing &&
                 <div className="message-edit-buttons">
                     <button onClick={() => onSave(input, undefined, mapAdditionalContext())}>Save</button>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -8,7 +8,7 @@ import { classNames } from '../../../utils/classNames';
 import { IContextManager } from '../../ContextManager/ContextManagerPlugin';
 import ChatDropdown from './ChatDropdown';
 import { Variable } from '../../ContextManager/VariableInspector';
-import { getActiveCellID } from '../../../utils/notebook';
+import { getActiveCellID, getActiveCellCode } from '../../../utils/notebook';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import '../../../../style/ChatInput.css';
 import '../../../../style/ChatDropdown.css';
@@ -59,6 +59,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const [expandedVariables, setExpandedVariables] = useState<ExpandedVariable[]>([]);
     const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
     const [activeCellID, setActiveCellID] = useState<string | undefined>(getActiveCellID(notebookTracker));
+    const activeCellCode = getActiveCellCode(notebookTracker) || '';
     const [isDropdownVisible, setDropdownVisible] = useState(false);
     const [dropdownFilter, setDropdownFilter] = useState('');
     const [additionalContext, setAdditionalContext] = useState<ContextItem[]>([]);
@@ -261,7 +262,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
     // Automatically add active cell context when in Chat mode and there's active cell code
     useEffect(() => {
-        if (!agentModeEnabled) {
+        if (!agentModeEnabled && activeCellCode && activeCellCode.trim().length > 0) {
             // Check if active cell context is already present
             const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
             
@@ -272,8 +273,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
                     display: 'Active Cell'
                 }]);
             }
+        } else if (agentModeEnabled) {
+            // Remove active cell context when in agent mode
+            const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
+            if (hasActiveCellContext) {
+                setAdditionalContext(prev => prev.filter(context => context.type !== 'active_cell'));
+            }
         }
-    }, [agentModeEnabled, additionalContext]);
+    }, [agentModeEnabled, additionalContext, activeCellCode]);
 
             return (
             <div 

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -244,7 +244,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                             .map((context, index) => (
                                                 <SelectedContextContainer
                                                     key={`${context.type}-${context.value}-${index}`}
-                                                    title={`${context.type.charAt(0).toUpperCase() + context.type.slice(1)}: ${context.value}`}
+                                                    title={`${context.value}`}
                                                     type={context.type}
                                                     onRemove={() => { }} // Read-only in chat history
                                                 />

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -133,8 +133,6 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                 isEditing={isEditing}
                 contextManager={contextManager}
                 notebookTracker={notebookTracker}
-                renderMimeRegistry={renderMimeRegistry}
-                displayActiveCellCode={true}
                 agentModeEnabled={false}
             />
         );

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -239,14 +239,16 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                 }
                                 {message.role === 'user' && additionalContext && additionalContext.length > 0 &&
                                     <>
-                                        {additionalContext.map((context, index) => (
-                                            <SelectedContextContainer
-                                                key={`${context.type}-${context.value}-${index}`}
-                                                title={`${context.type.charAt(0).toUpperCase() + context.type.slice(1)}: ${context.value}`}
-                                                type={context.type}
-                                                onRemove={() => { }} // Read-only in chat history
-                                            />
-                                        ))}
+                                        {additionalContext
+                                            .filter(context => context.type !== 'active_cell') // Hide active cell context in chat messages
+                                            .map((context, index) => (
+                                                <SelectedContextContainer
+                                                    key={`${context.type}-${context.value}-${index}`}
+                                                    title={`${context.type.charAt(0).toUpperCase() + context.type.slice(1)}: ${context.value}`}
+                                                    type={context.type}
+                                                    onRemove={() => { }} // Read-only in chat history
+                                                />
+                                            ))}
                                     </>
                                 }
                             </>

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1516,7 +1516,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     isEditing={false}
                     contextManager={contextManager}
                     notebookTracker={notebookTracker}
-                    renderMimeRegistry={renderMimeRegistry}
                     agentModeEnabled={agentModeEnabled}
                     agentExecutionStatus={agentExecutionStatus}
                 />

--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -45,7 +45,7 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
             break;
     }
 
-    const handleClick = () => {
+    const handleClick = (): void => {
         if (type === 'active_cell' && notebookTracker && activeCellID) {
             // Find the cell 
             const cell = getCellByID(notebookTracker, activeCellID);

--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -29,6 +29,9 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({ tit
         case 'db':
             icon = <DatabaseIcon />;
             break;
+        case 'active_cell':
+            icon = <CodeIcon />;
+            break;
     }
 
     return (

--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -46,17 +46,21 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
     }
 
     const handleClick = (): void => {
-        if (type === 'active_cell' && notebookTracker && activeCellID) {
-            // Find the cell 
-            const cell = getCellByID(notebookTracker, activeCellID);
-            if (cell) {
-                // Scroll to the cell
-                void notebookTracker.currentWidget?.content.scrollToCell(cell, 'center');
-                // Highlight the cell
-                setTimeout(() => {
-                    highlightCodeCell(notebookTracker, activeCellID);
-                }, 500);
+        if (type === 'active_cell') {
+            // Handle active cell context click
+            if (notebookTracker && activeCellID) {
+                // Find the cell 
+                const cell = getCellByID(notebookTracker, activeCellID);
+                if (cell) {
+                    // Scroll to the cell
+                    void notebookTracker.currentWidget?.content.scrollToCell(cell, 'center');
+                    // Highlight the cell
+                    setTimeout(() => {
+                        highlightCodeCell(notebookTracker, activeCellID);
+                    }, 500);
+                }
             }
+            // If notebookTracker or activeCellID are not available, do nothing
         } else if (onClick) {
             // Call the custom onClick handler for other context types
             onClick();

--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -47,12 +47,12 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
 
     const handleClick = () => {
         if (type === 'active_cell' && notebookTracker && activeCellID) {
-            // First scroll to the cell
+            // Find the cell 
             const cell = getCellByID(notebookTracker, activeCellID);
             if (cell) {
                 // Scroll to the cell
                 void notebookTracker.currentWidget?.content.scrollToCell(cell, 'center');
-                // Wait for scroll to complete, then highlight the entire cell
+                // Highlight the cell
                 setTimeout(() => {
                     highlightCodeCell(notebookTracker, activeCellID);
                 }, 500);

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -687,19 +687,5 @@ describe('ChatInput Component', () => {
             // Should not have any SelectedContextContainer
             expect(screen.queryByTestId('selected-context-container')).not.toBeInTheDocument();
         });
-
-        it('does not show active cell context when there is no active cell code', () => {
-            // Mock getActiveCellCode to return empty string
-            const { getActiveCellCode } = require('../../utils/notebook');
-            getActiveCellCode.mockImplementation(() => '');
-            
-            renderChatInput();
-            
-            // Should not show the active cell context container
-            expect(screen.queryByText('Active Cell')).not.toBeInTheDocument();
-            
-            // Should not have any SelectedContextContainer
-            expect(screen.queryByTestId('selected-context-container')).not.toBeInTheDocument();
-        });
     });
 });

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -654,4 +654,52 @@ describe('ChatInput Component', () => {
             expect(screen.queryByText('Machine Learning')).not.toBeInTheDocument();
         });
     });
+
+    describe('Active Cell Context', () => {
+        beforeEach(() => {
+            // Clear the DOM between tests
+            document.body.innerHTML = '';
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('shows active cell context automatically in Chat mode when there is active cell code', () => {
+            renderChatInput();
+            
+            // Should show the active cell context container
+            const activeCellContainer = screen.getByText('Active Cell');
+            expect(activeCellContainer).toBeInTheDocument();
+            
+            // Should be inside a SelectedContextContainer
+            const selectedContextContainer = screen.getByTestId('selected-context-container');
+            expect(selectedContextContainer).toBeInTheDocument();
+            expect(within(selectedContextContainer).getByText('Active Cell')).toBeInTheDocument();
+        });
+
+        it('does not show active cell context in Agent mode', () => {
+            renderChatInput({ agentModeEnabled: true });
+            
+            // Should not show the active cell context container
+            expect(screen.queryByText('Active Cell')).not.toBeInTheDocument();
+            
+            // Should not have any SelectedContextContainer
+            expect(screen.queryByTestId('selected-context-container')).not.toBeInTheDocument();
+        });
+
+        it('does not show active cell context when there is no active cell code', () => {
+            // Mock getActiveCellCode to return empty string
+            const { getActiveCellCode } = require('../../utils/notebook');
+            getActiveCellCode.mockImplementation(() => '');
+            
+            renderChatInput();
+            
+            // Should not show the active cell context container
+            expect(screen.queryByText('Active Cell')).not.toBeInTheDocument();
+            
+            // Should not have any SelectedContextContainer
+            expect(screen.queryByTestId('selected-context-container')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -245,7 +245,9 @@ describe('ChatInput Component', () => {
             fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
             
             // Verify onSave was called with the input content
-            expect(onSaveMock).toHaveBeenCalledWith(testMessage, undefined, []);
+            expect(onSaveMock).toHaveBeenCalledWith(testMessage, undefined, [
+                { type: 'active_cell', value: 'Active Cell', display: 'Active Cell' }
+            ]);
             
             // Verify the input was cleared
             expect(textarea).toHaveValue('');
@@ -357,7 +359,9 @@ describe('ChatInput Component', () => {
             fireEvent.keyDown(idleTextarea, { key: 'Enter', code: 'Enter' });
             
             // Verify onSave was called
-            expect(idleSaveMock).toHaveBeenCalledWith(testMessage, undefined, []);
+            expect(idleSaveMock).toHaveBeenCalledWith(testMessage, undefined, [
+                { type: 'active_cell', value: 'Active Cell', display: 'Active Cell' }
+            ]);
         });
     });
 
@@ -402,7 +406,9 @@ describe('ChatInput Component', () => {
             fireEvent.click(saveButton);
             
             // Verify onSave was called with the updated content
-            expect(editSaveMock).toHaveBeenCalledWith(updatedContent, undefined, []);
+            expect(editSaveMock).toHaveBeenCalledWith(updatedContent, undefined, [
+                { type: 'active_cell', value: 'Active Cell', display: 'Active Cell' }
+            ]);
         });
 
         it('calls onCancel when Cancel button is clicked', () => {
@@ -576,11 +582,17 @@ describe('ChatInput Component', () => {
             expect(textarea).toHaveValue('Data Analysis');
             
             // Wait for the SelectedContextContainer to appear
-            const selectedContextContainer = await screen.findByTestId('selected-context-container');
-            expect(selectedContextContainer).toBeInTheDocument();
+            const selectedContextContainers = await screen.findAllByTestId('selected-context-container');
+            expect(selectedContextContainers.length).toBeGreaterThan(0);
+            
+            // Find the container with the specific rule text
+            const dataAnalysisContainer = selectedContextContainers.find(container => 
+                within(container).queryByText('Data Analysis', {exact: false})
+            );
+            expect(dataAnalysisContainer).toBeInTheDocument();
 
             // Then, look for the rule text *within* that container
-            const ruleTextInContainer = within(selectedContextContainer).getByText('Data Analysis', {exact: false});
+            const ruleTextInContainer = within(dataAnalysisContainer!).getByText('Data Analysis', {exact: false});
             expect(ruleTextInContainer).toBeInTheDocument();
             
             // Look for the container by its class instead of data-testid as an alternative
@@ -611,15 +623,21 @@ describe('ChatInput Component', () => {
             });
             
             // SelectedContextContainer should be displayed with the selected rule
-            const selectedContextContainer = await screen.findByTestId('selected-context-container');
-            expect(selectedContextContainer).toBeInTheDocument();
+            const selectedContextContainers = await screen.findAllByTestId('selected-context-container');
+            expect(selectedContextContainers.length).toBeGreaterThan(0);
+            
+            // Find the container with the specific rule text
+            const machineLearningContainer = selectedContextContainers.find(container => 
+                within(container).queryByText('Machine Learning', {exact: false})
+            );
+            expect(machineLearningContainer).toBeInTheDocument();
 
             // And it should be in the chat input
             const selectedRule = within(textarea).getByText('Machine Learning');
             expect(selectedRule).toBeInTheDocument();
             
             // Check that the rule container has a remove button
-            const removeButton = selectedContextContainer.querySelector('.icon');
+            const removeButton = machineLearningContainer!.querySelector('.icon');
             expect(removeButton).toBeInTheDocument();
             
             // Click the remove button
@@ -629,8 +647,19 @@ describe('ChatInput Component', () => {
                 }
             });
             
-            // After removing, the SelectedContextContainer should not be in the document
-            expect(screen.queryByTestId('selected-context-container')).not.toBeInTheDocument();
+            // After removing, the Machine Learning SelectedContextContainer should not be in the document
+            // but the Active Cell context should still be there
+            const remainingContainers = screen.getAllByTestId('selected-context-container');
+            const removedMachineLearningContainer = remainingContainers.find(container => 
+                within(container).queryByText('Machine Learning', {exact: false})
+            );
+            expect(removedMachineLearningContainer).toBeUndefined();
+            
+            // Verify that the Active Cell context is still there
+            const activeCellContainer = remainingContainers.find(container => 
+                within(container).queryByText('Active Cell', {exact: false})
+            );
+            expect(activeCellContainer).toBeInTheDocument();
         });
     });
 

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -353,10 +353,10 @@ describe('ChatMessage Component', () => {
             expect(screen.getByText('Hello, can you help me with pandas?')).toBeInTheDocument();
 
             // Check that SelectedContextContainer components are rendered for each context item
-            // The SelectedContextContainer renders the title as text content
-            expect(screen.getByText('Variable: df')).toBeInTheDocument();
-            expect(screen.getByText('File: data.csv')).toBeInTheDocument();
-            expect(screen.getByText('Rule: Use pandas for data manipulation')).toBeInTheDocument();
+            // The SelectedContextContainer renders the value as text content
+            expect(screen.getByText('df')).toBeInTheDocument();
+            expect(screen.getByText('data.csv')).toBeInTheDocument();
+            expect(screen.getByText('Use pandas for data manipulation')).toBeInTheDocument();
 
             // Check that the containers have the correct test IDs
             const contextContainers = screen.getAllByTestId('selected-context-container');

--- a/mito-ai/style/SelectedContextContainer.css
+++ b/mito-ai/style/SelectedContextContainer.css
@@ -52,4 +52,5 @@
   justify-content: center;
   width: 12px;
   max-height: 14px;
+  color: var(--jp-content-font-color3);
 }


### PR DESCRIPTION
# Description

Removed the active cell preview (in Chat mode), and replaced it with an _Active Cell_ card in the Selected Context Container. 

# Testing

- In chat mode you should be able to see the Active Cell card.
- In chat mode you should be able to click on the card, and go to the active cell.
- In Agent mode the card should not be visible. 

# Documentation

No, this should be self-explanatory. 