### PR TITLE
Chart Wizard - Clearing timeout on chartData change 

### DIFF
--- a/mito-ai/src/Extensions/ChartWizard/hooks/useDebouncedNotebookUpdate.ts
+++ b/mito-ai/src/Extensions/ChartWizard/hooks/useDebouncedNotebookUpdate.ts
@@ -32,14 +32,14 @@ export const useDebouncedNotebookUpdate = ({
 }: UseDebouncedNotebookUpdateProps): UseDebouncedNotebookUpdateReturn => {
     const executeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-    // Cleanup timeout on unmount
+    // Cleanup timeout on unmount or when chartData changes
     useEffect(() => {
         return () => {
             if (executeTimeoutRef.current) {
                 clearTimeout(executeTimeoutRef.current);
             }
         };
-    }, []);
+    }, [chartData]);
 
     const updateNotebookCell = useCallback(
         (updatedCode: string): void => {


### PR DESCRIPTION
# Description

Fixing this (low severity) issue that bug bot picked up:

> The cleanup effect in useDebouncedNotebookUpdate has an empty dependency array, so it only clears pending timeouts on unmount. When chartData changes (user switches to a different chart), pending debounced updates aren't cleared. The scheduled timeout still captures the old updateNotebookCell callback, which references the previous chartData.cellId. This can cause the previous chart's cell to be unexpectedly updated after the user has already switched to viewing a different chart.

# Testing

1. Open Chart Wizard with a chart
2. Make a change that triggers a debounced update
3. Quickly switch to a different chart before the debounce completes
4. Verify the previous chart's cell is not updated
5. Make changes to the new chart and verify they work correctly

# Documentation

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix: debounce cleanup in `useDebouncedNotebookUpdate`**
> 
> - Update cleanup effect to depend on `chartData` (from `[]` to `[chartData]`) so pending timeouts are cleared on chart switches.
> - Prevents stale debounced `updateNotebookCell` executions from affecting previously selected chart cells.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6994a6cd696c88b27ef14a4435c66c10f26698bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->