### PR TITLE
mito-ai: set matplotlib inline

### DIFF
--- a/mito-ai/mito_ai/__init__.py
+++ b/mito-ai/mito_ai/__init__.py
@@ -14,6 +14,14 @@ from mito_ai.settings.urls import get_settings_urls
 from mito_ai.rules.urls import get_rules_urls
 from mito_ai.auth.urls import get_auth_urls
 from mito_ai.streamlit_preview.urls import get_streamlit_preview_urls
+
+# Sometimes matplotlib figures do not show up in the notebook with this warning: 
+# UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
+# I believe that streamlit is reconfiguring the matplotlib settings and this is happening as a result.
+# For now, we just set the backend to inline, so that the figures show up again
+import os
+os.environ['MPLBACKEND'] = 'inline'
+
 try:
     from _version import __version__
 except ImportError:


### PR DESCRIPTION
# Description

Fixes this warning from appearing when trying to see matplotlib graphs

<img width="1328" height="101" alt="Screenshot 2025-08-07 at 12 34 58 PM" src="https://github.com/user-attachments/assets/cb0279ce-8eca-4a8b-90db-9115f4877148" />

# Testing

0. On dev, create a matplotlib graph and see that you get this warning instead of seeing the graph
1. Switch to this branch and rerun the graph, see the graph now! 

# Documentation

No