### PR TITLE
mito-ai: better stream error handling with v2 lambda

### DIFF
--- a/mito-ai/mito_ai/constants.py
+++ b/mito-ai/mito_ai/constants.py
@@ -24,8 +24,9 @@ AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_MODEL = os.environ.get("AZURE_OPENAI_MODEL")
 
 # Mito AI Base URLs and Endpoint Paths
-MITO_PROD_BASE_URL = "https://7eax4i53f5odkshhlry4gw23by0yvnuv.lambda-url.us-east-1.on.aws/v1"
-MITO_DEV_BASE_URL = "https://g5vwmogjg7gh7aktqezyrvcq6a0hyfnr.lambda-url.us-east-1.on.aws/v1"
+MITO_PROD_BASE_URL = "https://7eax4i53f5odkshhlry4gw23by0yvnuv.lambda-url.us-east-1.on.aws/v2"
+MITO_DEV_BASE_URL = "https://g5vwmogjg7gh7aktqezyrvcq6a0hyfnr.lambda-url.us-east-1.on.aws/v2"
+MITO_LOCAL_BASE_URL = "http://127.0.0.1:8000/v2" # When you are running the mito completion server locally
 
 # Set ACTIVE_BASE_URL manually
 ACTIVE_BASE_URL = MITO_PROD_BASE_URL  # Change to MITO_DEV_BASE_URL for dev


### PR DESCRIPTION
# Description

Resolves: https://github.com/mito-ds/mito/issues/1925

### Original Error
When streaming responses failed, the frontend received a Runtime.StreamError with base64-encoded error body:

```
Lambda-Runtime-Function-Error-Type: Runtime.StreamError
Lambda-Runtime-Function-Error-Body: ZXJyb3lgcmVhZGluZyBhIGJvZHkgZnJvbSBjb25uZWN0aW9u
```

It looked like this: 
<img width="353" height="125" alt="Screenshot 2025-08-26 at 2 46 16 PM" src="https://github.com/user-attachments/assets/898f8818-6b50-4993-992c-9a73958da5e4" />

### Root Cause
The generate_response_stream function was yielding a dictionary object when an error occurred:
```
# Incorrect - yielding dict in stream
yield {"error": f"There was an error accessing the OpenAI API: {str(e)}"}
```

FastAPI's StreamingResponse expects strings/bytes, not dictionaries. When it tried to encode the dict, it failed with: AttributeError: 'dict' object has no attribute 'encode'

### Solution
Updated the error handling to yield a string with an error marker that the frontend can detect and parse:

```
# Correct - yield string with error marker
error_message = f"MITO_ERROR_MARKER:"There was an error accessing the OpenAI API: {str(e)}\"
yield error_message
```

In addition, we update the frontend so that it the `stream_response_from_mito_server` function now detects the MITO_ERROR_MARKER: prefix and handles errors appropriately, preventing the ugly Runtime.StreamError from reaching the frontend. 

Note 1: This does not actually prevent the errors from happening, but instead makes it so that we provide a clear error message when they do happen. I believe that the user most recently ran into this error consistently when the Anthropic API was down, so by showing the new error message to them that suggests moving to a different model provider, we will reduce the pain caused by these errors. 

Note 2: Because we are making a change to how we handle errors and therefore how the frontend should handle errors, we are creating a v2 of the ai-completion-server. This allows all existing users to continue using v1 until they upgrade and get the new frontend code to handle v2 error handling. Nice! This is our first time doing this versioning technique, so give the code an extra careful look + test. 

# Testing

To test: 
1. Review this PR first: https://github.com/mito-ds/ai-completion-server/pull/11
2. If it LGTM, merge it into dev to deploy the new lambda function. 
3. Then, to test this PR, in the constants.py file, update `ACTIVE_BASE_URL = MITO_DEV_BASE_URL` and make sure that completions still work! 

If there is more testing you want to do, you can always run the `ai-completion-server` locally and add raise statements, etc to test different edge cases. You just have to run `PORT=8000 ./run.sh` from the `ai-completion-server/app` folder 

# Documentation

No. 