### PR TITLE
mito-ai: make haiku the default model

### DIFF
--- a/mito-ai/src/components/ModelSelector.tsx
+++ b/mito-ai/src/components/ModelSelector.tsx
@@ -124,7 +124,7 @@ const MODEL_MAPPINGS: ModelMapping[] = [
 const ALL_MODEL_DISPLAY_NAMES = MODEL_MAPPINGS.map(mapping => mapping.displayName);
 
 // Maximum length for displayed model name before truncating
-export const DEFAULT_MODEL = CLAUDE_SONNET_DISPLAY_NAME;
+export const DEFAULT_MODEL = CLAUDE_HAIKU_DISPLAY_NAME;
 
 interface ModelSelectorProps {
   onConfigChange: (config: ModelConfig) => void;


### PR DESCRIPTION
# Description

Make Haiku the default model. Its a good tradeoff of speed to intelligence 
