### PR TITLE
Truncating long samples in VariableInspector

### DIFF
--- a/mito-ai/.gitignore
+++ b/mito-ai/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 *.tsbuildinfo
 mito_ai/labextension
 .vscode/
+sample_data/
 
 # Integration tests
 ui-tests/test-results/

--- a/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
+++ b/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
@@ -34,7 +34,10 @@ def get_dataframe_structure(df, sample_size=5):
             # Handle None and NaN (convert to None, which maps to null in JSON)
             return None
         elif not isinstance(value, (str, int, float, bool, type(None))):
-            return str(value)[:50] + "..."
+            value_str = str(value)
+            if len(value_str) > 50:
+                return value_str[:50] + "..."
+            return value_str
         elif isinstance(value, str) and len(value) > 50:
             # Truncate strings longer than 50 characters
             return value[:50] + "..."

--- a/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
+++ b/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
@@ -34,7 +34,10 @@ def get_dataframe_structure(df, sample_size=5):
             # Handle None and NaN (convert to None, which maps to null in JSON)
             return None
         elif not isinstance(value, (str, int, float, bool, type(None))):
-            return str(value)            
+            return str(value)[:50] + "..."
+        elif isinstance(value, str) and len(value) > 50:
+            # Truncate strings longer than 50 characters
+            return value[:50] + "..."
         return value 
         
     structure = {}


### PR DESCRIPTION
# Description

Fix for shapefiles blowing up the context window. When adding samples to the context manager, the VariableInspector will only add the first 50 characters. 

<img width="919" height="851" alt="Screenshot 2025-08-08 at 11 15 41 AM" src="https://github.com/user-attachments/assets/9318b9f5-adea-4892-a580-2425878e001a" />

# Testing

Add a shapefile, and have the Agent open it. You can then print the `contextManager` and look at the samples. 

# Documentation

No