### PR TITLE
Updated Code Block Padding

### DIFF
--- a/mito-ai/style/PythonCode.css
+++ b/mito-ai/style/PythonCode.css
@@ -17,7 +17,12 @@
   white-space: pre !important;
 }
 
-.code-block-python-code .jp-RenderedHTMLCommon > *:last-child {
+.code-block-python-code .jp-RenderedHTMLCommon {
+  /* Remove default Jupyter padding */
+  padding-right: 0px !important;
+}
+
+.code-block-python-code .jp-RenderedHTMLCommon>*:last-child {
   /* 
         Remove the default Jupyter ending margin 
         so that the rendered code is flush with the bottom


### PR DESCRIPTION
# Description

At some point Jupyter introduced a 20px padding-right to the `jp-RenderedHTMLCommon` class. This caused all of our code blocks to be rendered with whitespace on the right side. This PR removes the padding.

Note that the padding issue is only visible in dark mode. 

# Testing

Send a few prompts, look at the code blocks.

# Documentation

N/A