### PR TITLE
mito-ai: better alert blocks

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -52,9 +52,11 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
     return (
         <div className="chat-message-alert-container">
             <div className="chat-message-alert">
-                {content}
+                <div className="alert-error-message">
+                    {content}
+                </div>
             </div>
-            <div className="chat-message-alert-actions">
+            <div>
                 <p className="alert-actions-title">If this issue persists, we recommend:</p>
                 <ul className="alert-actions-list">
                     <li>Restarting JupyterLab completely</li>

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -3,11 +3,11 @@
  * Distributed under the terms of the GNU Affero General Public License v3.0 License.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import TextButton from '../../../components/TextButton';
 import { FREE_TIER_LIMIT_REACHED_ERROR_TITLE } from '../../../utils/errors';
 import { STRIPE_PAYMENT_LINK } from '../../../utils/stripe';
-
+import { logEvent } from '../../../restAPI/RestAPI';
 
 interface IAlertBlockProps {
     content: string;
@@ -15,6 +15,14 @@ interface IAlertBlockProps {
 }
 
 const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionErrorType }) => {
+    const [showEmailDetails, setShowEmailDetails] = useState(false);
+
+    // The first time this AlertBlock is rendered, log the error type
+    useEffect(() => {
+        logEvent('alert_block_displayed', { 'type': mitoAIConnectionErrorType, 'error': content });
+    }, []);
+
+
 
     if (mitoAIConnectionErrorType === FREE_TIER_LIMIT_REACHED_ERROR_TITLE) {
         return (
@@ -42,8 +50,39 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
     }
 
     return (
-        <div className="chat-message-alert">
-            {content}
+        <div className="chat-message-alert-container">
+            <div className="chat-message-alert">
+                {content}
+            </div>
+            <div className="chat-message-alert-actions">
+                <p className="alert-actions-title">If this issue persists, we recommend:</p>
+                <ul className="alert-actions-list">
+                    <li>Restarting JupyterLab completely</li>
+                    <li>Upgrading to the latest version of Mito AI</li>
+                    <li>
+                        Sending us an email to founders@sagacollab.com &nbsp; 
+                        <div className="details-toggle">
+                            <button 
+                                type="button"
+                                onClick={() => setShowEmailDetails(!showEmailDetails)}
+                                className="toggle-button"
+                            >
+                                <span className="toggle-text"> Info to send us</span>
+                                <span className={`toggle-caret ${showEmailDetails ? 'open' : ''}`}>
+                                    ▼
+                                </span>
+                            </button>
+                        </div>
+                        {showEmailDetails && (
+                            <div className="details-content">
+                                <li>A screenshot of your entire Jupyter window</li>
+                                <li>A screenshot of your browser's console. You can access this by right clicking on this error message, clicking "Inspect", and then clicking the "Console" tab. Then find the red error message at the bottom of the console and screenshot it.</li>
+                                <li>Your `pip list` output</li>
+                            </div>
+                        )}
+                    </li>
+                </ul>
+            </div>
         </div>
     );
 };

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -76,7 +76,7 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
                         {showEmailDetails && (
                             <div className="details-content">
                                 <li>A screenshot of your entire Jupyter window</li>
-                                <li>A screenshot of your browser's console. You can access this by right clicking on this error message, clicking "Inspect", and then clicking the "Console" tab. Then find the red error message at the bottom of the console and screenshot it.</li>
+                                <li>A screenshot of your browser&apos;s console. You can access this by right clicking on this error message, clicking &quot;Inspect&quot;, and then clicking the &quot;Console&quot; tab. Then find the red error message at the bottom of the console and screenshot it.</li>
                                 <li>Your `pip list` output</li>
                             </div>
                         )}

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AlertBlock.tsx
@@ -22,8 +22,6 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
         logEvent('alert_block_displayed', { 'type': mitoAIConnectionErrorType, 'error': content });
     }, []);
 
