### PR TITLE
Add missing mitosheet project URLs

### DIFF
--- a/mitosheet/package.json
+++ b/mitosheet/package.json
@@ -17,10 +17,10 @@
     "email": "aaron@sagacollab.com"
   },
   "bugs": {
-    "url": "https://github.com/mito-ds/monorepo/issues"
+    "url": "https://github.com/mito-ds/mito/issues"
   },
   "repository": {
-    "url": "https://github.com/mito-ds/monorepo",
+    "url": "https://github.com/mito-ds/mito",
     "type": "git"
   },
   "version": "0.2.1",
@@ -100,7 +100,7 @@
     "typescript": "^5.5.4"
   },
   "main": "lib/index.js",
-  "homepage": "https://trymito.io",
+  "homepage": "https://github.com/mito-ds/mito",
   "types": "./lib/index.d.ts",
   "description": "The Mito Spreadsheet",
   "resolutions": {

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -70,6 +70,11 @@ setup_args = dict(
     author                  = package_json["author"]["name"],
     author_email            = package_json["author"]["email"],
     description             = package_json["description"],
+    project_urls            = {
+        "Homepage": package_json["homepage"],
+        "Repository": package_json["repository"]["url"],
+        "Issues": package_json["bugs"]["url"]
+    },
     license                 = "GNU Affero General Public License v3",
     long_description        = long_description,
     long_description_content_type = "text/markdown",


### PR DESCRIPTION
Hi team—I'm going through JupyterLab extensions with missing metadata for the [JupyterLab Marketplace](labextensions.dev) and noticed `mitosheet`'s PyPI page doesn't link back to this repo.

## Summary
- add homepage/repository/issues URLs to package metadata so npm + PyPI both point to mito-ds/mito
- surface those same links via setup.py's project_urls so PyPI shows the repo and issue tracker
