### PR TITLE
Database Search by Alias

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
@@ -142,7 +142,8 @@ const ChatDropdown: React.FC<ChatDropdownProps> = ({
         } else if (option.type === 'file') {
             return option.file.variable_name.toLowerCase().includes(effectiveFilterText.toLowerCase());
         } else if (option.type === 'db') {
-            return option.variable.value.toLowerCase().includes(effectiveFilterText.toLowerCase());
+            return option.variable.variable_name.toLowerCase().includes(effectiveFilterText.toLowerCase()) ||
+                   option.variable.value.toLowerCase().includes(effectiveFilterText.toLowerCase());
         } else {
             return option.rule.toLowerCase().includes(effectiveFilterText.toLowerCase());
         }


### PR DESCRIPTION
# Description

This fixes a bug where the ChatDropdown was using the underlying database value for filtering. However, the value is made up of `connectionId + " - " + connection.type` where the `connectionId` is a UUID. 

Now filtering is done against the alias or database type. 

# Testing

Add a database with an alias that is unique. It should not contain the database type (sqlite, psotgres, etc). Then search for the alias and the type. 

# Documentation

No, this fix is the expected behavior. 