-
-
     if (mitoAIConnectionErrorType === FREE_TIER_LIMIT_REACHED_ERROR_TITLE) {
         return (
             <div className="chat-message-alert">
@@ -53,7 +51,7 @@ const AlertBlock: React.FC<IAlertBlockProps> = ({ content, mitoAIConnectionError
         <div className="chat-message-alert-container">
             <div className="chat-message-alert">
                 <div className="alert-error-message">
-                    {content}
+                    &#9888; {content}
                 </div>
             </div>
             <div>

--- a/mito-ai/style/ChatMessage.css
+++ b/mito-ai/style/ChatMessage.css
@@ -223,23 +223,14 @@
 }
 
 .toggle-button:hover {
-  color: var(--red-900);
-}
-
-.toggle-text {
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  transition: text-decoration-color 0.2s ease;
-}
-
-.toggle-button:hover .toggle-text {
-  text-decoration-color: var(--red-900);
+  color: var(--red-800);
 }
 
 .toggle-caret {
   font-size: 10px;
   transition: transform 0.2s ease;
   display: inline-block;
+  text-decoration: none !important;
 }
 
 .toggle-caret.open {
@@ -264,15 +255,4 @@
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.details-content p {
-  margin: 0 0 8px 0;
-  font-size: 12px;
-}
-
-.details-content ul {
-  margin: 0;
-  padding-left: 16px;
-  font-size: 12px;
 }

--- a/mito-ai/style/ChatMessage.css
+++ b/mito-ai/style/ChatMessage.css
@@ -139,7 +139,10 @@
   background-color: var(--jp-layout-color2);
 }
 
-.chat-message-alert {
+.chat-message-alert-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   background-color: var(--purple-300);
   border-radius: 5px;
   padding: 10px;
@@ -150,4 +153,126 @@
 .chat-message-alert a {
   color: var(--purple-700);
   text-decoration: underline;
+}
+
+.chat-message-alert-actions {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--grey-300);
+}
+
+.alert-actions-header {
+  margin-bottom: 12px;
+}
+
+.alert-actions-title {
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  color: var(--grey-900);
+}
+
+.alert-actions-list {
+  margin: 0;
+  padding-left: 16px;
+  color: var(--grey-700);
+}
+
+.alert-actions-list li {
+  margin-bottom: 4px;
+}
+
+.alert-action-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+  color: var(--grey-800);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.action-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.details-toggle {
+  display: inline-flex;
+  align-items: center;
+}
+
+.toggle-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--purple-700);
+  font-size: 12px;
+  font-family: inherit;
+}
+
+.toggle-button:hover {
+  color: var(--purple-600);
+}
+
+.toggle-text {
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.2s ease;
+}
+
+.toggle-button:hover .toggle-text {
+  text-decoration-color: var(--purple-700);
+}
+
+.toggle-caret {
+  font-size: 10px;
+  transition: transform 0.2s ease;
+  display: inline-block;
+}
+
+.toggle-caret.open {
+  transform: rotate(180deg);
+}
+
+.details-content {
+  margin-top: 8px;
+  margin-left: 16px;
+  padding: 8px;
+  background-color: var(--grey-100);
+  border-radius: 4px;
+  animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.details-content p {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+}
+
+.details-content ul {
+  margin: 0;
+  padding-left: 16px;
+  font-size: 12px;
+}
+
+.details-content code {
+  background-color: var(--grey-200);
+  padding: 1px 3px;
+  border-radius: 2px;
+  font-size: 11px;
 }

--- a/mito-ai/style/ChatMessage.css
+++ b/mito-ai/style/ChatMessage.css
@@ -143,11 +143,11 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  background-color: var(--purple-300);
+  background-color: var(--red-300);
   border-radius: 5px;
   padding: 10px;
-  border: 1px solid var(--purple-500);
-  color: var(--grey-900);
+  border: 1px solid var(--red-900);
+  color: var(--red-900);
 }
 
 .chat-message-alert a {
@@ -155,10 +155,13 @@
   text-decoration: underline;
 }
 
-.chat-message-alert-actions {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--grey-300);
+/* New style for the main error message */
+.alert-error-message {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--red-900);
+  margin-bottom: 8px;
 }
 
 .alert-actions-header {
@@ -166,19 +169,22 @@
 }
 
 .alert-actions-title {
-  font-weight: 600;
+  font-weight: 500;
   margin: 0 0 8px 0;
-  color: var(--grey-900);
+  color: var(--red-900);
+  font-size: 13px;
 }
 
 .alert-actions-list {
   margin: 0;
   padding-left: 16px;
-  color: var(--grey-700);
+  color: var(--red-800);
 }
 
 .alert-actions-list li {
   margin-bottom: 4px;
+  font-size: 13px;
+  line-height: 1.4;
 }
 
 .alert-action-item {
@@ -186,7 +192,7 @@
   align-items: flex-start;
   gap: 8px;
   padding: 8px 0;
-  color: var(--grey-800);
+  color: var(--red-800);
   font-size: 13px;
   line-height: 1.4;
 }
@@ -210,13 +216,14 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  color: var(--purple-700);
+  color: var(--red-900);
   font-size: 12px;
   font-family: inherit;
+  text-decoration: underline;
 }
 
 .toggle-button:hover {
-  color: var(--purple-600);
+  color: var(--red-900);
 }
 
 .toggle-text {
@@ -226,7 +233,7 @@
 }
 
 .toggle-button:hover .toggle-text {
-  text-decoration-color: var(--purple-700);
+  text-decoration-color: var(--red-900);
 }
 
 .toggle-caret {
@@ -268,11 +275,4 @@
   margin: 0;
   padding-left: 16px;
   font-size: 12px;
-}
-
-.details-content code {
-  background-color: var(--grey-200);
-  padding: 1px 3px;
-  border-radius: 2px;
-  font-size: 11px;
 }


### PR DESCRIPTION
# Description

Remakes the Alert that we show users when there is trouble with Mito. It now does a few things:
<img width="323" height="252" alt="Screenshot 2025-08-07 at 9 40 00 PM" src="https://github.com/user-attachments/assets/98c401d2-ca44-4a3d-b4e6-dbbb25110e6a" />

1. Gives them some instructions on how to fix things. Often, they just need to relaunch Jupyter because something funky happened. 
2. Adds a bit of logging so when something goes wrong, we at least know about it. 
3. Makes it look a bit better, I think. 

# Testing

Add this line to the mito_server_utils.py file and then send a message
```raise ProviderCompletionException("431 Request Header Fields Too Large", 'OpenAI', 'LLMProviderError')```

# Documentation

No. 