### PR TITLE
mito-ai: remove improper environment check

### DIFF
--- a/mito-ai/mito_ai/__init__.py
+++ b/mito-ai/mito_ai/__init__.py
@@ -33,16 +33,6 @@ from mito_ai.chart_wizard.urls import get_chart_wizard_urls
 import os
 os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"
 
-try:
-    from _version import __version__
-except ImportError:
-    # Fallback when using the package in dev mode without installing in editable mode with pip. It is highly recommended to install
-    # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
-    import warnings
-    
-    warnings.warn("Importing 'mito_ai' outside a proper installation.")
-    __version__ = "dev"
-
 def _jupyter_labextension_paths() -> List[Dict[str, str]]:
     return [{"src": "labextension", "dest": "mito_ai"}]
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **init changes**
> 
> - Forces Matplotlib to use the Jupyter inline backend by setting `os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"` very early in `__init__.py` to ensure figures render inline in notebooks even if other libs set `Agg`.
> - Removes the dev-mode `__version__` import/try-except and warning fallback from `__init__.py`.
> 
> No other files changed; server extension registration remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 005b51626d07ef2d18bbbdcde84d017a4802f0c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->