### PR TITLE
Auto-Close Preview Notification 

### DIFF
--- a/mito-ai/src/Extensions/AppPreview/utils.ts
+++ b/mito-ai/src/Extensions/AppPreview/utils.ts
@@ -25,7 +25,7 @@ export const startStreamlitPreviewAndNotify = async (notebookPath: string, force
       id: notificationId,
       message: 'Streamlit preview started successfully!',
       type: 'default',
-      autoClose: false
+      autoClose: 5 * 1000
     });
   
     return { previewData, notificationId };


### PR DESCRIPTION
# Description

Auto-closes preview notification after 5s. This way users don't have a stack of notifications as they rebuild their app during development.

# Testing

Rebuild the app, make sure the notification dissapears.

# Documentation

N/A