### PR TITLE
Context Menu Limits

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatDropdown.tsx
@@ -44,21 +44,29 @@ export type ChatDropdownOption =
     | ChatDropdownFileOption
     | ChatDropdownDatabaseOption;
 
-const limitOptionsByType = (options: ChatDropdownOption[], maxPerType: number): ChatDropdownOption[] => {
+const priortizeByType = (options: ChatDropdownOption[], maxPerType: number): ChatDropdownOption[] => {
+    /* 
+    Makes sure that some of each type are displayed at the top of the dropdown so 
+    users can easily see what types of options are available to them.
+    */
     const typeCounts: Record<string, number> = {};
-    const result: ChatDropdownOption[] = [];
+    const prioritizedOptions: ChatDropdownOption[] = [];
+    const extraOptions: ChatDropdownOption[] = [];
 
     for (const option of options) {
         const type = option.type;
         const currentCount = typeCounts[type] || 0;
 
         if (currentCount < maxPerType) {
-            result.push(option);
+            prioritizedOptions.push(option);
             typeCounts[type] = currentCount + 1;
+        } else {
+            extraOptions.push(option);
         }
     }
 
-    return result;
+    // Return prioritized options first, then extras at the bottom
+    return [...prioritizedOptions, ...extraOptions];
 };
 
 const ChatDropdown: React.FC<ChatDropdownProps> = ({
@@ -167,7 +175,7 @@ const ChatDropdown: React.FC<ChatDropdownProps> = ({
     // If user is searching (has filter text), show all matches
     // Otherwise, show only 3 of each type by default
     if (effectiveFilterText.trim() === '') { 
-        searchFilteredOptions = limitOptionsByType(searchFilteredOptions, 3);
+        searchFilteredOptions = priortizeByType(searchFilteredOptions, 3);
     }
 
     useEffect(() => {

--- a/mito-ai/src/tests/AiChat/ChatDropdown.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatDropdown.test.tsx
@@ -85,7 +85,7 @@ describe('ChatDropdown Component', () => {
     });
 
     describe('Rendering', () => {
-        it('renders the dropdown with all options', async () => {
+        it('renders the dropdown with limited options by default (3 per type)', async () => {
             // Render with default props
             renderChatDropdown({ onSelect: onSelectMock });
 
@@ -100,10 +100,10 @@ describe('ChatDropdown Component', () => {
 
             // Verify all list items are rendered (not counting spans or other elements with similar test IDs)
             const options = screen.getAllByTestId(/^chat-dropdown-item-(?!type|name)/);
-            // Expect 5 variables + 3 mocked rules + 3 database connections, but limited by maxDropdownItems (10)
-            expect(options).toHaveLength(10);
+            // Expect 3 rules + 3 database connections + 3 variables (limited to 3 per type)
+            expect(options).toHaveLength(9);
 
-            // Check individual items in the correct order
+            // Check individual items in the correct order - only first 3 of each type
             expect(screen.getByTestId('chat-dropdown-item-Data Analysis')).toBeInTheDocument();
             expect(screen.getByTestId('chat-dropdown-item-Visualization')).toBeInTheDocument();
             expect(screen.getByTestId('chat-dropdown-item-Machine Learning')).toBeInTheDocument();
@@ -113,8 +113,7 @@ describe('ChatDropdown Component', () => {
             expect(screen.getByTestId('chat-dropdown-item-column')).toBeInTheDocument();
             expect(screen.getByTestId('chat-dropdown-item-df')).toBeInTheDocument();
             expect(screen.getByTestId('chat-dropdown-item-series')).toBeInTheDocument();
-            expect(screen.getByTestId('chat-dropdown-item-number')).toBeInTheDocument();
-            // Note: 'text' variable is not in the first 10 items due to maxDropdownItems limit
+            // Note: 'number' and 'text' variables are not shown due to 3-per-type limit
         });
 
         it('displays the correct shortened types', async () => {
@@ -129,9 +128,8 @@ describe('ChatDropdown Component', () => {
             // Check the shortened types are displayed correctly
             expect(screen.getByTestId('chat-dropdown-item-type-df').textContent).toBe('df');
             expect(screen.getByTestId('chat-dropdown-item-type-series').textContent).toBe('s');
-            expect(screen.getByTestId('chat-dropdown-item-type-number').textContent).toBe('int');
-            // Note: 'text' variable is no longer in the first 10 items due to database connections
-            // so we can't test it in this basic rendering test
+            // Note: 'number' and 'text' variables are not shown due to 3-per-type limit
+            // so we can't test them in this basic rendering test
         });
 
         it('displays "No variables found" when no options match', async () => {
@@ -207,6 +205,38 @@ describe('ChatDropdown Component', () => {
             expect(screen.queryByTestId('chat-dropdown-item-analytics_db')).not.toBeInTheDocument();
             expect(screen.queryByTestId('chat-dropdown-item-test_db')).not.toBeInTheDocument();
         });
+
+        it('shows all matches when searching (not limited to 3 per type)', async () => {
+            // Create more variables to test the search behavior
+            const manyVariables = [
+                ...createMockVariables(),
+                { variable_name: 'var1', type: '<class \'int\'>', value: 1 },
+                { variable_name: 'var2', type: '<class \'int\'>', value: 2 },
+                { variable_name: 'var3', type: '<class \'int\'>', value: 3 },
+                { variable_name: 'var4', type: '<class \'int\'>', value: 4 },
+            ];
+
+            // Re-render with search text that matches multiple variables
+            renderChatDropdown({ 
+                options: manyVariables,
+                filterText: 'var' 
+            });
+
+            // Wait for options to be loaded and filtered
+            await waitFor(() => {
+                expect(screen.getByTestId('chat-dropdown-item-var1')).toBeInTheDocument();
+            });
+
+            // Should show all variables that match 'var', not just 3
+            expect(screen.getByTestId('chat-dropdown-item-var1')).toBeInTheDocument();
+            expect(screen.getByTestId('chat-dropdown-item-var2')).toBeInTheDocument();
+            expect(screen.getByTestId('chat-dropdown-item-var3')).toBeInTheDocument();
+            expect(screen.getByTestId('chat-dropdown-item-var4')).toBeInTheDocument();
+            
+            // Should not show other variables that don't match
+            expect(screen.queryByTestId('chat-dropdown-item-df')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('chat-dropdown-item-series')).not.toBeInTheDocument();
+        });
     });
 
     describe('Selection', () => {
@@ -247,7 +277,7 @@ describe('ChatDropdown Component', () => {
             });
         });
 
-        it('limits the number of displayed options to maxDropdownItems', async () => {
+        it('limits the number of displayed options to maxDropdownItems when searching', async () => {
             // Create options that exceed the max
             const manyOptions = Array.from({ length: 15 }, (_, i) => ({
                 variable_name: `var${i}`,
@@ -255,10 +285,11 @@ describe('ChatDropdown Component', () => {
                 value: i
             }));
 
-            // Re-render with more options and a lower max
+            // Re-render with more options, a lower max, and search text
             renderChatDropdown({
                 options: manyOptions,
-                maxDropdownItems: 5
+                maxDropdownItems: 5,
+                filterText: 'var' // This triggers search mode
             });
 
             // Wait for options to be rendered (rules might also load)
@@ -354,8 +385,8 @@ describe('ChatDropdown Component', () => {
 
             // Press up arrow when first item is selected to go to the last item
             fireEvent.keyDown(document, { key: 'ArrowUp' });
-            // The last item should be the last variable (number)
-            expect(screen.getByTestId('chat-dropdown-item-number')).toHaveClass('selected');
+            // The last item should be the last variable (series) due to 3-per-type limit
+            expect(screen.getByTestId('chat-dropdown-item-series')).toHaveClass('selected');
 
             // Press down arrow when last item is selected to go to the first item
             fireEvent.keyDown(document, { key: 'ArrowDown' });

--- a/mito-ai/style/ChatDropdown.css
+++ b/mito-ai/style/ChatDropdown.css
@@ -28,6 +28,8 @@
   margin: 0;
   width: 100%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  overflow-y: auto;
+  max-height: 350px;
 }
 
 .chat-dropdown-item {


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1945 by ensuring that only three of each type (rule, csv, etc.) is shown by default. 

# Testing

Search, and make sure what you are looking for shows up in the context menu dropdown. Test both the button and the `@` tag. 

It might also be helpful to create a bunch of CSVs to make sure they don't take over the default dropdown window. 

# Documentation

No, should not need an explanation. 