### PR TITLE
Fixed Signup Header in Dark Mode

### DIFF
--- a/mito-ai/style/AuthPopup.css
+++ b/mito-ai/style/AuthPopup.css
@@ -143,7 +143,7 @@
 
 /* Tab styling for sign in/sign up tabs */
 .modal-content .amplify-tabs__item {
-  color: var(--jp-ui-font-color2) !important;
+  color: var(--purple-500) !important;
   border-bottom: 2px solid transparent !important;
 }
 
@@ -161,7 +161,7 @@
 
 
 .modal-content .amplify-tabs__item:hover {
-  color: var(--jp-ui-font-color1) !important;
+  color: var(--purple-700) !important;
 }
 
 /* Override any default blue tab styling from Amplify */


### PR DESCRIPTION
# Description

Signup header was unreadable in dark mode:

<img width="515" height="524" alt="Screenshot 2025-12-01 at 10 47 07 AM" src="https://github.com/user-attachments/assets/5b17bbb2-8dbe-4ae6-baca-94d1295462d5" />


# Testing

Toggle between light and dark mode, make sure the signup headers look reasonable.

# Documentation

N/A