### PR TITLE
Added Rule for Alpha Values in Chart

### DIFF
--- a/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
@@ -20,6 +20,8 @@ Rules:
 - All imports must appear at the top, before the chart configuration section.
 - Variables with multiple words should be underscore-separated.
 - All colors should be in hex format (e.g., "#3498db"). Use quotes around the hex string: COLOR = "#3498db" or COLOR = '#3498db'. Do NOT nest quotes.
+- Never use RGB/RGBA tuples/lists for colors (e.g. (0, 0.4, 0.8, 0.8) is forbidden).
+- If transparency is needed, store it separately as ALPHA = 0.8 and apply it in code (e.g. to_rgba(HEX_COLOR, ALPHA)).
 - Variables can only be strings, numbers, booleans, tuples, or lists. 
 - NEVER include comments on the same line as a variable assignment. Each variable assignment must be on its own line with no trailing comments.
 - For string values, use either single or double quotes (e.g., TITLE = "Sales by Product" or TITLE = 'Sales by Product'). Do not use nested quotes (e.g., do NOT use '"value"').


### PR DESCRIPTION
# Description

This fixes an issue where alpha values show up as a third value in a tuple:

```python
BLOOMBERG_BLUE = (0, 0.4, 0.8, 0.8)
```

This third value breaks the parser, which expects two values. Instead, we are asking the AI to make the alpha value a separate variable.

This has two benefits:

1. Changes won't break the parser.
2. Users can edit the alpha value.
3. Colors are always hex values, allowing the color picker to be used. 

# Testing

Create a chart with transparency. Make sure the chart config has the alpha as a separate value. 

# Documentation

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `CHART_CONFIG_RULES` in `prompt_constants.py` to tighten chart color guidance.
> 
> - Enforces hex-only color values; explicitly disallows RGB/RGBA tuples/lists
> - Requires transparency to be defined as a separate `ALPHA` variable and applied in code (e.g., `to_rgba(HEX_COLOR, ALPHA)`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 189dd06ec1c60f07578238107c608ed71fde905f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->