### PR TITLE
Fix - Chat Taskpane Vanishes on Cell Type Update

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
@@ -86,6 +86,7 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
     // This ensures re-renders when cells are reordered (even if count stays the same)
     const cellOrderKey = useMemo(() => {
         return Array.from(cellOrder.entries())
+            .filter(([cellId]) => cellId != null) // Filter out entries with undefined/null keys
             .sort((a, b) => a[0].localeCompare(b[0])) // Sort by cellId for stable string
             .map(([cellId, cellNumber]) => `${cellId}:${cellNumber}`)
             .join(',');


### PR DESCRIPTION
# Description

When switching a cell's type, the entire chat taskpane would disappear. 

The issue was in the `MarkdownBlock` component. Specifically,  when the `cellOrderKey` var was being created. 

According to Cursor:

> [...] cellOrder could temporarily include entries with undefined keys. Sorting then called localeCompare on undefined, causing the error and hiding the chat taskpane.

# Testing

Switch a cell's type, make sure the taskpane is still there.

# Documentation

No, just a call out in the release notes. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the chat taskpane remains visible when notebook cells change type by stabilizing cell order serialization in `MarkdownBlock`.
> 
> - Filters out `undefined/null` `cellId` entries before sorting in `cellOrderKey` to avoid `localeCompare` errors
> - Keeps citation and cell reference rendering logic unchanged; only dependency key generation is adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cefd95383c6484c1240f38179ce5e0aaa168ddc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->