### PR TITLE
mito-ai: truncate long variables

### DIFF
--- a/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
+++ b/mito-ai/src/Extensions/ContextManager/VariableInspector.tsx
@@ -146,7 +146,6 @@ export function fetchVariablesAndUpdateState(notebookPanel: NotebookPanel, setVa
             if (KernelMessage.isStreamMsg(msg)) {
                 if (msg.content.name === 'stdout') {
                     try {
-                        console.log("VARIABLES", msg.content.text)
                         setVariables(JSON.parse(msg.content.text))
                     } catch (e) {
                         console.log("Error parsing variables", e)


### PR DESCRIPTION
# Description

Truncates long variables, similar to how we handle large cells. I think this is the biggest contributing factor to context window limits! 

# Testing

Try it out :) 

# Documentation

Nope. 