### PR TITLE
Fix random test hangs in pytest

### DIFF
--- a/mito-ai/mito_ai/tests/conftest.py
+++ b/mito-ai/mito_ai/tests/conftest.py
@@ -41,7 +41,17 @@ def jp_serverapp(jp_server_config, tmp_path):
     time.sleep(1)
 
     yield app
-    app.stop()
+    
+    # Properly stop the server and clean up resources
+    try:
+        app.stop()
+        # Wait for the server thread to finish with a timeout
+        server_thread.join(timeout=5.0)
+        if server_thread.is_alive():
+            # Thread didn't stop in time, but it's daemon so it will be killed
+            print("Warning: Server thread did not stop within timeout")
+    except Exception as e:
+        print(f"Error stopping server: {e}")
 
 @pytest.fixture
 def jp_base_url(jp_serverapp):

--- a/mito-ai/mito_ai/tests/db/connections_test.py
+++ b/mito-ai/mito_ai/tests/db/connections_test.py
@@ -5,6 +5,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import SNOWFLAKE
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 
 # --- ADD CONNECTION ---
 
@@ -14,6 +17,7 @@ def test_add_connection_with_auth(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=SNOWFLAKE,
+        timeout=REQUEST_TIMEOUT,
     )
     if response.status_code != 200:
         print(f"Error response: {response.text}")
