### PR TITLE
mito-ai: rename OpenAIProvider to ProviderManager

### DIFF
--- a/mito-ai/mito_ai/__init__.py
+++ b/mito-ai/mito_ai/__init__.py
@@ -4,7 +4,7 @@
 from typing import List, Dict
 from jupyter_server.utils import url_path_join
 from mito_ai.completions.handlers import CompletionHandler
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.app_deploy.handlers import AppDeployHandler
 from mito_ai.streamlit_preview.handlers import StreamlitPreviewHandler

--- a/mito-ai/mito_ai/chart_wizard/handlers.py
+++ b/mito-ai/mito_ai/chart_wizard/handlers.py
@@ -6,7 +6,7 @@ import tornado
 from typing import List
 from jupyter_server.base.handlers import APIHandler
 from openai.types.chat import ChatCompletionMessageParam
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.utils.anthropic_utils import FAST_ANTHROPIC_MODEL
 from mito_ai.completions.models import MessageType
 from mito_ai.completions.prompt_builders.chart_conversion_prompt import create_chart_conversion_prompt

--- a/mito-ai/mito_ai/chart_wizard/urls.py
+++ b/mito-ai/mito_ai/chart_wizard/urls.py
@@ -4,7 +4,7 @@
 from typing import List, Tuple, Any
 from jupyter_server.utils import url_path_join
 from mito_ai.chart_wizard.handlers import ChartWizardHandler
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 
 
 def get_chart_wizard_urls(base_url: str, llm: ProviderManager) -> List[Tuple[str, Any, dict]]:

--- a/mito-ai/mito_ai/completions/completion_handlers/agent_auto_error_fixup_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/agent_auto_error_fixup_handler.py
@@ -4,7 +4,7 @@
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import AgentResponse, AgentSmartDebugMetadata, MessageType, ResponseFormatInfo
 from mito_ai.completions.prompt_builders.agent_smart_debug_prompt import create_agent_smart_debug_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_agent_system_message

--- a/mito-ai/mito_ai/completions/completion_handlers/agent_execution_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/agent_execution_handler.py
@@ -5,7 +5,7 @@ from typing import List, Literal, Union
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import AgentExecutionMetadata, MessageType, ResponseFormatInfo, AgentResponse
 from mito_ai.completions.prompt_builders.agent_execution_prompt import create_agent_execution_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_agent_system_message, create_ai_optimized_message

--- a/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
@@ -6,7 +6,7 @@ from typing import List, Union, AsyncGenerator, Callable
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import ChatMessageMetadata, MessageType, CompletionRequest, CompletionStreamChunk, CompletionReply
 from mito_ai.completions.prompt_builders.chat_prompt import create_chat_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_chat_system_message, create_ai_optimized_message

--- a/mito-ai/mito_ai/completions/completion_handlers/code_explain_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/code_explain_handler.py
@@ -5,7 +5,7 @@ from typing import List, Union, AsyncGenerator, Callable
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import CodeExplainMetadata, MessageType, CompletionRequest, CompletionStreamChunk, CompletionReply
 from mito_ai.completions.prompt_builders.explain_code_prompt import create_explain_code_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_chat_system_message

