### PR TITLE
GPT-5.2

### DIFF
--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -172,8 +172,7 @@ def get_open_ai_completion_function_params(
         "messages": messages,
     }
 
-    if model == "gpt-5.2-fast":
-        completion_function_params["model"] = "gpt-5.2"
+    if model == "gpt-5.2":
         completion_function_params["reasoning_effort"] = "low"
     
     # If a response format is provided, we need to convert it to a json schema.

--- a/mito-ai/src/components/ModelSelector.tsx
+++ b/mito-ai/src/components/ModelSelector.tsx
@@ -53,7 +53,7 @@ const MODEL_MAPPINGS: ModelMapping[] = [
   },
   {
     displayName: 'GPT 5.2',
-    fullName: 'gpt-5.2-fast',
+    fullName: 'gpt-5.2',
     type: 'fast',
     goodFor: [...GOOD_FOR_FAST],
     provider: 'OpenAI',


### PR DESCRIPTION
# Description

Added support for gpt-5.2, and reasoning levels. 

# Testing

Use the three new models. Test locally and with a server key. 

# Documentation

Would be good to highlight. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GPT-5.2 as a selectable fast model and sets low reasoning effort for it in OpenAI requests.
> 
> - **Frontend (Model selection)**:
>   - Add `GPT 5.2` to `MODEL_MAPPINGS` as a `fast` OpenAI model (`gpt-5.2`) with updated metadata.
>   - Introduce shared presets `GOOD_FOR_FAST` and `GOOD_FOR_SMART`; refactor model `goodFor` entries to use them.
> - **Backend (OpenAI utils)**:
>   - In `get_open_ai_completion_function_params`, when model is `gpt-5.2`, set `reasoning_effort: "low"` in request params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf47d1677467d55f9b8fe8252c2f435a4202ed5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->