### PR TITLE
mito-ai: set default window mode to defer

### DIFF
--- a/mito-ai/src/Extensions/AiChat/AiChatPlugin.ts
+++ b/mito-ai/src/Extensions/AiChat/AiChatPlugin.ts
@@ -18,7 +18,7 @@ import { IChatTracker } from './token';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { IContextManager } from '../ContextManager/ContextManagerPlugin';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { setRenameUntitledFileOnSave } from './jupyterSettingsManager';
+import { setDefaultWindowingMode, setRenameUntitledFileOnSave } from './jupyterSettingsManager';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 
 // The Widget Rank determins where the ChatIcon is displayed
@@ -150,6 +150,7 @@ const AiChatPlugin: JupyterFrontEndPlugin<WidgetTracker> = {
 
     // Update jupyter settings to work best with mito-ai
     void setRenameUntitledFileOnSave(settingRegistry, documentManager);
+    void setDefaultWindowingMode(settingRegistry)
 
     // By returning a tracker token, we can require the token in other 
     // plugins. This allows us to force plugin load order. For example, 

--- a/mito-ai/src/Extensions/AiChat/jupyterSettingsManager.ts
+++ b/mito-ai/src/Extensions/AiChat/jupyterSettingsManager.ts
@@ -8,6 +8,8 @@ import { IDocumentManager } from "@jupyterlab/docmanager";
 
 // Document manager plugin ID
 const DOCMANAGER_PLUGIN_ID = '@jupyterlab/docmanager-extension:plugin';
+const NOTEBOOK_PLUGIN_ID = '@jupyterlab/notebook-extension:tracker'
+
 
 // Set renameUntitledFileOnSave to false when the extension loads
 export const setRenameUntitledFileOnSave = async (settingRegistry: ISettingRegistry, _documentManager: IDocumentManager): Promise<void> => {
@@ -17,6 +19,18 @@ export const setRenameUntitledFileOnSave = async (settingRegistry: ISettingRegis
     try {
         await settingRegistry.set(DOCMANAGER_PLUGIN_ID, 'renameUntitledFileOnSave', false);
     } catch (error) {
-        console.error('Failed to set renameUntitledFileOnSave setting:', error);
+        console.error('[mito-ai jupyter settings manager] Failed to set renameUntitledFileOnSave setting:', error);
     }
 };
+
+
+export const setDefaultWindowingMode = async (settingRegistry: ISettingRegistry): Promise<void> => {
+
+    try {
+        await settingRegistry.set(NOTEBOOK_PLUGIN_ID, 'windowingMode', 'defer');
+    } catch (error) {
+        console.log('[mito-ai jupyter settings manager] Failed to set windowingMode to defer', error);
+    }
+}
+
+


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1921

The root cause of this issue (as we expected) is that the virtual cell rendering was incorrectly calculating the height of cells + outputs and causing the notebook footer to be in the wrong place. Lesson learned here that if we see issues like this, we should try to see if there are Jupyter config options we can set to improve it! I should've checked that a long time ago :) 

https://github.com/user-attachments/assets/0a625005-48c7-4621-9e4f-d0df850fd06d

# Testing

1. Make sure that you are automatically set onto defer mode by going to Jupyter settings and looking for `window`
2. Open a notebook with some graphs in it and a bunch of cells and then see that in `defer` mode there is no issue, but in `full` mode there is overlapping! This is easiest to recreate on safari for me. 

# Documentation

No. 