--- a/mito-ai/mito_ai/completions/completion_handlers/completion_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/completion_handler.py
@@ -4,7 +4,7 @@
 from typing import Protocol, TypeVar
 from abc import abstractmethod, ABCMeta
 from mito_ai.completions.models import ChatMessageMetadata, ScratchpadResultMetadata, SmartDebugMetadata, CodeExplainMetadata, AgentExecutionMetadata, InlineCompleterMetadata, AgentSmartDebugMetadata
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 
 T = TypeVar('T', 

--- a/mito-ai/mito_ai/completions/completion_handlers/inline_completer_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/inline_completer_handler.py
@@ -5,7 +5,7 @@ from typing import List
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import InlineCompleterMetadata, MessageType
 from mito_ai.completions.prompt_builders.inline_completer_prompt import create_inline_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 

--- a/mito-ai/mito_ai/completions/completion_handlers/scratchpad_result_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/scratchpad_result_handler.py
@@ -5,7 +5,7 @@ from typing import List, Literal, Union
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import ScratchpadResultMetadata, MessageType, ResponseFormatInfo, AgentResponse
 from mito_ai.completions.prompt_builders.scratchpad_result_prompt import create_scratchpad_result_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_agent_system_message, create_ai_optimized_message

--- a/mito-ai/mito_ai/completions/completion_handlers/smart_debug_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/smart_debug_handler.py
@@ -15,7 +15,7 @@ from mito_ai.completions.prompt_builders.smart_debug_prompt import (
     create_error_prompt,
     remove_inner_thoughts_from_message,
 )
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.completion_handlers.completion_handler import CompletionHandler
 from mito_ai.completions.completion_handlers.utils import append_chat_system_message

--- a/mito-ai/mito_ai/completions/completion_handlers/utils.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/utils.py
@@ -5,7 +5,7 @@ import base64
 from typing import Optional, Union, List, Dict, Any, cast
 from mito_ai.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.models import ThreadID
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.prompt_builders.chat_system_message import (
     create_chat_system_message_prompt,

--- a/mito-ai/mito_ai/completions/handlers.py
+++ b/mito-ai/mito_ai/completions/handlers.py
@@ -37,7 +37,7 @@ from mito_ai.completions.models import (
     ScratchpadResultMetadata,
     MessageType
 )
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.utils.create import initialize_user
 from mito_ai.utils.version_utils import is_pro
 from mito_ai.completions.completion_handlers.chat_completion_handler import get_chat_completion, stream_chat_completion

--- a/mito-ai/mito_ai/completions/message_history.py
+++ b/mito-ai/mito_ai/completions/message_history.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 from openai.types.chat import ChatCompletionMessageParam
 from mito_ai.completions.models import CompletionRequest, ChatThreadMetadata, MessageType, ThreadID
 from mito_ai.completions.prompt_builders.chat_name_prompt import create_chat_name_prompt
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.utils.schema import MITO_FOLDER
 from mito_ai.utils.message_history_utils import trim_old_messages
 

--- a/mito-ai/mito_ai/provider_manager.py
+++ b/mito-ai/mito_ai/provider_manager.py
@@ -281,4 +281,3 @@ This attribute is observed by the websocket provider to push the error to the cl
                 error=CompletionError.from_exception(e),
             ))
             raise
-

--- a/mito-ai/mito_ai/tests/message_history/test_generate_short_chat_name.py
+++ b/mito-ai/mito_ai/tests/message_history/test_generate_short_chat_name.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from traitlets.config import Config
 from mito_ai.completions.message_history import generate_short_chat_name
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 
 
 @pytest.fixture
@@ -20,9 +20,9 @@ def provider_config() -> Config:
 # Test cases for different models and their expected providers/fast models
 PROVIDER_TEST_CASES = [
     # (model, client_patch_path)
-    ("gpt-4.1", "mito_ai.completions.providers.OpenAIClient"),
-    ("claude-3-5-sonnet-20241022", "mito_ai.completions.providers.AnthropicClient"),
-    ("gemini-2.0-flash-exp", "mito_ai.completions.providers.GeminiClient")
+    ("gpt-4.1", "mito_ai.provider_manager.OpenAIClient"),
+    ("claude-3-5-sonnet-20241022", "mito_ai.provider_manager.AnthropicClient"),
+    ("gemini-2.0-flash-exp", "mito_ai.provider_manager.GeminiClient")
 ]
 
 @pytest.mark.parametrize("selected_model,client_patch_path", PROVIDER_TEST_CASES)

