### PR TITLE
Image Upload Size and Type Fix

### DIFF
--- a/mito-ai/mito_ai/completions/completion_handlers/agent_execution_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/agent_execution_handler.py
@@ -38,7 +38,7 @@ class AgentExecutionHandler(CompletionHandler[AgentExecutionMetadata]):
         display_prompt = metadata.input
         
         # Add the prompt to the message history
-        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.base64EncodedUploadedImage)
+        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.additionalContext)
         new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, model, provider, metadata.threadId)

--- a/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
@@ -47,7 +47,7 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
         display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.input}"
         
         # Add the prompt to the message history
-        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.base64EncodedUploadedImage)
+        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.additionalContext)
         new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, model, provider, metadata.threadId)
         
@@ -110,7 +110,7 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
         display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.input}"
         
         # Add the prompt to the message history
-        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.base64EncodedUploadedImage)
+        new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.additionalContext)
         new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, model, provider, metadata.threadId)
         

--- a/mito-ai/mito_ai/completions/completion_handlers/utils.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/utils.py
@@ -120,12 +120,12 @@ def create_ai_optimized_message(
             }
         ]
 
-        if has_uploaded_image:
+        for img in encoded_images:
             message_content.append(
                 {
                     "type": "image_url",
                     "image_url": {
-                        "url": encoded_images[0]
+                        "url": img
                     },
                 }
             )

