### PR TITLE
Fix For Excessive Whitespace When Editing Message

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -313,7 +313,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
     return (
         <div
-            className={classNames("chat-input-container")}
+            className={classNames("chat-input-container", { "editing": isEditing })}
         >
             <div className='context-container'>
                 <DatabaseButton app={app} />

--- a/mito-ai/style/ChatInput.css
+++ b/mito-ai/style/ChatInput.css
@@ -18,6 +18,10 @@
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.chat-input-container.editing {
+  margin-top: 0;
+}
+
 .chat-input-text-area-container {
   position: relative;
   height: min-content;


### PR DESCRIPTION
# Description

Fix for huge amounts of white space that appears on top of messages when editing:

<img width="441" height="934" alt="Screenshot 2025-09-24 at 1 38 40 PM" src="https://github.com/user-attachments/assets/0036aacd-bc29-4337-8168-64937cf61b36" />

Why this is happening, from Cursor:

> The `margin-top: auto` in the .chat-input-container CSS is used to push the chat input to the bottom of its flex container.

# Testing

Send a message, edit, make sure the message does not have whitespace on top.

# Documentation

N/A