--- a/mito-ai/mito_ai/tests/providers/test_azure.py
+++ b/mito-ai/mito_ai/tests/providers/test_azure.py
@@ -9,7 +9,7 @@ import pytest
 from traitlets.config import Config
 from openai.types.chat import ChatCompletionMessageParam
 
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.models import (
     MessageType,
     AICapabilities,

--- a/mito-ai/mito_ai/tests/providers/test_capabilities.py
+++ b/mito-ai/mito_ai/tests/providers/test_capabilities.py
@@ -3,7 +3,7 @@
 
 import pytest
 from unittest.mock import MagicMock, patch
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.tests.providers.utils import mock_azure_openai_client, mock_openai_client, patch_server_limits
 from traitlets.config import Config
 

--- a/mito-ai/mito_ai/tests/providers/test_model_resolution.py
+++ b/mito-ai/mito_ai/tests/providers/test_model_resolution.py
@@ -9,7 +9,7 @@ import pytest
 from mito_ai.utils.provider_utils import does_message_require_fast_model
 from mito_ai.completions.models import MessageType
 from unittest.mock import AsyncMock, MagicMock, patch
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.models import MessageType
 from mito_ai.utils.provider_utils import does_message_require_fast_model
 from traitlets.config import Config

--- a/mito-ai/mito_ai/tests/providers/test_provider_limits.py
+++ b/mito-ai/mito_ai/tests/providers/test_provider_limits.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 import pytest
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.tests.providers.utils import mock_openai_client, patch_server_limits
 from mito_ai.utils.server_limits import OS_MONTHLY_AI_COMPLETIONS_LIMIT
 from traitlets.config import Config

--- a/mito-ai/mito_ai/tests/providers/test_providers.py
+++ b/mito-ai/mito_ai/tests/providers/test_providers.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from mito_ai.tests.providers.utils import mock_azure_openai_client, mock_openai_client, patch_server_limits
 import pytest
 from traitlets.config import Config
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.models import (
     MessageType,
     AICapabilities,
@@ -50,7 +50,7 @@ def reset_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
         "env_vars": {"OPENAI_API_KEY": FAKE_API_KEY},
         "constants": {"OPENAI_API_KEY": FAKE_API_KEY},
         "model": "gpt-4o-mini",
-        "mock_patch": "mito_ai.completions.providers.OpenAIClient",
+        "mock_patch": "mito_ai.provider_manager.OpenAIClient",
         "mock_method": "request_completions",
         "provider_name": "OpenAI with user key",
         "key_type": "user"
@@ -60,7 +60,7 @@ def reset_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
         "env_vars": {"CLAUDE_API_KEY": "claude-key"},
         "constants": {"CLAUDE_API_KEY": "claude-key", "OPENAI_API_KEY": None},
         "model": "claude-3-opus-20240229",
-        "mock_patch": "mito_ai.completions.providers.AnthropicClient",
+        "mock_patch": "mito_ai.provider_manager.AnthropicClient",
         "mock_method": "request_completions",
         "provider_name": "Claude",
         "key_type": "claude"
@@ -70,7 +70,7 @@ def reset_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
         "env_vars": {"GEMINI_API_KEY": "gemini-key"},
         "constants": {"GEMINI_API_KEY": "gemini-key", "OPENAI_API_KEY": None},
         "model": "gemini-2.0-flash",
-        "mock_patch": "mito_ai.completions.providers.GeminiClient",
+        "mock_patch": "mito_ai.provider_manager.GeminiClient",
         "mock_method": "request_completions",
         "provider_name": "Gemini",
         "key_type": "gemini"
@@ -80,7 +80,7 @@ def reset_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
         "env_vars": {"AZURE_OPENAI_API_KEY": "azure-key"},
         "constants": {"AZURE_OPENAI_API_KEY": "azure-key", "OPENAI_API_KEY": None},
         "model": "gpt-4o",
-        "mock_patch": "mito_ai.completions.providers.OpenAIClient",
+        "mock_patch": "mito_ai.provider_manager.OpenAIClient",
         "mock_method": "request_completions",
         "provider_name": "Azure OpenAI",
         "key_type": "azure"
@@ -134,7 +134,7 @@ async def test_completion_request(
         "env_vars": {"OPENAI_API_KEY": FAKE_API_KEY},
         "constants": {"OPENAI_API_KEY": FAKE_API_KEY},
         "model": "gpt-4o-mini",
-        "mock_patch": "mito_ai.completions.providers.OpenAIClient",
+        "mock_patch": "mito_ai.provider_manager.OpenAIClient",
         "mock_method": "stream_completions",
         "provider_name": "OpenAI with user key",
         "key_type": "user"
@@ -144,7 +144,7 @@ async def test_completion_request(
         "env_vars": {"CLAUDE_API_KEY": "claude-key"},
         "constants": {"CLAUDE_API_KEY": "claude-key", "OPENAI_API_KEY": None},
         "model": "claude-3-opus-20240229",
-        "mock_patch": "mito_ai.completions.providers.AnthropicClient",
+        "mock_patch": "mito_ai.provider_manager.AnthropicClient",
         "mock_method": "stream_completions", 
         "provider_name": "Claude",
         "key_type": "claude"
@@ -154,7 +154,7 @@ async def test_completion_request(
         "env_vars": {"GEMINI_API_KEY": "gemini-key"},
         "constants": {"GEMINI_API_KEY": "gemini-key", "OPENAI_API_KEY": None},
         "model": "gemini-2.0-flash",
-        "mock_patch": "mito_ai.completions.providers.GeminiClient",
+        "mock_patch": "mito_ai.provider_manager.GeminiClient",
         "mock_method": "stream_completions",
         "provider_name": "Gemini",
         "key_type": "gemini"
@@ -224,7 +224,7 @@ def test_error_handling(monkeypatch: pytest.MonkeyPatch, provider_config: Config
     mock_client.key_type = "user"
     mock_client.request_completions.side_effect = Exception("API error")
 
-    with patch("mito_ai.completions.providers.OpenAIClient", return_value=mock_client):
+    with patch("mito_ai.provider_manager.OpenAIClient", return_value=mock_client):
         llm = ProviderManager(config=provider_config)
         assert llm.last_error is None  # Error should be None until a request is made
 
@@ -242,7 +242,7 @@ def test_claude_error_handling(monkeypatch: pytest.MonkeyPatch, provider_config:
     mock_client.key_type = "claude"
     mock_client.request_completions.side_effect = Exception("API error")
 
-    with patch("mito_ai.completions.providers.AnthropicClient", return_value=mock_client):
+    with patch("mito_ai.provider_manager.AnthropicClient", return_value=mock_client):
         llm = ProviderManager(config=provider_config)
         assert llm.last_error is None  # Error should be None until a request is made
 

--- a/mito-ai/mito_ai/tests/providers/test_retry_logic.py
+++ b/mito-ai/mito_ai/tests/providers/test_retry_logic.py
@@ -4,7 +4,7 @@
 import pytest
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
-from mito_ai.completions.providers import ProviderManager
+from mito_ai.provider_manager import ProviderManager
 from mito_ai.completions.models import MessageType, CompletionError
 from mito_ai.utils.mito_server_utils import ProviderCompletionException
 from mito_ai.tests.providers.utils import mock_openai_client, patch_server_limits

--- a/mito-ai/mito_ai/tests/providers/utils.py
+++ b/mito-ai/mito_ai/tests/providers/utils.py
@@ -38,7 +38,7 @@ def mock_openai_client() -> Any:
     mock_client.key_type = "user"
     mock_client.request_completions = AsyncMock(return_value="Test completion")
     mock_client.stream_completions = AsyncMock(return_value="Test completion")
-    return patch("mito_ai.completions.providers.OpenAIClient", return_value=mock_client)
+    return patch("mito_ai.provider_manager.OpenAIClient", return_value=mock_client)
 
 
 def mock_gemini_client() -> Any:
@@ -52,7 +52,7 @@ def mock_gemini_client() -> Any:
     mock_client.key_type = "gemini"
     mock_client.request_completions = AsyncMock(return_value="Test completion")
     mock_client.stream_completions = AsyncMock(return_value="Test completion")
-    return patch("mito_ai.completions.providers.GeminiClient", return_value=mock_client)
+    return patch("mito_ai.provider_manager.GeminiClient", return_value=mock_client)
 
 
 def mock_azure_openai_client() -> Any:
@@ -66,7 +66,7 @@ def mock_azure_openai_client() -> Any:
     mock_client.key_type = "azure"
     mock_client.request_completions = AsyncMock(return_value="Test completion")
     mock_client.stream_completions = AsyncMock(return_value="Test completion")
-    return patch("mito_ai.completions.providers.OpenAIClient", return_value=mock_client)
+    return patch("mito_ai.provider_manager.OpenAIClient", return_value=mock_client)
 
 
 
@@ -82,4 +82,4 @@ def mock_claude_client() -> Any:
     mock_client.request_completions = AsyncMock(return_value="Test completion")
     mock_client.stream_completions = AsyncMock(return_value="Test completion")
     mock_client.stream_response = AsyncMock(return_value="Test completion")
-    return patch("mito_ai.completions.providers.AnthropicClient", return_value=mock_client)
+    return patch("mito_ai.provider_manager.AnthropicClient", return_value=mock_client)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a centralized `ProviderManager` to replace `OpenAIProvider` and updates all references accordingly.
> 
> - Core refactor: new `provider_manager.py` implements unified routing, retry/stream logic, capabilities, and key typing across OpenAI/Azure OpenAI, Claude, and Gemini
> - Server wiring: `__init__.py` now instantiates `ProviderManager` and passes it (and its `key_type`) to websocket and REST handlers; `chart_wizard` endpoints updated to accept `ProviderManager`
> - Completions layer: all completion handlers, utilities, and `GlobalMessageHistory` now depend on `ProviderManager` (signatures, imports, and calls updated)
> - Tests:全面 update to use `ProviderManager` (Azure integration, capabilities selection, model resolution, provider limits, retry logic, and Mito-server fallbacks); patch targets adjusted from `completions.providers.*` to `provider_manager.*`
> 
> No endpoint or feature changes intended; primarily a rename and centralization for multi-provider support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34fa57268d2065421eaa81ec65419628f68ad8d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->