### PR TITLE
Fix/validate agent response

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -10,6 +10,7 @@ import { getActiveCellCode, getActiveCellID, getActiveCellIDInNotebookPanel, get
 import { AgentResponse, IAgentExecutionMetadata, IAgentSmartDebugMetadata, IChatMessageMetadata, ICodeExplainMetadata, ISmartDebugMetadata } from "../../websockets/completions/CompletionModels";
 import { addMarkdownCodeFormatting } from "../../utils/strings";
 import { isChromeBasedBrowser } from "../../utils/user";
+import { validateAndCorrectAgentResponse } from "./validationUtils";
 
 export type PromptType = 
     'chat' | 
@@ -206,11 +207,6 @@ export class ChatHistoryManager {
         return agentExecutionMetadata
     }
 
-    dropMessagesStartingAtIndex(index: number): void {
-        this.displayOptimizedChatHistory.splice(index)
-    }
-
-
     addSmartDebugMessage(activeThreadId: string, errorMessage: string): ISmartDebugMetadata {
     
         const activeCellID = getActiveCellID(this.notebookTracker) || ''
@@ -351,6 +347,7 @@ export class ChatHistoryManager {
     }
 
     addAIMessageFromAgentResponse(agentResponse: AgentResponse): void {
+        agentResponse = validateAndCorrectAgentResponse(agentResponse)
         let content = agentResponse.message
         if (agentResponse.type === 'cell_update') {
             // For cell_update messages, we want to display the code the agent wrote along with 
@@ -402,6 +399,10 @@ export class ChatHistoryManager {
         }
 
         return this.displayOptimizedChatHistory[lastAIMessagesIndex]
+    }
+
+    dropMessagesStartingAtIndex(index: number): void {
+        this.displayOptimizedChatHistory.splice(index)
     }
 }
 

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -76,6 +76,12 @@ export class ChatHistoryManager {
     private initializeAssumptionsFromHistory(): void {
         this._allAssumptions.clear();
         this.displayOptimizedChatHistory.forEach(item => {
+            // Validate the agent response if it exists
+            if (item.agentResponse !== undefined) {
+                item.agentResponse = validateAndCorrectAgentResponse(item.agentResponse)
+            }
+
+            // Process the assumptions
             if (item.agentResponse?.analysis_assumptions) {
                 item.agentResponse.analysis_assumptions.forEach(assumption => {
                     this._allAssumptions.add(assumption);

--- a/mito-ai/src/Extensions/AiChat/validationUtils.ts
+++ b/mito-ai/src/Extensions/AiChat/validationUtils.ts
@@ -1,0 +1,66 @@
+
+
+
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { AgentResponse } from '../../websockets/completions/CompletionModels';
+
+/**
+ * Validates and corrects an AgentResponse to ensure it adheres to the expected format.
+ * Handles common mistakes like string instead of array, missing fields, etc.
+ */
+export function validateAndCorrectAgentResponse(agentResponse: AgentResponse): AgentResponse {
+    // Create a copy to avoid mutating the original
+    const correctedResponse: AgentResponse = { ...agentResponse };
+    
+    // Ensure type is valid. Default to finished_task if not valid.
+    const validTypes = ['cell_update', 'get_cell_output', 'run_all_cells', 'finished_task'];
+    correctedResponse.type = (correctedResponse.type && validTypes.includes(correctedResponse.type)) 
+        ? correctedResponse.type 
+        : 'finished_task';
+    
+    // Ensure message is a string. Default to empty string if not valid.
+    if (!correctedResponse.message || typeof correctedResponse.message !== 'string') {
+        correctedResponse.message = '';
+    }
+    
+    // Correct get_cell_output_cell_id if present
+    const getCellOutputCellIdType = typeof correctedResponse.get_cell_output_cell_id;
+    correctedResponse.get_cell_output_cell_id = getCellOutputCellIdType === 'string' ? correctedResponse.get_cell_output_cell_id : undefined;
+    
+    // Correct next_steps - handle string to array conversion
+    if (correctedResponse.next_steps !== undefined && correctedResponse.next_steps !== null) {
+        correctedResponse.next_steps = correctStringArray(correctedResponse.next_steps);
+    }
+    
+    // Correct analysis_assumptions - handle string to array conversion
+    if (correctedResponse.analysis_assumptions !== undefined && correctedResponse.analysis_assumptions !== null) {
+        correctedResponse.analysis_assumptions = correctStringArray(correctedResponse.analysis_assumptions);
+    }
+
+    // For now we don't validate the cell_update object itself, as this is more complex and has 
+    // not caused issues thus far.
+    
+    return correctedResponse;
+}
+
+
+/**
+ * Corrects a value to be a string array, handling various input formats.
+ * Handles cases where the AI returns a string instead of an array of strings.
+ */
+function correctStringArray(value: any): string[] | null {
+    // If it's already a valid array of strings, return it
+    if (Array.isArray(value)) {
+        return value 
+    }
+
+    if (typeof value === 'string') {
+        return [value];
+    }
+    
+    return null;
+}

--- a/mito-ai/src/tests/AiChat/validationUtils.test.tsx
+++ b/mito-ai/src/tests/AiChat/validationUtils.test.tsx
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { validateAndCorrectAgentResponse } from '../../Extensions/AiChat/validationUtils';
+import { AgentResponse } from '../../websockets/completions/CompletionModels';
+
+describe('validateAndCorrectAgentResponse', () => {
+    describe('type validation', () => {
+        it('should preserve valid types', () => {
+            const validTypes = ['cell_update', 'get_cell_output', 'run_all_cells', 'finished_task'];
+            
+            validTypes.forEach(type => {
+                const response: AgentResponse = {
+                    type: type as any,
+                    message: 'test message'
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.type).toBe(type);
+            });
+        });
+
+        it('should default to finished_task for invalid types', () => {
+            const invalidTypes = ['invalid_type', '', null, undefined, 123, {}];
+            
+            invalidTypes.forEach(invalidType => {
+                const response: AgentResponse = {
+                    type: invalidType as any,
+                    message: 'test message'
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.type).toBe('finished_task');
+            });
+        });
+    });
+
+    describe('message validation', () => {
+        it('should preserve valid string messages', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'This is a valid message'
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.message).toBe('This is a valid message');
+        });
+
+        it('should default to empty string for invalid messages', () => {
+            const invalidMessages = [null, undefined, 123, {}, []];
+            
+            invalidMessages.forEach(invalidMessage => {
+                const response: AgentResponse = {
+                    type: 'finished_task',
+                    message: invalidMessage as any
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.message).toBe('');
+            });
+        });
+    });
+
+    describe('get_cell_output_cell_id validation', () => {
+        it('should preserve valid string cell_id', () => {
+            const response: AgentResponse = {
+                type: 'get_cell_output',
+                message: 'test',
+                get_cell_output_cell_id: 'cell-123'
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.get_cell_output_cell_id).toBe('cell-123');
+        });
+
+        it('should preserve null and undefined cell_id', () => {
+            const responseWithNull: AgentResponse = {
+                type: 'get_cell_output',
+                message: 'test',
+                get_cell_output_cell_id: null
+            };
+            
+            const responseWithUndefined: AgentResponse = {
+                type: 'get_cell_output',
+                message: 'test',
+                get_cell_output_cell_id: undefined
+            };
+            
+            expect(validateAndCorrectAgentResponse(responseWithNull).get_cell_output_cell_id).toBe(undefined);
+            expect(validateAndCorrectAgentResponse(responseWithUndefined).get_cell_output_cell_id).toBe(undefined);
+        });
+
+        it('should default to undefined for invalid cell_id types', () => {
+            const invalidCellIds = [123, {}, [], true];
+            
+            invalidCellIds.forEach(invalidCellId => {
+                const response: AgentResponse = {
+                    type: 'get_cell_output',
+                    message: 'test',
+                    get_cell_output_cell_id: invalidCellId as any
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.get_cell_output_cell_id).toBe(undefined);
+            });
+        });
+    });
+
+    describe('next_steps validation', () => {
+        it('should preserve valid string arrays', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                next_steps: ['step1', 'step2', 'step3']
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.next_steps).toEqual(['step1', 'step2', 'step3']);
+        });
+
+        it('should convert string to array', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                next_steps: 'single step' as any
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.next_steps).toEqual(['single step']);
+        });
+
+        it('should preserve null and undefined next_steps', () => {
+            const responseWithNull: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                next_steps: null
+            };
+            
+            const responseWithUndefined: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                next_steps: undefined
+            };
+            
+            expect(validateAndCorrectAgentResponse(responseWithNull).next_steps).toBe(null);
+            expect(validateAndCorrectAgentResponse(responseWithUndefined).next_steps).toBe(undefined);
+        });
+
+        it('should return null for invalid next_steps types', () => {
+            const invalidNextSteps = [123, {}, true];
+            
+            invalidNextSteps.forEach(invalidNextStep => {
+                const response: AgentResponse = {
+                    type: 'finished_task',
+                    message: 'test',
+                    next_steps: invalidNextStep as any
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.next_steps).toBe(null);
+            });
+        });
+    });
+
+    describe('analysis_assumptions validation', () => {
+        it('should preserve valid string arrays', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                analysis_assumptions: ['assumption1', 'assumption2']
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.analysis_assumptions).toEqual(['assumption1', 'assumption2']);
+        });
+
+        it('should convert string to array', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                analysis_assumptions: 'single assumption' as any
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.analysis_assumptions).toEqual(['single assumption']);
+        });
+
+        it('should preserve null and undefined analysis_assumptions', () => {
+            const responseWithNull: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                analysis_assumptions: null
+            };
+            
+            const responseWithUndefined: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                analysis_assumptions: undefined
+            };
+            
+            expect(validateAndCorrectAgentResponse(responseWithNull).analysis_assumptions).toBe(null);
+            expect(validateAndCorrectAgentResponse(responseWithUndefined).analysis_assumptions).toBe(undefined);
+        });
+
+        it('should return null for invalid analysis_assumptions types', () => {
+            const invalidAssumptions = [123, {}, true];
+            
+            invalidAssumptions.forEach(invalidAssumption => {
+                const response: AgentResponse = {
+                    type: 'finished_task',
+                    message: 'test',
+                    analysis_assumptions: invalidAssumption as any
+                };
+                
+                const result = validateAndCorrectAgentResponse(response);
+                expect(result.analysis_assumptions).toBe(null);
+            });
+        });
+    });
+
+    describe('cell_update validation', () => {
+        it('should preserve valid cell_update objects', () => {
+            const response: AgentResponse = {
+                type: 'cell_update',
+                message: 'test',
+                cell_update: {
+                    type: 'modification',
+                    id: 'cell-123',
+                    code: 'print("hello")',
+                    code_summary: 'Print hello',
+                    cell_type: 'code'
+                }
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.cell_update).toEqual(response.cell_update);
+        });
+
+        it('should preserve null and undefined cell_update', () => {
+            const responseWithNull: AgentResponse = {
+                type: 'cell_update',
+                message: 'test',
+                cell_update: null
+            };
+            
+            const responseWithUndefined: AgentResponse = {
+                type: 'cell_update',
+                message: 'test',
+                cell_update: undefined
+            };
+            
+            expect(validateAndCorrectAgentResponse(responseWithNull).cell_update).toBe(null);
+            expect(validateAndCorrectAgentResponse(responseWithUndefined).cell_update).toBe(undefined);
+        });
+    });
+
+    describe('immutability', () => {
+        it('should not mutate the original response', () => {
+            const originalResponse: AgentResponse = {
+                type: 'invalid_type' as any,
+                message: 'test',
+                next_steps: 'single step' as any
+            };
+            
+            const originalCopy = { ...originalResponse };
+            const result = validateAndCorrectAgentResponse(originalResponse);
+            
+            // Original should be unchanged
+            expect(originalResponse).toEqual(originalCopy);
+            
+            // Result should be corrected
+            expect(result.type).toBe('finished_task');
+            expect(result.next_steps).toEqual(['single step']);
+        });
+    });
+
+    describe('complex scenarios', () => {
+        it('should handle completely malformed response', () => {
+            const malformedResponse: AgentResponse = {
+                type: 'invalid' as any,
+                message: null as any,
+                get_cell_output_cell_id: 123 as any,
+                next_steps: 'step1,step2' as any,
+                analysis_assumptions: 'assumption1' as any,
+                cell_update: null
+            };
+            
+            const result = validateAndCorrectAgentResponse(malformedResponse);
+            
+            expect(result.type).toBe('finished_task');
+            expect(result.message).toBe('');
+            expect(result.get_cell_output_cell_id).toBe(undefined);
+            expect(result.next_steps).toEqual(['step1,step2']);
+            expect(result.analysis_assumptions).toEqual(['assumption1']);
+            expect(result.cell_update).toBe(null);
+        });
+
+        it('should handle empty arrays correctly', () => {
+            const response: AgentResponse = {
+                type: 'finished_task',
+                message: 'test',
+                next_steps: [],
+                analysis_assumptions: []
+            };
+            
+            const result = validateAndCorrectAgentResponse(response);
+            expect(result.next_steps).toEqual([]);
+            expect(result.analysis_assumptions).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
# Description

AIs are smart, but they don't always follow our instructions. For example, if agent is only returning one `analysis_assumptions`, it might accidentally return a string instead of a list containing one string. This results in errors. 

This PR introduces a validation step so we can ensure that the AgentResponse adheres to our type system before doing anything with the agent response. That way we can do all of this error handling in one place instead of chasing it across the entire codebase. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.