### PR TITLE
Add go-to-cell button for CellUpdate code blocks

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/AssistantCodeBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/AssistantCodeBlock.tsx
@@ -13,6 +13,9 @@ import { CodeReviewStatus } from '../ChatTaskpane';
 import CodeIcon from '../../../icons/CodeIcon';
 import CodeBlockToolbar from './CodeBlockToolbar';
 import AgentComponentHeader from '../../../components/AgentComponents/AgentComponentHeader';
+import GoToCellIcon from '../../../icons/GoToCellIcon';
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { scrollToCell, setActiveCellByIDInNotebookPanel } from '../../../utils/notebook';
 
 interface IAssistantCodeBlockProps {
     code: string;
@@ -26,6 +29,8 @@ interface IAssistantCodeBlockProps {
     codeReviewStatus: CodeReviewStatus;
     agentModeEnabled: boolean;
     isErrorFixup?: boolean;
+    cellId?: string;
+    notebookPanel?: NotebookPanel | null;
 }
 
 const AssistantCodeBlock: React.FC<IAssistantCodeBlockProps> = ({
@@ -40,9 +45,34 @@ const AssistantCodeBlock: React.FC<IAssistantCodeBlockProps> = ({
     codeReviewStatus,
     agentModeEnabled,
     isErrorFixup,
+    cellId,
+    notebookPanel,
 }) => {
     const [isCodeExpanded, setIsCodeExpanded] = useState(false);
     const shouldShowToolbar = isLastAiMessage || isCodeComplete;
+
+    const handleGoToCell = (e: React.MouseEvent): void => {
+        e.stopPropagation();
+        if (cellId && notebookPanel) {
+            setActiveCellByIDInNotebookPanel(notebookPanel, cellId);
+            scrollToCell(notebookPanel, cellId, undefined, 'center');
+        }
+    };
+
+    const renderActionButtons = (): React.ReactNode => {
+        if (!cellId || !notebookPanel) {
+            return null;
+        }
+        return (
+            <button
+                className="agent-component-header-action-button"
+                onClick={handleGoToCell}
+                title="Go to cell"
+            >
+                <GoToCellIcon />
+            </button>
+        );
+    };
 
     if (agentModeEnabled) {
 
@@ -58,6 +88,7 @@ const AssistantCodeBlock: React.FC<IAssistantCodeBlockProps> = ({
                     isExpanded={isCodeExpanded}
                     displayBorder={!isErrorFixup}
                     className={isErrorFixup ? 'error-fixup' : undefined}
+                    actionButtons={renderActionButtons()}
                 />
                 {isCodeExpanded && (
                     <PythonCode

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1006,6 +1006,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                                 key={index}
                                 messages={displayOptimizedChat}
                                 renderMimeRegistry={renderMimeRegistry}
+                                notebookTracker={notebookTracker}
                             />
                         )
                     } else {

--- a/mito-ai/src/components/AgentComponents/AgentComponentHeader.tsx
+++ b/mito-ai/src/components/AgentComponents/AgentComponentHeader.tsx
@@ -13,6 +13,7 @@ interface AgentComponentHeaderProps {
     isExpanded: boolean;
     displayBorder?: boolean;
     className?: string;
+    actionButtons?: React.ReactNode;
 }
 
 const AgentComponentHeader: React.FC<AgentComponentHeaderProps> = ({
@@ -21,7 +22,8 @@ const AgentComponentHeader: React.FC<AgentComponentHeaderProps> = ({
     onClick,
     isExpanded,
     displayBorder = true,
-    className
+    className,
+    actionButtons
 }): JSX.Element => {
     return (
         <div
@@ -35,25 +37,28 @@ const AgentComponentHeader: React.FC<AgentComponentHeaderProps> = ({
                 {icon}
                 {text}
             </span>
-            <svg
-                className={classNames('agent-component-header-expand-icon', {
-                    expanded: isExpanded
-                })}
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-            >
-                <path
-                    d="M4 6L8 10L12 6"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    transform={isExpanded ? 'rotate(90 8 8)' : 'rotate(0 8 8)'}
-                />
-            </svg>
+            <div className="agent-component-header-actions">
+                {actionButtons}
+                <svg
+                    className={classNames('agent-component-header-expand-icon', {
+                        expanded: isExpanded
+                    })}
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M4 6L8 10L12 6"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        transform={isExpanded ? 'rotate(90 8 8)' : 'rotate(0 8 8)'}
+                    />
+                </svg>
+            </div>
         </div>
     );
 };

--- a/mito-ai/src/icons/GoToCellIcon.tsx
+++ b/mito-ai/src/icons/GoToCellIcon.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+
+const GoToCellIcon: React.FC = () => (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+            d="M3 8H11M11 8L8 5M11 8L8 11M13 3V13"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+);
+
+export default GoToCellIcon;

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -84,6 +84,21 @@ export const getCellIndexByIDInNotebookPanel = (notebookPanel: NotebookPanel | n
     return undefined
 }
 
+export const getCellIDByIndex = (notebookTracker: INotebookTracker, index: number): string | undefined => {
+    const notebookPanel = notebookTracker.currentWidget
+    return getCellIDByIndexInNotebookPanel(notebookPanel, index)
+}
+
+export const getCellIDByIndexInNotebookPanel = (notebookPanel: NotebookPanel | null, index: number): string | undefined => {
+    const cellList = notebookPanel?.model?.cells
+
+    if (cellList === undefined || index < 0 || index >= cellList.length) {
+        return undefined
+    }
+
+    return cellList.get(index)?.id
+}
+
 export const setActiveCellByID = (notebookTracker: INotebookTracker, cellID: string | undefined): void => {
     const notebookPanel = notebookTracker.currentWidget
     setActiveCellByIDInNotebookPanel(notebookPanel, cellID)

--- a/mito-ai/style/AgentComponentHeader.css
+++ b/mito-ai/style/AgentComponentHeader.css
@@ -49,6 +49,33 @@
     flex-shrink: 0;
 }
 
+.agent-component-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.agent-component-header-action-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 4px;
+    color: var(--jp-ui-font-color2);
+    transition: background-color 0.15s ease, color 0.15s ease;
+    padding: 0;
+}
+
+.agent-component-header-action-button:hover {
+    background-color: var(--jp-layout-color3);
+    color: var(--jp-ui-font-color1);
+}
+
 .agent-component-header-expand-icon {
     flex-shrink: 0;
     transition: transform 0.2s ease;


### PR DESCRIPTION
## Description

Add a button to the code block header that allows users to navigate to the cell being updated in the notebook. The button appears for both modification and new cell updates, with support for getting cell IDs by index. Also enhanced the AgentComponentHeader to support action buttons on the right side of the header.

## Testing

- Test navigation button appears for code block headers in chat and error fixup modes
- Test clicking the button sets the active cell and scrolls to it
- Test button works for both modification type updates (using existing cell ID) and new cell updates (by looking up cell ID by index)

## Documentation

No documentation changes needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a go-to-cell button to assistant code block headers (chat and error-fixup) and wires cell ID resolution for both modified and newly created cells.
> 
> - **AI Chat UI**:
>   - `AssistantCodeBlock.tsx`: Adds optional "Go to cell" action in header; selects and scrolls to target cell via `setActiveCellByIDInNotebookPanel` and `scrollToCell` when `cellId` and `notebookPanel` are provided.
>   - `ChatMessage.tsx`: Derives `cellId` from `AgentResponse.cell_update` (uses ID for modifications, index lookup for new cells) and passes `notebookPanel` to `AssistantCodeBlock`.
>   - `components/AgentComponents/ErrorFixupToolUI.tsx`: Same `cellId` derivation and wiring in error-fixup flows.
>   - `components/AgentComponents/AgentComponentHeader.tsx`: Supports right-side `actionButtons` area; updated header layout.
>   - Styles `AgentComponentHeader.css`: Adds styles for header action area and action buttons.
> - **Utils**:
>   - `utils/notebook.tsx`: Adds `getCellIDByIndex`/`getCellIDByIndexInNotebookPanel` helpers; used for resolving IDs of newly inserted cells.
> - **Icons**:
>   - New `icons/GoToCellIcon.tsx` for the header action button.
> - **Wiring**:
>   - `ChatTaskpane.tsx`: Passes `notebookTracker` to `GroupedErrorsAndFixes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77db410becf19f26dbe377ff50f94548bba9706f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->