### PR TITLE
changes to immediately show the app deploy notifications

### DIFF
--- a/mito-ai/src/Extensions/AppDeploy/DeployAppNotification.tsx
+++ b/mito-ai/src/Extensions/AppDeploy/DeployAppNotification.tsx
@@ -7,32 +7,29 @@ import { Notification } from '@jupyterlab/apputils';
 import { checkAppStatus } from '../AppManager/CheckAppStatusAPI';
 import type { IAppManagerService } from '../AppManager/ManageAppsPlugin';
 
-export const deployAppNotification = (url: string, appManagerService: IAppManagerService): void => {
+export const deployAppNotification = (url: string, appManagerService: IAppManagerService, notificationId: string): void => {
     // Total deployment time in milliseconds (3 minutes = 180000ms)
     const totalDeploymentTime = 180000;
     
     // Create an array of deployment steps
     const deploymentSteps = [
-        "Step 1/7: Preparing your app...",
-        "Step 2/7: Assembling clouds...",
-        "Step 3/7: Building your app...",
-        "Step 4/7: Configuring network settings...",
-        "Step 5/7: Adding final touches...",
-        "Step 6/7: Running security checks...",
+        "Step 2/7: Preparing your app...",
+        "Step 3/7: Assembling clouds...",
+        "Step 4/7: Building your app...",
+        "Step 5/7: Configuring network settings...",
+        "Step 6/7: Adding final touches...",
+        "Step 7/7: Running security checks...",
         "Deployment complete! Your app is ready."
     ];
     
     // Create initial "in progress" notification to get notificaiton id
-    const notificationId = Notification.emit(deploymentSteps[0]!, 'in-progress', {
-        autoClose: false
-    });
-    
+
     // Calculate time between steps (evenly distribute throughout the total deployment time)
     const stepInterval = totalDeploymentTime / (deploymentSteps.length - 1);
     let retryCount = 5;
     
     // Update message at each step interval
-    for (let i = 1; i < deploymentSteps.length; i++) {
+    for (let i = 0; i < deploymentSteps.length; i++) {
         setTimeout(() => {
             const isLastStep = i === deploymentSteps.length - 1;
             if (isLastStep) {

--- a/mito-ai/src/Extensions/AppDeploy/DeployStreamlitApp.ts
+++ b/mito-ai/src/Extensions/AppDeploy/DeployStreamlitApp.ts
@@ -48,6 +48,10 @@ export const deployStreamlitApp = async (
     }
   }
 
+  const notificationId = Notification.emit('Step 1/7: Gathering requirements...', 'in-progress', {
+        autoClose: false
+    });
+
   const notebookPanel = notebookTracker.currentWidget;
   if (!notebookPanel) {
     console.error('No notebook is currently active');
@@ -75,13 +79,16 @@ export const deployStreamlitApp = async (
     });
 
     if (response.error) {
-      Notification.emit(response.error.title, 'error', {
-          autoClose: false
-      });
+      Notification.update({
+                id: notificationId,
+                message: response.error.title,
+                type: 'error',
+                autoClose: false
+            });
     } else {
       console.log("App deployment response:", response);
       const url = response.url;
-      deployAppNotification(url, appManagerService);
+      deployAppNotification(url, appManagerService, notificationId);
     }
   } catch (error) {
     // TODO: Do something with the error

--- a/mito-ai/src/tests/AppDeploy/NotebookToStreamlit.test.tsx
+++ b/mito-ai/src/tests/AppDeploy/NotebookToStreamlit.test.tsx
@@ -22,7 +22,8 @@ jest.mock('@jupyterlab/coreutils', () => ({
 }));
 jest.mock('@jupyterlab/apputils', () => ({
     Notification: {
-        emit: jest.fn()
+        emit: jest.fn().mockReturnValue('test-notification-id'),
+        update: jest.fn()
     }
 }));
 jest.mock('../../Extensions/AppDeploy/fileUtils', () => ({
@@ -186,7 +187,7 @@ describe('NotebookToStreamlit Conversion and Deployment', () => {
 
         await deployStreamlitApp(mockNotebookTracker, mockAppDeployService, mockAppManagerService);
 
-        expect(deployAppNotification).toHaveBeenCalledWith('https://test-app.streamlit.app', mockAppManagerService);
+        expect(deployAppNotification).toHaveBeenCalledWith('https://test-app.streamlit.app', mockAppManagerService, 'test-notification-id');
     });
 
     test('should handle deployment response with error', async () => {


### PR DESCRIPTION
# Description

On clicking the deploy app button, the in-progress notification wasnt immediate, causing some confusion as to whether the process is running. This PR fixes that by immediately showing an in-progress notification

# Testing

- [x] I have tested this on real data that is reasonable and large
- [x] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation
\-