--- a/mito-ai/mito_ai/completions/completion_handlers/utils.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/utils.py
@@ -77,7 +77,7 @@ async def append_agent_system_message(
 
 
 def extract_and_encode_images_from_additional_context(
-    additional_context: List[Dict[str, str]] | None,
+    additional_context: Optional[List[Dict[str, str]]],
 ) -> List[str]:
     encoded_images = []
 
@@ -98,7 +98,7 @@ def extract_and_encode_images_from_additional_context(
 def create_ai_optimized_message(
     text: str,
     base64EncodedActiveCellOutput: Optional[str] = None,
-    additional_context: List[Dict[str, str]] | None = None,
+    additional_context: Optional[List[Dict[str, str]]] = None,
 ) -> ChatCompletionMessageParam:
 
     message_content: Union[str, List[Dict[str, Any]]]

--- a/mito-ai/mito_ai/completions/models.py
+++ b/mito-ai/mito_ai/completions/models.py
@@ -83,7 +83,6 @@ class ChatMessageMetadata():
     variables: Optional[List[str]] = None
     files: Optional[List[str]] = None
     base64EncodedActiveCellOutput: Optional[str] = None
-    base64EncodedUploadedImage: Optional[str] = None
     index: Optional[int] = None
     stream: bool = False
     additionalContext: Optional[List[Dict[str, str]]] = None
@@ -97,7 +96,6 @@ class AgentExecutionMetadata():
     aiOptimizedCells: List[AIOptimizedCell]
     isChromeBrowser: bool
     base64EncodedActiveCellOutput: Optional[str] = None
-    base64EncodedUploadedImage: Optional[str] = None
     variables: Optional[List[str]] = None
     files: Optional[List[str]] = None
     index: Optional[int] = None

--- a/mito-ai/mito_ai/completions/prompt_builders/utils.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/utils.py
@@ -38,7 +38,7 @@ def get_selected_context_str(additional_context: Optional[List[Dict[str, str]]])
     selected_variables = [context["value"] for context in additional_context if context.get("type") == "variable"]
     selected_files = [context["value"] for context in additional_context if context.get("type") == "file"]
     selected_db_connections = [context["value"] for context in additional_context if context.get("type") == "db"]
-    selected_images = [context["value"] for context in additional_context if context.get("type") == "img"]
+    selected_images = [context["value"] for context in additional_context if context.get("type", "").startswith("image/")]
 
     # STEP 2: Create a list of strings (instructions) for each context type
     context_parts = []
@@ -68,5 +68,4 @@ def get_selected_context_str(additional_context: Optional[List[Dict[str, str]]])
         )
 
     # STEP 3: Combine into a single string
-
     return "\n\n".join(context_parts)

--- a/mito-ai/mito_ai/file_uploads/handlers.py
+++ b/mito-ai/mito_ai/file_uploads/handlers.py
@@ -35,13 +35,9 @@ def _check_image_size_limit(file_data: bytes, filename: str) -> None:
         return
 
     file_size_mb = len(file_data) / (1024 * 1024)  # Convert bytes to MB
-    truncated_filename = filename[0:5]
-    file_extension = filename.split(".")[-1]
 
     if file_size_mb > MAX_IMAGE_SIZE_MB:
-        raise ValueError(
-            f"{truncated_filename}[...].{file_extension} exceeds the 3MB limit for image uploads."
-        )
+        raise ValueError("Image exceeded 3MB limit.")
 
 
 class FileUploadHandler(APIHandler):
@@ -85,7 +81,7 @@ class FileUploadHandler(APIHandler):
             self.finish()
 
         except Exception as e:
-            self._handle_error(f"Failed to save file: {str(e)}")
+            self._handle_error(str(e))
 
     def _validate_file_upload(self) -> bool:
         """Validate that a file was uploaded in the request."""

--- a/mito-ai/mito_ai/file_uploads/handlers.py
+++ b/mito-ai/mito_ai/file_uploads/handlers.py
@@ -38,7 +38,7 @@ def _check_image_size_limit(file_data: bytes, filename: str) -> None:
 
         if file_size_mb > MAX_IMAGE_SIZE_MB:
             raise ValueError(
-                f"{truncated_filename}[...].{file_extension} exceeds the 3MB limit."
+                f"{truncated_filename}[...].{file_extension} exceeds the 3MB limit for image uploads."
             )
 
 

--- a/mito-ai/mito_ai/file_uploads/handlers.py
+++ b/mito-ai/mito_ai/file_uploads/handlers.py
@@ -37,7 +37,7 @@ def _check_image_size_limit(file_data: bytes, filename: str) -> None:
     file_size_mb = len(file_data) / (1024 * 1024)  # Convert bytes to MB
 
     if file_size_mb > MAX_IMAGE_SIZE_MB:
-        raise ValueError("Image exceeded 3MB limit.")
+        raise ValueError(f"Image exceeded {MAX_IMAGE_SIZE_MB}MB limit.")
 
 
 class FileUploadHandler(APIHandler):

--- a/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
+++ b/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
@@ -1,7 +1,24 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import os
+import tempfile
+from contextlib import contextmanager
 from mito_ai.completions.completion_handlers.utils import create_ai_optimized_message
+
+
+@contextmanager
+def temporary_image_file(suffix=".png", content=b"fake_image_data"):
+    """Context manager that creates a temporary image file for testing."""
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_file.write(content)
+        temp_file_path = temp_file.name
+
+    try:
+        yield temp_file_path
+    finally:
+        # Clean up the temporary file
+        os.unlink(temp_file_path)
 
 
 def test_text_only_message():
@@ -14,14 +31,16 @@ def test_text_only_message():
 
 def test_message_with_uploaded_image():
     """Test scenario where the user uploads an image"""
-    result = create_ai_optimized_message(
-        text="Analyze this", additional_context=[{"type": "image/png", "value": "image_data"}]
-    )
+    with temporary_image_file() as temp_file_path:
+        result = create_ai_optimized_message(
+            text="Analyze this",
+            additional_context=[{"type": "image/png", "value": temp_file_path}],
+        )
 
-    assert result["role"] == "user"
-    assert isinstance(result["content"], list)
-    assert result["content"][0]["type"] == "text"
-    assert result["content"][1]["type"] == "image_url"
+        assert result["role"] == "user"
+        assert isinstance(result["content"], list)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "image_url"
 
 
 def test_message_with_active_cell_output():
@@ -38,14 +57,15 @@ def test_message_with_active_cell_output():
 
 def test_message_with_uploaded_image_and_active_cell_output():
     """Test scenario where the user uploads an image and the active cell has an output"""
-    result = create_ai_optimized_message(
-        text="Analyze this",
-        additional_context=[{"type": "image/png", "value": "image_data"}],
-        base64EncodedActiveCellOutput="cell_output_data",
-    )
+    with temporary_image_file() as temp_file_path:
+        result = create_ai_optimized_message(
+            text="Analyze this",
+            additional_context=[{"type": "image/png", "value": temp_file_path}],
+            base64EncodedActiveCellOutput="cell_output_data",
+        )
 
-    assert result["role"] == "user"
-    assert isinstance(result["content"], list)
-    assert result["content"][0]["type"] == "text"
-    assert result["content"][1]["type"] == "image_url"
-    assert result["content"][2]["type"] == "image_url"
+        assert result["role"] == "user"
+        assert isinstance(result["content"], list)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "image_url"
+        assert result["content"][2]["type"] == "image_url"

--- a/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
+++ b/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
@@ -47,6 +47,31 @@ def test_message_with_uploaded_image():
         assert result["content"][1]["type"] == "image_url"
 
 
+def test_message_with_multiple_uploaded_images():
+    """Test scenario where the user uploads multiple images"""
+    with temporary_image_file(suffix=".png", content=b"image1_data") as temp_file1:
+        with temporary_image_file(suffix=".jpg", content=b"image2_data") as temp_file2:
+            result = create_ai_optimized_message(
+                text="Analyze these images",
+                additional_context=[
+                    {"type": "image/png", "value": temp_file1},
+                    {"type": "image/jpeg", "value": temp_file2},
+                ],
+            )
+
+            assert result["role"] == "user"
+            assert isinstance(result["content"], list)
+            assert len(result["content"]) == 3  # text + 2 images
+            assert result["content"][0]["type"] == "text"
+            assert result["content"][0]["text"] == "Analyze these images"
+            assert result["content"][1]["type"] == "image_url"
+            assert result["content"][2]["type"] == "image_url"
+            
+            # Verify the image URLs are properly formatted
+            assert result["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+            assert result["content"][2]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
 def test_message_with_active_cell_output():
     """Test scenario where the active cell has an output"""
     result = create_ai_optimized_message(

--- a/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
+++ b/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
@@ -15,7 +15,7 @@ def test_text_only_message():
 def test_message_with_uploaded_image():
     """Test scenario where the user uploads an image"""
     result = create_ai_optimized_message(
-        text="Analyze this", base64EncodedUploadedImage="image_data"
+        text="Analyze this", additional_context=[{"type": "image/png", "value": "image_data"}]
     )
 
     assert result["role"] == "user"
@@ -40,7 +40,7 @@ def test_message_with_uploaded_image_and_active_cell_output():
     """Test scenario where the user uploads an image and the active cell has an output"""
     result = create_ai_optimized_message(
         text="Analyze this",
-        base64EncodedUploadedImage="image_data",
+        additional_context=[{"type": "image/png", "value": "image_data"}],
         base64EncodedActiveCellOutput="cell_output_data",
     )
 

--- a/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
+++ b/mito-ai/mito_ai/tests/completions/completion_handlers_utils_test.py
@@ -1,10 +1,14 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import base64
 import os
 import tempfile
 from contextlib import contextmanager
-from mito_ai.completions.completion_handlers.utils import create_ai_optimized_message
+from mito_ai.completions.completion_handlers.utils import (
+    create_ai_optimized_message,
+    extract_and_encode_images_from_additional_context,
+)
 
 
 @contextmanager
@@ -69,3 +73,93 @@ def test_message_with_uploaded_image_and_active_cell_output():
         assert result["content"][0]["type"] == "text"
         assert result["content"][1]["type"] == "image_url"
         assert result["content"][2]["type"] == "image_url"
+
+
+def test_extract_and_encode_images_from_additional_context_valid_image():
+    """Test extracting and encoding a valid image file"""
+    with temporary_image_file() as temp_file_path:
+        additional_context = [{"type": "image/png", "value": temp_file_path}]
+
+        encoded_images = extract_and_encode_images_from_additional_context(
+            additional_context
+        )
+
+        assert len(encoded_images) == 1
+        assert encoded_images[0].startswith("data:image/png;base64,")
+        # Verify it's valid base64 by checking it can be decoded
+        base64_data = encoded_images[0].split(",")[1]
+        decoded_data = base64.b64decode(base64_data)
+        assert decoded_data == b"fake_image_data"
+
+
+def test_extract_and_encode_images_from_additional_context_multiple_images():
+    """Test extracting and encoding multiple image files"""
+    with temporary_image_file(suffix=".png", content=b"image1_data") as temp_file1:
+        with temporary_image_file(suffix=".jpg", content=b"image2_data") as temp_file2:
+            additional_context = [
+                {"type": "image/png", "value": temp_file1},
+                {"type": "image/jpeg", "value": temp_file2},
+            ]
+
+            encoded_images = extract_and_encode_images_from_additional_context(
+                additional_context
+            )
+
+            assert len(encoded_images) == 2
+            assert encoded_images[0].startswith("data:image/png;base64,")
+            assert encoded_images[1].startswith("data:image/jpeg;base64,")
+
+
+def test_extract_and_encode_images_from_additional_context_invalid_file():
+    """Test handling of invalid/non-existent image files"""
+    additional_context = [{"type": "image/png", "value": "non_existent_file.png"}]
+
+    encoded_images = extract_and_encode_images_from_additional_context(
+        additional_context
+    )
+
+    assert len(encoded_images) == 0
+
+
+def test_extract_and_encode_images_from_additional_context_non_image_types():
+    """Test that non-image types are ignored"""
+    with temporary_image_file(suffix=".txt", content=b"text_data") as temp_file:
+        additional_context = [
+            {"type": "text/plain", "value": temp_file},
+            {"type": "application/pdf", "value": "document.pdf"},
+        ]
+
+        encoded_images = extract_and_encode_images_from_additional_context(
+            additional_context
+        )
+
+        assert len(encoded_images) == 0
+
+
+def test_extract_and_encode_images_from_additional_context_mixed_types():
+    """Test handling of mixed image and non-image types"""
+    with temporary_image_file() as temp_image_file:
+        additional_context = [
+            {"type": "image/png", "value": temp_image_file},
+            {"type": "text/plain", "value": "document.txt"},
+            {"type": "image/jpeg", "value": "non_existent.jpg"},
+        ]
+
+        encoded_images = extract_and_encode_images_from_additional_context(
+            additional_context
+        )
+
+        # Should only have the valid PNG image
+        assert len(encoded_images) == 1
+        assert encoded_images[0].startswith("data:image/png;base64,")
+
+
+def test_extract_and_encode_images_from_additional_context_empty():
+    """Test handling of empty or None additional_context"""
+    # Test with None
+    encoded_images = extract_and_encode_images_from_additional_context(None)
+    assert len(encoded_images) == 0
+
+    # Test with empty list
+    encoded_images = extract_and_encode_images_from_additional_context([])
+    assert len(encoded_images) == 0

--- a/mito-ai/mito_ai/tests/file_uploads/test_handlers.py
+++ b/mito-ai/mito_ai/tests/file_uploads/test_handlers.py
@@ -265,3 +265,19 @@ def test_save_chunk(handler, temp_dir):
 
         # Clean up
         del handler._temp_dirs[filename]
+
+
+def test_image_size_limit_exceeded(handler, temp_dir):
+    """Test that image uploads exceeding 3MB are rejected."""
+    filename = "large_image.jpg"
+    # Create 5MB of data (5 * 1024 * 1024 bytes)
+    file_data = b"x" * (5 * 1024 * 1024)
+    notebook_dir = temp_dir
+
+    # The _handle_regular_upload should raise a ValueError for oversized images
+    with pytest.raises(ValueError) as exc_info:
+        handler._handle_regular_upload(filename, file_data, notebook_dir)
+    
+    # Verify the error message mentions the size limit
+    assert "exceeds the 3MB limit" in str(exc_info.value)
+    assert "large[...].jpg" in str(exc_info.value)

--- a/mito-ai/mito_ai/tests/file_uploads/test_handlers.py
+++ b/mito-ai/mito_ai/tests/file_uploads/test_handlers.py
@@ -279,5 +279,4 @@ def test_image_size_limit_exceeded(handler, temp_dir):
         handler._handle_regular_upload(filename, file_data, notebook_dir)
     
     # Verify the error message mentions the size limit
-    assert "exceeds the 3MB limit" in str(exc_info.value)
-    assert "large[...].jpg" in str(exc_info.value)
+    assert "exceeded 3MB limit" in str(exc_info.value)

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -70,6 +70,9 @@ const ChatInput: React.FC<ChatInputProps> = ({
         let uploadType: string;
 
         if (file.type.startsWith('image/')) {
+            // If the file is an image, we want to preserve the file type.
+            // The type is used to display the image icon in the SelectedContextContainer,
+            // and is used to encode the image on the backend.
             uploadType = file.type;
         } else {
             uploadType = 'file';

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -67,31 +67,22 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const [isDropdownFromButton, setIsDropdownFromButton] = useState(false);
 
     const handleFileUpload = (file: File): void => {
+        let uploadType: string;
+
         if (file.type.startsWith('image/')) {
-            const reader = new FileReader();
-            reader.onload = () => {
-                const base64String = reader.result as string;
-                const base64Data = base64String.split(',')[1]; // Remove data URL prefix
-                // Add the uploaded file to the additional context
-                setAdditionalContext(prev => [
-                    ...prev, {
-                        type: file.type || 'image',
-                        value: base64Data || '',
-                        display: file.name
-                    }
-                ]);
-            };
-            reader.readAsDataURL(file);
+            uploadType = file.type;
         } else {
-            // Add the uploaded file to the additional context
-            setAdditionalContext(prev => [
-                ...prev, {
-                    type: 'file',
-                    value: file.name,
-                    display: file.name
-                }
-            ]);
+            uploadType = 'file';
         }
+
+        // Add the uploaded file to the additional context
+        setAdditionalContext(prev => [
+            ...prev, {
+                type: uploadType,
+                value: file.name,
+                display: file.name
+            }
+        ]);
     };
 
     // Debounce the active cell ID change to avoid multiple rerenders. 
@@ -256,18 +247,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
                 result.push({
                     type: contextItem.type,
                     value: contextItem.value
-                });
-            } else if (contextItem.type.startsWith('image/')) {
-                // If the user uploaded an image, we:
-                // 1. Keep the original context item. This is the base64 encoded image 
-                //    that will be processed in ChatTaskpane.tsx.
-                // 2. Add a second item to the additionalContext array, which will
-                //    have the image's filename, and be used in the prompt.
-                result.push(contextItem);
-                const fileName = contextItem.display || contextItem.value.split('/').pop() || 'image';
-                result.push({
-                    type: 'img',
-                    value: fileName
                 });
             } else {
                 result.push(contextItem);

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -66,7 +66,7 @@ import { scrollToDiv } from '../../utils/scroll';
 import { getCodeBlockFromMessage, removeMarkdownCodeFormatting } from '../../utils/strings';
 import { OperatingSystem } from '../../utils/user';
 import { waitForNotebookReady } from '../../utils/waitForNotebookReady';
-import { extractImagesFromContext, getBase64EncodedCellOutput } from './utils';
+import { getBase64EncodedCellOutput } from './utils';
 
 // Internal imports - Websockets
 import type { CompletionWebsocketClient } from '../../websockets/completions/CompletionsWebsocketClient';
@@ -614,9 +614,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
             agentExecutionMetadata.index = messageIndex
         }
 
-        // Extract images from additionalContext and update agentExecutionMetadata
-        additionalContext = extractImagesFromContext(additionalContext, agentExecutionMetadata)
-
         agentExecutionMetadata.base64EncodedActiveCellOutput = await getBase64EncodedCellOutput(notebookTracker, sendCellIDOutput)
 
         setChatHistoryManager(newChatHistoryManager)
@@ -672,9 +669,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (activeCellOutput !== undefined) {
             chatMessageMetadata.base64EncodedActiveCellOutput = activeCellOutput
         }
-
-        // Extract images from additionalContext and update chatMessageMetadata
-        additionalContext = extractImagesFromContext(additionalContext, chatMessageMetadata)
 
         const completionRequest: IChatCompletionRequest = {
             type: 'chat',

--- a/mito-ai/src/Extensions/AiChat/utils.tsx
+++ b/mito-ai/src/Extensions/AiChat/utils.tsx
@@ -32,19 +32,3 @@ export const getBase64EncodedCellOutput = async (notebookTracker: INotebookTrack
     
     return undefined
 }
-
-export const extractImagesFromContext = (
-    additionalContext: Array<{ type: string, value: string }> | undefined,
-    metadata: { base64EncodedUploadedImage?: string }
-): Array<{ type: string, value: string }> | undefined => {
-    // Move any (base64 encoded) images from additionalContext into metadata.
-    // The metadata is used on the backend to "attach" the image to the prompt;
-    // plus the base64 encoded image is too big to include directly in the prompt.
-    additionalContext?.map((context) => {
-        if (context.type.startsWith('image/')) {
-            metadata.base64EncodedUploadedImage = context.value
-        }
-    })
-    // Remove images from the additionalContext array and return the filtered result.
-    return additionalContext?.filter(c => !c.type.startsWith('image/'))
-}

--- a/mito-ai/src/components/AttachFileButton.tsx
+++ b/mito-ai/src/components/AttachFileButton.tsx
@@ -197,7 +197,6 @@ const AttachFileButton: React.FC<AttachFileButtonProps> = ({ onFileUploaded, not
                 autoClose: 5 * 1000 // 5 seconds
             });
             console.error('Upload failed:', resp.error.message);
-            throw new Error(resp.error.message);
         } else if (resp.data) {
             console.log('File uploaded successfully:', resp.data);
 

--- a/mito-ai/src/websockets/completions/CompletionModels.ts
+++ b/mito-ai/src/websockets/completions/CompletionModels.ts
@@ -75,7 +75,6 @@ export interface IChatMessageMetadata {
   activeCellCode: string;
   activeCellId: string;
   base64EncodedActiveCellOutput?: string;
-  base64EncodedUploadedImage?: string;
   input: string;
   index?: number;
   threadId: string;
@@ -86,7 +85,6 @@ export interface IAgentExecutionMetadata {
   promptType: 'agent:execution'
   aiOptimizedCells: AIOptimizedCell[]
   base64EncodedActiveCellOutput?: string;
-  base64EncodedUploadedImage?: string;
   variables?: Variable[];
   files?: File[];
   input: string;


### PR DESCRIPTION
# Description

This PR fixes two bugs:

1. Large images break the websocket connection - When a large image is uploaded (>1mb), the Base64 encoding is so large that sending it all in one request to the backend will cause a websocket disconnect. To fix this, we are encoding the image on the backend. 
2. File types hardcoded - When we are creating the final prompt message on the backend, we were prefixing everything with "image/png." For OpenAI requests, this was not issue. However, for Claude, you need to use the correct type.  

Also, because we've drastically simplified the encoding logic, I was able to add support for multiple image uploads. 

# Testing

Upload a few image, use different providers. Make sure your images are large, ideally >5mb. 

# Documentation

N/A, bug fix. 