### PR TITLE
polish the selected context containers

### DIFF
--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -81,6 +81,27 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
         }
     };
 
+    const getTooltipText = (): string => {
+        if (type.startsWith('image/')) {
+            return `The AI will be able to view the ${title} image before deciding how to respond`;
+        } else if (type === 'file') {
+            return `The path ${title} will be shared with the AI`;
+        } else if (type === 'notebook') {
+            return "The AI will be able to read all of the code and markdown in your notebook. It is included by default in Agent mode.";
+        } else if (type === 'active_cell') {
+            return "The AI will write its code based on the currently active cell. It is included by default in Chat mode.";
+        } else if (type === 'cell') {
+            return `The AI will be able to see the code in ${title}`;
+        } else if (type === 'variable') {
+            return `The AI will receive a summary of the ${title} variable`;
+        } else if (type === 'rule') {
+            return `The AI will be guided by the ${title} rule`;
+        } else if (type === 'db') {
+            return `The AI will be able to access the ${title} database connection`;
+        }
+        return "This context will be included in your message to help the AI understand what you're working with";
+    };
+
     return (
         <button
             className="selected-context-container"
@@ -88,6 +109,8 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
             onMouseLeave={() => setIsHovered(false)}
             onClick={handleClick}
             data-testid="selected-context-container"
+            data-type={type}
+            title={getTooltipText()}
         >
             <div
                 className={`icon`}

--- a/mito-ai/style/SelectedContextContainer.css
+++ b/mito-ai/style/SelectedContextContainer.css
@@ -21,7 +21,7 @@
   display: flex;
   align-items: center;
   text-align: center;
-  background-color: var(--jp-layout-color2);
+  background-color: var(--purple-300);
   border-radius: 3px;
   padding: 4px 8px;
   margin: 2px;
@@ -31,17 +31,23 @@
   max-width: 100%;
   min-width: 0;
 
-  border: 1px solid var(--jp-border-color1);
+  border: none;
   cursor: pointer;
 }
 
 .selected-context-container:hover {
-  background-color: var(--jp-layout-color3);
+  background-color: var(--purple-400);
+}
+
+/* Disable hover effect for notebook and active_cell types since they don't have user actions */
+.selected-context-container[data-type="notebook"]:hover,
+.selected-context-container[data-type="active_cell"]:hover {
+  background-color: var(--purple-300);
 }
 
 .selected-context-container .rule-name {
   margin-left: 6px;
-  color: var(--jp-content-font-color1);
+  color: var(--purple-700);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -54,5 +60,5 @@
   justify-content: center;
   width: 12px;
   max-height: 14px;
-  color: var(--jp-content-font-color3);
+  color: var(--purple-700);
 }


### PR DESCRIPTION
# Description

Add some polish to the selected context containers! Resolves https://github.com/mito-ds/mito/issues/2128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Polishes the SelectedContextContainer UI and metadata for better context display and styling.
> 
> - Adds `getTooltipText` and sets `title` on the container to show context-specific tooltips (image, file, notebook, active_cell, cell, variable, rule, db)
> - Adds `data-type` attribute to the container and uses it in CSS to disable hover effect for `notebook` and `active_cell`
> - Updates styling to a purple theme: background/hover colors, text/icon colors; removes border
> - Keeps click-to-scroll/highlight behavior; no logic changes besides tooltip/title and data attributes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b461df62213a4c1350a63e03264d1f039e21d7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->