### PR TITLE
mito-ai: replace first match

### DIFF
--- a/mito-ai/mito_ai/streamlit_conversion/search_replace_utils.py
+++ b/mito-ai/mito_ai/streamlit_conversion/search_replace_utils.py
@@ -5,6 +5,7 @@ import re
 from typing import List, Tuple
 
 from mito_ai.utils.error_classes import StreamlitConversionError
+from mito_ai.utils.telemetry_utils import log
 
 
 def extract_search_replace_blocks(message_content: str) -> List[Tuple[str, str]]:
@@ -85,9 +86,9 @@ def apply_search_replace(text: str, search_replace_pairs: List[Tuple[str, str]])
             raise StreamlitConversionError(f"Search text not found: {repr(search_text)}", error_code=500)
         elif count > 1:
             print("Search Text Found Multiple Times: ", repr(search_text))
-            raise StreamlitConversionError(f"Search text found {count} times (must be unique): {repr(search_text)}", error_code=500)
-        
+            log("mito_ai_search_text_found_multiple_times", params={"search_text": repr(search_text)}, key_type="mito_server_key")
+
         # Perform the replacement
-        result = result.replace(search_text, replace_text)
+        result = result.replace(search_text, replace_text, 1)
     
     return result

--- a/mito-ai/mito_ai/tests/streamlit_conversion/test_apply_search_replace.py
+++ b/mito-ai/mito_ai/tests/streamlit_conversion/test_apply_search_replace.py
@@ -200,6 +200,23 @@ st.write("Welcome to my application")""",
 
 st.title("🚀 My App")
 st.write("Welcome to my application")"""
+    ),
+    
+    # Test case 11: Only replace first occurrence when search text exists multiple times
+    (
+        """import streamlit as st
+
+st.write("Hello World")
+st.title("My App")
+st.write("Hello World")
+st.write("Another message")""",
+        [("st.write(\"Hello World\")", "st.write(\"Hi There\")")],
+        """import streamlit as st
+
+st.write("Hi There")
+st.title("My App")
+st.write("Hello World")
+st.write("Another message")"""
     )
 ])
 def test_apply_search_replace(original_text, search_replace_pairs, expected_result):
@@ -220,7 +237,4 @@ def test_apply_search_replace_search_not_found():
         apply_search_replace("st.title(\"My App\")", [("st.title(\"Not Found\")", "st.title(\"New Title\")")])
 
 
-def test_apply_search_replace_multiple_matches():
-    """Test that ValueError is raised when search text is found multiple times."""
-    with pytest.raises(StreamlitConversionError, match="Search text found 2 times"):
-        apply_search_replace("st.write(\"Hello\")\nst.write(\"Hello\")", [("st.write(\"Hello\")", "st.write(\"Hi\")")])
+


### PR DESCRIPTION
# Description

When the streamlit agent finds multiple matches, defaults to replacing the first one. 

# Testing

See the new test

# Documentation

No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change search/replace to replace only the first occurrence and log when multiple matches are found; update tests accordingly.
> 
> - **Streamlit conversion**:
>   - `apply_search_replace` in `mito_ai/streamlit_conversion/search_replace_utils.py` now:
>     - Logs multiple matches via `log("mito_ai_search_text_found_multiple_times", ...)` instead of raising.
>     - Replaces only the first occurrence using `result.replace(search_text, replace_text, 1)`.
> - **Tests**:
>   - Add test to verify only the first occurrence is replaced when duplicates exist.
>   - Remove test expecting an error on multiple matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ffcee43d49f695b3085ba0bd9dc9ede726de0f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->