### PR TITLE
Displaying "Last deployed at" instead of "Created at" in the manage apps pane

### DIFF
--- a/mito-ai/mito_ai/app_manager/handlers.py
+++ b/mito-ai/mito_ai/app_manager/handlers.py
@@ -17,6 +17,7 @@ from mito_ai.app_manager.models import (
 )
 from mito_ai.constants import ACTIVE_STREAMLIT_BASE_URL
 from mito_ai.logger import get_logger
+from mito_ai.app_manager.utils import convert_utc_to_local_time
 import requests
 
 
@@ -101,6 +102,10 @@ class AppManagerHandler(BaseWebSocketHandler):
             manage_apps_response.raise_for_status()
 
             apps_data = manage_apps_response.json()
+
+            for app in apps_data:
+                if 'last_deployed_at' in app:
+                    app['last_deployed_at'] = convert_utc_to_local_time(app['last_deployed_at'])
 
             # Create successful response
             reply = ManageAppReply(

--- a/mito-ai/mito_ai/app_manager/models.py
+++ b/mito-ai/mito_ai/app_manager/models.py
@@ -1,5 +1,4 @@
 # Copyright (c) Saga Inc.
-
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 from dataclasses import dataclass, field
@@ -24,7 +23,7 @@ class App:
     app_name: str
     url: str
     status: str
-    created_at: str
+    last_deployed_at: str
 
 @dataclass(frozen=True)
 class AppManagerError:

--- a/mito-ai/mito_ai/app_manager/utils.py
+++ b/mito-ai/mito_ai/app_manager/utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from datetime import datetime, timezone
+
+def convert_utc_to_local_time(time_str: str) -> str:
+    """Convert UTC time to a user's local time"""
+    try:
+        # Remove the 'Z' suffix and parse the UTC datetime
+        utc_time_str = time_str.rstrip('Z')
+        utc_time = datetime.fromisoformat(utc_time_str)
+
+        # Set timezone to UTC
+        utc_time = utc_time.replace(tzinfo=timezone.utc)
+
+        # Convert to local timezone (system timezone)
+        local_time = utc_time.astimezone()
+
+        # Format as 'MMM DD HH:MM'
+        return local_time.strftime('%m-%d-%Y %H:%M')
+
+    except (ValueError, AttributeError) as e:
+        # Return original string if parsing fails
+        return time_str

--- a/mito-ai/src/Extensions/AppManager/AppsList.tsx
+++ b/mito-ai/src/Extensions/AppManager/AppsList.tsx
@@ -163,8 +163,8 @@ export const AppsList: React.FC<AppsListProps> = ({ appManagerService }) => {
                       {getStatusText(app.status)}
                     </span>
                   </div>
-                  <div className="app-item-created">
-                    Created: {app.createdAt}
+                  <div className="app-item-last-deployed">
+                    Last Deployed at: {app.lastDeployedAt}
                   </div>
                 </div>
               </div>

--- a/mito-ai/src/Extensions/AppManager/ListAppsAPI.ts
+++ b/mito-ai/src/Extensions/AppManager/ListAppsAPI.ts
@@ -17,7 +17,7 @@ export interface AppMetadata {
   name: string;
   url: string;
   status: AppStatus;
-  createdAt: string;
+  lastDeployedAt: string;
 }
 
 export interface GetAppsSuccess {
@@ -75,7 +75,7 @@ export const fetchUserApps = async (
       name: app.app_name,
       url: app.url,
       status: (app.status?.toLowerCase() as AppStatus),
-      createdAt: app.created_at
+      lastDeployedAt: app.last_deployed_at
     }));
 
     return {

--- a/mito-ai/src/tests/AppManager/AppsList.test.tsx
+++ b/mito-ai/src/tests/AppManager/AppsList.test.tsx
@@ -49,19 +49,19 @@ const mockApps: AppMetadata[] = [
     name: 'Test App 1',
     url: 'https://test1.example.com',
     status: 'active',
-    createdAt: '2024-01-01T00:00:00Z'
+    lastDeployedAt: '2024-01-01T00:00:00Z'
   },
   {
     name: 'Test App 2',
     url: 'https://test2.example.com',
     status: 'shut down',
-    createdAt: '2024-01-02T00:00:00Z'
+    lastDeployedAt: '2024-01-02T00:00:00Z'
   },
   {
     name: 'Test App 3',
     url: 'https://test3.example.com',
     status: 'deploying',
-    createdAt: '2024-01-03T00:00:00Z'
+    lastDeployedAt: '2024-01-03T00:00:00Z'
   }
 ];
 
@@ -191,8 +191,8 @@ describe('AppsList Component', () => {
       render(<AppsList appManagerService={mockAppManagerService} />);
       
       await waitFor(() => {
-        expect(screen.getByText('Created: 2024-01-01T00:00:00Z')).toBeInTheDocument();
-        expect(screen.getByText('Created: 2024-01-02T00:00:00Z')).toBeInTheDocument();
+        expect(screen.getByText('Last deployed: 2024-01-01T00:00:00Z')).toBeInTheDocument();
+        expect(screen.getByText('Last deployed: 2024-01-02T00:00:00Z')).toBeInTheDocument();
       });
     });
 
@@ -244,7 +244,7 @@ describe('AppsList Component', () => {
           name: 'Incomplete App',
           url: 'https://incomplete.example.com',
           status: 'active' as const,
-          createdAt: '2024-01-01T00:00:00Z'
+          lastDeployedAt: '2024-01-01T00:00:00Z'
         }
       ];
       
@@ -266,7 +266,7 @@ describe('AppsList Component', () => {
         name: 'Long URL App',
         url: 'https://very-long-subdomain-name-that-might-cause-layout-issues.example.com/very/deep/path/with/many/segments',
         status: 'active' as const,
-        createdAt: '2024-01-01T00:00:00Z'
+        lastDeployedAt: '2024-01-01T00:00:00Z'
       };
       
       mockFetchUserApps.mockResolvedValue({

--- a/mito-ai/src/tests/AppManager/AppsList.test.tsx
+++ b/mito-ai/src/tests/AppManager/AppsList.test.tsx
@@ -49,19 +49,19 @@ const mockApps: AppMetadata[] = [
     name: 'Test App 1',
     url: 'https://test1.example.com',
     status: 'active',
-    lastDeployedAt: '2024-01-01T00:00:00Z'
+    lastDeployedAt: '2024-01-01 00:00'
   },
   {
     name: 'Test App 2',
     url: 'https://test2.example.com',
     status: 'shut down',
-    lastDeployedAt: '2024-01-02T00:00:00Z'
+    lastDeployedAt: '2024-01-02 00:00'
   },
   {
     name: 'Test App 3',
     url: 'https://test3.example.com',
     status: 'deploying',
-    lastDeployedAt: '2024-01-03T00:00:00Z'
+    lastDeployedAt: '2024-01-03 00:00'
   }
 ];
 
@@ -187,12 +187,12 @@ describe('AppsList Component', () => {
       });
     });
 
-    test('should display creation date correctly', async () => {
+    test('should display last deployed date correctly', async () => {
       render(<AppsList appManagerService={mockAppManagerService} />);
       
       await waitFor(() => {
-        expect(screen.getByText('Last deployed: 2024-01-01T00:00:00Z')).toBeInTheDocument();
-        expect(screen.getByText('Last deployed: 2024-01-02T00:00:00Z')).toBeInTheDocument();
+        expect(screen.getByText('Last deployed at: 2024-01-01 00:00')).toBeInTheDocument();
+        expect(screen.getByText('Last deployed at: 2024-01-02 00:00')).toBeInTheDocument();
       });
     });
 
@@ -244,7 +244,7 @@ describe('AppsList Component', () => {
           name: 'Incomplete App',
           url: 'https://incomplete.example.com',
           status: 'active' as const,
-          lastDeployedAt: '2024-01-01T00:00:00Z'
+          lastDeployedAt: '2024-01-01 00:00'
         }
       ];
       
@@ -266,7 +266,7 @@ describe('AppsList Component', () => {
         name: 'Long URL App',
         url: 'https://very-long-subdomain-name-that-might-cause-layout-issues.example.com/very/deep/path/with/many/segments',
         status: 'active' as const,
-        lastDeployedAt: '2024-01-01T00:00:00Z'
+        lastDeployedAt: '2024-01-01 00:00'
       };
       
       mockFetchUserApps.mockResolvedValue({

--- a/mito-ai/src/tests/AppManager/AppsList.test.tsx
+++ b/mito-ai/src/tests/AppManager/AppsList.test.tsx
@@ -191,8 +191,8 @@ describe('AppsList Component', () => {
       render(<AppsList appManagerService={mockAppManagerService} />);
       
       await waitFor(() => {
-        expect(screen.getByText('Last deployed at: 2024-01-01 00:00')).toBeInTheDocument();
-        expect(screen.getByText('Last deployed at: 2024-01-02 00:00')).toBeInTheDocument();
+        expect(screen.getByText('Last Deployed at: 2024-01-01 00:00')).toBeInTheDocument();
+        expect(screen.getByText('Last Deployed at: 2024-01-02 00:00')).toBeInTheDocument();
       });
     });
 

--- a/mito-ai/src/tests/AppManager/ListAppsAPI.test.tsx
+++ b/mito-ai/src/tests/AppManager/ListAppsAPI.test.tsx
@@ -45,13 +45,13 @@ describe('list-apps-api', () => {
               app_name: 'Test App 1',
               url: 'https://test1.example.com',
               status: 'running',
-              created_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01T00:00:00Z'
             },
             {
               app_name: 'Test App 2',
               url: 'https://test2.example.com',
               status: 'stopped',
-              created_at: '2024-01-02T00:00:00Z'
+              last_deployed_at: '2024-02-01T00:00:00Z'
             }
           ]
         };
@@ -71,14 +71,14 @@ describe('list-apps-api', () => {
             name: 'Test App 1',
             url: 'https://test1.example.com',
             status: 'running',
-            createdAt: '2024-01-01T00:00:00Z'
+            lastDeployedAt: '2024-01-01T00:00:00Z'
           });
 
           expect(result.apps[1]).toEqual({
             name: 'Test App 2',
             url: 'https://test2.example.com',
             status: 'stopped',
-            createdAt: '2024-01-02T00:00:00Z'
+            lastDeployedAt: '2024-01-02T00:00:00Z'
           });
         }
 
@@ -119,19 +119,19 @@ describe('list-apps-api', () => {
               app_name: 'Running App',
               url: 'https://running.example.com',
               status: 'RUNNING',
-              created_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01T00:00:00Z'
             },
             {
               app_name: 'Stopped App',
               url: 'https://stopped.example.com',
               status: 'STOPPED',
-              created_at: '2024-01-02T00:00:00Z'
+              last_deployed_at: '2024-01-02T00:00:00Z'
             },
             {
               app_name: 'Deploying App',
               url: 'https://deploying.example.com',
               status: 'DEPLOYING',
-              created_at: '2024-01-03T00:00:00Z'
+              last_deployed_at: '2024-01-03T00:00:00Z'
             }
           ]
         };
@@ -218,13 +218,13 @@ describe('list-apps-api', () => {
               app_name: 'App 1',
               url: 'https://app1.example.com',
               status: 'running',
-              created_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01T00:00:00Z'
             },
             {
               app_name: 'App 2',
               url: 'https://app2.example.com',
               status: 'stopped',
-              created_at: '2024-01-02T00:00:00Z'
+              last_deployed_at: '2024-01-02T00:00:00Z'
             }
           ]
         };

--- a/mito-ai/src/tests/AppManager/ListAppsAPI.test.tsx
+++ b/mito-ai/src/tests/AppManager/ListAppsAPI.test.tsx
@@ -45,13 +45,13 @@ describe('list-apps-api', () => {
               app_name: 'Test App 1',
               url: 'https://test1.example.com',
               status: 'running',
-              last_deployed_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01 00:00'
             },
             {
               app_name: 'Test App 2',
               url: 'https://test2.example.com',
               status: 'stopped',
-              last_deployed_at: '2024-02-01T00:00:00Z'
+              last_deployed_at: '2024-02-01 00:00'
             }
           ]
         };
@@ -71,14 +71,14 @@ describe('list-apps-api', () => {
             name: 'Test App 1',
             url: 'https://test1.example.com',
             status: 'running',
-            lastDeployedAt: '2024-01-01T00:00:00Z'
+            lastDeployedAt: '2024-01-01 00:00'
           });
 
           expect(result.apps[1]).toEqual({
             name: 'Test App 2',
             url: 'https://test2.example.com',
             status: 'stopped',
-            lastDeployedAt: '2024-01-02T00:00:00Z'
+            lastDeployedAt: '2024-02-01 00:00'
           });
         }
 
