### PR TITLE
mito-ai: use sonnet 4.5 in app mode

### DIFF
--- a/mito-ai/mito_ai/streamlit_conversion/agent_utils.py
+++ b/mito-ai/mito_ai/streamlit_conversion/agent_utils.py
@@ -9,7 +9,7 @@ from mito_ai.utils.anthropic_utils import stream_anthropic_completion_from_mito_
 from mito_ai.streamlit_conversion.prompts.prompt_constants import MITO_TODO_PLACEHOLDER
 from mito_ai.completions.models import MessageType
 
-STREAMLIT_AI_MODEL = "claude-3-5-haiku-latest"
+STREAMLIT_AI_MODEL = "claude-sonnet-4-5-20250929"
 
 def extract_todo_placeholders(agent_response: str) -> List[str]:
     """Extract TODO placeholders from the agent's response"""
@@ -18,7 +18,7 @@ def extract_todo_placeholders(agent_response: str) -> List[str]:
 async def get_response_from_agent(message_to_agent: List[MessageParam]) -> str:
     """Gets the streaming response from the agent using the mito server"""
     model = STREAMLIT_AI_MODEL
-    max_tokens = 8192 # 64_000
+    max_tokens = 64000 # TODO: If we move to haiku, we must reset this to 8192
     temperature = 0.2
 
     accumulated_response = ""


### PR DESCRIPTION
# Description

Use sonnet 4.5 for app mode. This seems to fix issues with the AI responding with the wrong search_replace blocks: 
1.  It is using <<<<<<REPLACE as the delimiter instead of ========= (This one is happening a decent amount!)
2. Other times it put ``` right before the =========
It also leads to a more complete translation of the app. 

This comes at the expense of a 2-3x slowdown in app creation speed. I think we can do it for now and work on improving speed later if it is a blocker. 

# Testing

Just use it

# Documentation

No. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Streamlit conversion agent to Claude Sonnet 4.5 and increases max_tokens to 64k.
> 
> - **Streamlit conversion agent (`mito_ai/streamlit_conversion/agent_utils.py`)**:
>   - Change model to `claude-sonnet-4-5-20250929` (from `claude-3-5-haiku-latest`).
>   - Increase `max_tokens` to `64000` (was `8192`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1584e92a78f10e02e288a4624a21125d34ec18fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->