### PR TITLE
Set Max Height For Chat Input

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -116,9 +116,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
         if (!textarea) return;
 
         textarea.style.minHeight = 'auto';
+        const maxHeight = 350;
         textarea.style.height = !textarea.value || resetHeight
             ? '80px'
-            : `${Math.max(80, textarea.scrollHeight)}px`;
+            : `${Math.min(maxHeight, Math.max(80, textarea.scrollHeight))}px`;
     };
 
     useEffect(() => {

--- a/mito-ai/style/ChatInput.css
+++ b/mito-ai/style/ChatInput.css
@@ -29,7 +29,7 @@
   resize: none;
   width: 100%;
   padding: 10px;
-  overflow-y: hidden;
+  overflow-y: auto;
   box-sizing: border-box;
   flex-shrink: 0 !important;
   background-color: var(--chat-user-message-background-color);


### PR DESCRIPTION
# Description

Fixes https://github.com/mito-ds/mito/issues/1909

This PR introduces a hight limit for the chat input, so that really long content does not break scrolling. 

# Testing

Go to [lipsum.com](https://www.lipsum.com/) and generate 15 paragraphs of text, then paste it into the chat task pane. You should see that the height is capped to 350px, and vertical scrolling is enabled. 

# Documentation

N/A