@@ -119,19 +119,19 @@ describe('list-apps-api', () => {
               app_name: 'Running App',
               url: 'https://running.example.com',
               status: 'RUNNING',
-              last_deployed_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01 00:00'
             },
             {
               app_name: 'Stopped App',
               url: 'https://stopped.example.com',
               status: 'STOPPED',
-              last_deployed_at: '2024-01-02T00:00:00Z'
+              last_deployed_at: '2024-01-02 00:00'
             },
             {
               app_name: 'Deploying App',
               url: 'https://deploying.example.com',
               status: 'DEPLOYING',
-              last_deployed_at: '2024-01-03T00:00:00Z'
+              last_deployed_at: '2024-01-03 00:00'
             }
           ]
         };
@@ -218,13 +218,13 @@ describe('list-apps-api', () => {
               app_name: 'App 1',
               url: 'https://app1.example.com',
               status: 'running',
-              last_deployed_at: '2024-01-01T00:00:00Z'
+              last_deployed_at: '2024-01-01 00:00'
             },
             {
               app_name: 'App 2',
               url: 'https://app2.example.com',
               status: 'stopped',
-              last_deployed_at: '2024-01-02T00:00:00Z'
+              last_deployed_at: '2024-01-02 00:00'
             }
           ]
         };

--- a/mito-ai/src/websockets/appManager/appManagerModels.ts
+++ b/mito-ai/src/websockets/appManager/appManagerModels.ts
@@ -50,7 +50,7 @@ export interface IManageAppReply {
     app_name: string;
     url: string;
     status: string;
-    created_at: string;
+    last_deployed_at: string;
   }>;
 
   /**

--- a/mito-ai/style/AppsList.css
+++ b/mito-ai/style/AppsList.css
@@ -119,7 +119,7 @@
   font-size: 12px;
 }
 
-.app-item-created {
+.app-item-last-deployed {
   color: var(--jp-ui-font-color2);
   font-size: 11px;
 }


### PR DESCRIPTION

# Description

This PR includes changes in info provided to the user about his/her apps. Instead of showing when the app was first created, we now show when it was last deployed.
This PR is supported by another PR in the monorepo as well which is going to modify the status of the app with the last_deployed field.
# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [x] I have tested this on real data that is reasonable and large
- [x] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation
\-