@@ -24,6 +28,7 @@ def test_add_connection_with_no_auth(jp_base_url: str) -> None:
     response = requests.post(
         jp_base_url + "/mito-ai/db/connections",
         json=SNOWFLAKE,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -33,6 +38,7 @@ def test_add_connection_with_incorrect_auth(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token incorrect-token"},
         json=SNOWFLAKE,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -44,6 +50,7 @@ def test_get_connections_with_auth(jp_base_url: str, first_connection_id: str) -
     response = requests.get(
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Ensure the response has the correct number of connections
@@ -53,7 +60,7 @@ def test_get_connections_with_auth(jp_base_url: str, first_connection_id: str) -
 
 
 def test_get_connections_with_no_auth(jp_base_url: str) -> None:
-    response = requests.get(jp_base_url + "/mito-ai/db/connections")
+    response = requests.get(jp_base_url + "/mito-ai/db/connections", timeout=REQUEST_TIMEOUT)
     assert response.status_code == 403  # Forbidden
 
 
@@ -61,6 +68,7 @@ def test_get_connections_with_incorrect_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -71,6 +79,7 @@ def test_get_connections_with_incorrect_auth(jp_base_url: str) -> None:
 def test_delete_connection_with_no_auth(jp_base_url: str, first_connection_id: str) -> None:
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/connections/{first_connection_id}",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -81,6 +90,7 @@ def test_delete_connection_with_incorrect_auth(
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/connections/{first_connection_id}",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -91,6 +101,7 @@ def test_delete_connection_with_auth(
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/connections/{first_connection_id}",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -98,5 +109,6 @@ def test_delete_connection_with_auth(
     response = requests.get(
         jp_base_url + f"/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert len(response.json()) == 0

--- a/mito-ai/mito_ai/tests/db/mssql_test.py
+++ b/mito-ai/mito_ai/tests/db/mssql_test.py
@@ -5,6 +5,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import MSSQL_CONNECTION_DETAILS
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # To create a postgres database, run the following command:
 # docker-compose -f mito_ai/docker/mssql/compose.yml up
 # and then, to delete the database, run the following command:
@@ -16,6 +19,7 @@ def test_add_mssql_connection(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=MSSQL_CONNECTION_DETAILS,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -23,6 +27,7 @@ def test_add_mssql_connection(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response

--- a/mito-ai/mito_ai/tests/db/mysql_test.py
+++ b/mito-ai/mito_ai/tests/db/mysql_test.py
@@ -5,6 +5,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import MYSQL_CONNECTION_DETAILS
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # To create a mysql database, run the following command:
 # docker-compose -f mito_ai/docker/mysql/compose.yml up
 # and then, to delete the database, run the following command:
@@ -16,6 +19,7 @@ def test_add_mysql_connection(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=MYSQL_CONNECTION_DETAILS,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -23,6 +27,7 @@ def test_add_mysql_connection(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response

--- a/mito-ai/mito_ai/tests/db/oracle_test.py
+++ b/mito-ai/mito_ai/tests/db/oracle_test.py
@@ -5,6 +5,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import ORACLE_CONNECTION_DETAILS
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # To create a postgres database, run the following command:
 # docker-compose -f mito_ai/docker/postgres/compose.yml up
 # and then, to delete the database, run the following command:
@@ -16,6 +19,7 @@ def test_add_oracle_connection(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=ORACLE_CONNECTION_DETAILS,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -23,6 +27,7 @@ def test_add_oracle_connection(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response

--- a/mito-ai/mito_ai/tests/db/postgres_test.py
+++ b/mito-ai/mito_ai/tests/db/postgres_test.py
@@ -5,6 +5,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import POSTGRES_CONNECTION_DETAILS
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # To create a postgres database, run the following command:
 # docker-compose -f mito_ai/docker/postgres/compose.yml up
 # and then, to delete the database, run the following command:
@@ -16,6 +19,7 @@ def test_add_postgres_connection(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=POSTGRES_CONNECTION_DETAILS,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -23,6 +27,7 @@ def test_add_postgres_connection(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response

--- a/mito-ai/mito_ai/tests/db/schema_test.py
+++ b/mito-ai/mito_ai/tests/db/schema_test.py
@@ -6,6 +6,9 @@ import requests
 from mito_ai.tests.db.test_db_constants import SNOWFLAKE
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # --- GET SCHEMAS ---
 
 
@@ -15,6 +18,7 @@ def test_get_schemas_with_auth(jp_base_url: str) -> None:
         jp_base_url + f"/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=SNOWFLAKE,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -22,6 +26,7 @@ def test_get_schemas_with_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response
@@ -35,6 +40,7 @@ def test_ensure_no_application_databases(jp_base_url: str, first_connection_id: 
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
 
     crawled_databases = response.json()[first_connection_id]["databases"].keys()
@@ -45,6 +51,7 @@ def test_ensure_no_application_databases(jp_base_url: str, first_connection_id: 
 def test_get_schemas_with_no_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -53,6 +60,7 @@ def test_get_schemas_with_incorrect_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -64,6 +72,7 @@ def test_delete_schema_with_auth(jp_base_url: str, first_connection_id: str) -> 
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/schemas/{first_connection_id}",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -71,6 +80,7 @@ def test_delete_schema_with_auth(jp_base_url: str, first_connection_id: str) -> 
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     assert len(response.json()) == 0
@@ -79,6 +89,7 @@ def test_delete_schema_with_auth(jp_base_url: str, first_connection_id: str) -> 
 def test_delete_schema_with_no_auth(jp_base_url: str, first_connection_id: str) -> None:
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/schemas/{first_connection_id}",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -89,5 +100,6 @@ def test_delete_schema_with_incorrect_auth(
     response = requests.delete(
         jp_base_url + f"/mito-ai/db/schemas/{first_connection_id}",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden

--- a/mito-ai/mito_ai/tests/db/sqlite_test.py
+++ b/mito-ai/mito_ai/tests/db/sqlite_test.py
@@ -9,6 +9,9 @@ from mito_ai.tests.db.test_db_constants import (
 )
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 
 def test_add_sqlite_connection(jp_base_url: str) -> None:
     # Check for the sqlite database
@@ -18,6 +21,7 @@ def test_add_sqlite_connection(jp_base_url: str) -> None:
         jp_base_url + "/mito-ai/db/connections",
         headers={"Authorization": f"token {TOKEN}"},
         json=SQLITE_CONNECTION_DETAILS,
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -25,6 +29,7 @@ def test_add_sqlite_connection(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/db/schemas",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     # Esnure that there is one scema dict in the response

--- a/mito-ai/mito_ai/tests/rules/rules_test.py
+++ b/mito-ai/mito_ai/tests/rules/rules_test.py
@@ -8,6 +8,9 @@ RULE_CONTENT = "This is a test rule for data analysis."
 
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # --- PUT RULES ---
 
 
@@ -16,6 +19,7 @@ def test_put_rule_with_auth(jp_base_url):
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         headers={"Authorization": f"token {TOKEN}"},
         json={"content": RULE_CONTENT},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -28,6 +32,7 @@ def test_put_rule_with_no_auth(jp_base_url):
     response = requests.put(
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         json={"content": RULE_CONTENT},
+        timeout=REQUEST_TIMEOUT,
     )
 
     assert response.status_code == 403  # Forbidden
@@ -38,6 +43,7 @@ def test_put_rule_with_incorrect_auth(jp_base_url):
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         headers={"Authorization": f"token incorrect-token"}, # <- wrong token
         json={"content": RULE_CONTENT},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -47,6 +53,7 @@ def test_put_rule_missing_content(jp_base_url):
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         headers={"Authorization": f"token {TOKEN}"},
         json={},  # Missing content field
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 400  # Bad Request
 
@@ -58,6 +65,7 @@ def test_get_rule_with_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     assert response.json() == {"key": RULE_NAME, "content": RULE_CONTENT}
@@ -66,6 +74,7 @@ def test_get_rule_with_auth(jp_base_url):
 def test_get_rule_with_no_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -74,6 +83,7 @@ def test_get_rule_with_incorrect_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules/{RULE_NAME}",
         headers={"Authorization": f"token incorrect-token"}, # <- wrong token
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -82,6 +92,7 @@ def test_get_nonexistent_rule_with_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules/nonexistent_rule",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 404  # Not Found
 
@@ -93,6 +104,7 @@ def test_get_all_rules_with_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     
@@ -105,6 +117,7 @@ def test_get_all_rules_with_auth(jp_base_url):
 def test_get_all_rules_with_no_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -113,5 +126,6 @@ def test_get_all_rules_with_incorrect_auth(jp_base_url):
     response = requests.get(
         jp_base_url + f"/mito-ai/rules",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden

--- a/mito-ai/mito_ai/tests/settings/settings_test.py
+++ b/mito-ai/mito_ai/tests/settings/settings_test.py
@@ -8,6 +8,9 @@ SETTINGS_VALUE = "yes"
 
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 # --- PUT SETTINGS ---
 
 
@@ -16,6 +19,7 @@ def test_put_settings_with_auth(jp_base_url: str) -> None:
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
         headers={"Authorization": f"token {TOKEN}"},
         json={"value": SETTINGS_VALUE},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
 
@@ -29,6 +33,7 @@ def test_put_settings_with_no_auth(jp_base_url: str) -> None:
     response = requests.put(
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
         json={"value": SETTINGS_VALUE},
+        timeout=REQUEST_TIMEOUT,
     )
 
     assert response.status_code == 403  # Forbidden
@@ -39,6 +44,7 @@ def test_put_settings_with_incorrect_auth(jp_base_url: str) -> None:
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
         headers={"Authorization": f"token incorrect-token"},
         json={"value": SETTINGS_VALUE},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -50,6 +56,7 @@ def test_get_settings_with_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
         headers={"Authorization": f"token {TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 200
     assert response.json() == {"key": SETTINGS_KEY, "value": SETTINGS_VALUE}
@@ -58,6 +65,7 @@ def test_get_settings_with_auth(jp_base_url: str) -> None:
 def test_get_settings_with_no_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -66,5 +74,6 @@ def test_get_settings_with_incorrect_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/settings/{SETTINGS_KEY}",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden

--- a/mito-ai/mito_ai/tests/user/test_user.py
+++ b/mito-ai/mito_ai/tests/user/test_user.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 import pytest
 from mito_ai.tests.conftest import TOKEN
 
+# Timeout for HTTP requests to prevent indefinite hangs
+REQUEST_TIMEOUT = 10  # seconds
+
 
 @pytest.fixture
 def mock_user_json():
@@ -42,6 +45,7 @@ def test_get_user_with_mocked_data_success(
         response = requests.get(
             jp_base_url + f"/mito-ai/user/user_email",
             headers={"Authorization": f"token {TOKEN}"},
+            timeout=REQUEST_TIMEOUT,
         )
         assert response.status_code == 200
 
@@ -58,6 +62,7 @@ def test_get_user_with_mocked_data_not_found(
         response = requests.get(
             jp_base_url + "/mito-ai/user/non_existent_key",
             headers={"Authorization": f"token {TOKEN}"},
+            timeout=REQUEST_TIMEOUT,
         )
         assert response.status_code == 404
 
@@ -70,6 +75,7 @@ def test_get_user_with_mocked_data_not_found(
 def test_get_user_with_no_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/user/user_email",
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -78,6 +84,7 @@ def test_get_user_with_incorrect_auth(jp_base_url: str) -> None:
     response = requests.get(
         jp_base_url + f"/mito-ai/user/user_email",
         headers={"Authorization": f"token incorrect-token"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -94,6 +101,7 @@ def test_put_user_with_mocked_data_success(
             jp_base_url + f"/mito-ai/user/user_email",
             headers={"Authorization": f"token {TOKEN}"},
             json={"value": "jdoe@mail.com"},
+            timeout=REQUEST_TIMEOUT,
         )
         assert response.status_code == 200
 
@@ -107,6 +115,7 @@ def test_put_user_with_no_auth(jp_base_url: str) -> None:
     response = requests.put(
         jp_base_url + f"/mito-ai/user/user_email",
         json={"value": "jdoe@mail.com"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden
 
@@ -116,5 +125,6 @@ def test_put_user_with_incorrect_auth(jp_base_url: str) -> None:
         jp_base_url + f"/mito-ai/user/user_email",
         headers={"Authorization": f"token incorrect-token"},
         json={"value": "jdoe@mail.com"},
+        timeout=REQUEST_TIMEOUT,
     )
     assert response.status_code == 403  # Forbidden

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -54,6 +54,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 test = [
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
+    "pytest-timeout>=2.1.0",
     "mypy>=1.8.0",
     "types-tornado>=5.1.1",
     "types-requests>=2.25.0",
@@ -111,3 +112,7 @@ ignore = ["W002"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
+# Set individual test timeout to 30 seconds to prevent indefinite hangs
+timeout = 30
+# Use thread method for timeout to work with blocking operations
+timeout_method = "thread"


### PR DESCRIPTION
Add global test timeouts, improve asyncio and server resource cleanup, and set explicit HTTP request timeouts to prevent test suite hangs.

---
<a href="https://cursor.com/background-agent?bcId=bc-c59de731-7b1a-45cd-806a-05988718f420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c59de731-7b1a-45cd-806a-05988718f420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

