### PR TITLE
mito-ai: gpt-5.3-codex support

### DIFF
--- a/mito-ai/mito_ai/tests/test_model_utils.py
+++ b/mito-ai/mito_ai/tests/test_model_utils.py
@@ -111,6 +111,11 @@ class TestGetFastModelForSelectedModel:
         """Test that GPT 5.2 returns GPT 4.1 (fastest OpenAI model)."""
         result = get_fast_model_for_selected_model("gpt-5.2")
         assert result == "gpt-4.1"
+
+    def test_openai_gpt_5_3_codex_returns_gpt_4_1(self):
+        """Test that GPT 5.3 Codex returns GPT 4.1 (fastest OpenAI model)."""
+        result = get_fast_model_for_selected_model("gpt-5.3-codex")
+        assert result == "gpt-4.1"
     
     def test_gemini_pro_returns_flash(self):
         """Test that Gemini Pro returns Gemini Flash (fastest Gemini model)."""
@@ -169,7 +174,7 @@ class TestGetFastModelForSelectedModel:
             (
                 "litellm/openai/gpt-5.2",
                 [
-                    "litellm/openai/gpt-5.2",  # Index 1 in OPENAI_MODEL_ORDER
+                    "litellm/openai/gpt-5.2",  # Index 2 in OPENAI_MODEL_ORDER
                     "litellm/anthropic/claude-haiku-4-5-20251001",  # Index 0 in ANTHROPIC_MODEL_ORDER
                 ],
                 "litellm/anthropic/claude-haiku-4-5-20251001",
@@ -331,7 +336,7 @@ class TestGetFastModelForSelectedModel:
             (
                 "Abacus/gpt-5.2",
                 [
-                    "Abacus/gpt-5.2",  # Index 1 in OPENAI_MODEL_ORDER
+                    "Abacus/gpt-5.2",  # Index 2 in OPENAI_MODEL_ORDER
                     "Abacus/claude-haiku-4-5-20251001",  # Index 0 in ANTHROPIC_MODEL_ORDER
                 ],
                 "Abacus/claude-haiku-4-5-20251001",

--- a/mito-ai/mito_ai/utils/model_utils.py
+++ b/mito-ai/mito_ai/utils/model_utils.py
@@ -15,6 +15,7 @@ OPENAI_MODEL_ORDER = [
     "gpt-4.1",      # Fastest
     "gpt-5",
     "gpt-5.2",      # Slower
+    "gpt-5.3-codex",
 ]
 
 GEMINI_MODEL_ORDER = [
@@ -26,6 +27,7 @@ GEMINI_MODEL_ORDER = [
 STANDARD_MODELS = [
     "gpt-4.1",
     "gpt-5.2",
+    "gpt-5.3-codex",
     "claude-haiku-4-5-20251001",
     "gemini-3-flash-preview",
     "gemini-3-pro-preview",

--- a/mito-ai/mito_ai/utils/open_ai_utils.py
+++ b/mito-ai/mito_ai/utils/open_ai_utils.py
@@ -152,7 +152,7 @@ def get_open_ai_completion_function_params(
         "messages": messages,
     }
 
-    if model == "gpt-5.2":
+    if model == "gpt-5.2" or model == "gpt-5.3-codex":
         completion_function_params["reasoning_effort"] = "low"
     
     # If a response format is provided, we need to convert it to a json schema.

--- a/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
+++ b/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
@@ -12,6 +12,8 @@ import {
   GPT_4_1_DISPLAY_NAME, 
   GPT_4_1_MODEL_NAME,
   GPT_5_2_MODEL_NAME,
+  GPT_5_3_CODEX_DISPLAY_NAME,
+  GPT_5_3_CODEX_MODEL_NAME,
   CLAUDE_HAIKU_MODEL_NAME,
   GEMINI_3_FLASH_MODEL_NAME,
   GEMINI_3_PRO_MODEL_NAME,
@@ -42,6 +44,7 @@ describe('ModelSelector', () => {
         models: [
           GPT_4_1_MODEL_NAME,
           GPT_5_2_MODEL_NAME,
+          GPT_5_3_CODEX_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_PRO_MODEL_NAME,
@@ -94,6 +97,30 @@ describe('ModelSelector', () => {
     });
   });
 
+  it('shows GPT 5.3 Codex in dropdown and calls onConfigChange when selected', async () => {
+    render(<ModelSelector onConfigChange={mockOnConfigChange} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+    });
+
+    const dropdown = screen.getByText(DEFAULT_MODEL).closest('.model-selector-dropdown');
+    if (!dropdown) throw new Error('Dropdown element not found');
+    fireEvent.click(dropdown);
+
+    const modelOptionsContainer = await waitFor(() => {
+      return screen.getByTestId('model-selector').querySelector('.model-options');
+    });
+    if (!modelOptionsContainer) throw new Error('Model options container not found');
+
+    const modelOption = within(modelOptionsContainer as HTMLElement).getByText(GPT_5_3_CODEX_DISPLAY_NAME);
+    fireEvent.click(modelOption);
+
+    expect(mockOnConfigChange).toHaveBeenCalledWith({
+      model: GPT_5_3_CODEX_MODEL_NAME
+    });
+  });
+
   it('defaults to default model when no storedConfig exists and GPT 4.1 is first in available models', async () => {
     // Mock models with GPT 4.1 first (simulating the bug scenario)
     mockRequestAPI.mockResolvedValue({
@@ -101,6 +128,7 @@ describe('ModelSelector', () => {
         models: [
           GPT_4_1_MODEL_NAME,
           GPT_5_2_MODEL_NAME,
+          GPT_5_3_CODEX_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_PRO_MODEL_NAME,

--- a/mito-ai/src/utils/models.ts
+++ b/mito-ai/src/utils/models.ts
@@ -15,6 +15,9 @@ export const GPT_4_1_MODEL_NAME = 'gpt-4.1';
 export const GPT_5_2_DISPLAY_NAME = 'GPT 5.2';
 export const GPT_5_2_MODEL_NAME = 'gpt-5.2';
 
+export const GPT_5_3_CODEX_DISPLAY_NAME = 'GPT 5.3 Codex';
+export const GPT_5_3_CODEX_MODEL_NAME = 'gpt-5.3-codex';
+
 export const GEMINI_3_FLASH_DISPLAY_NAME = 'Gemini 3 Flash';
 export const GEMINI_3_FLASH_MODEL_NAME = 'gemini-3-flash-preview';
 
@@ -40,6 +43,7 @@ export async function getAvailableModels(): Promise<string[]> {
         return [
             GPT_4_1_MODEL_NAME,
             GPT_5_2_MODEL_NAME,
+            GPT_5_3_CODEX_MODEL_NAME,
             CLAUDE_HAIKU_MODEL_NAME,
             GEMINI_3_FLASH_MODEL_NAME,
             GEMINI_3_PRO_MODEL_NAME,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive model-constant and UI selection wiring changes with test coverage; limited behavioral impact beyond model selection and a small OpenAI parameter tweak.
> 
> **Overview**
> Adds **GPT 5.3 Codex** as a selectable model across backend and frontend model lists, including OpenAI ordering and default model fallbacks.
> 
> Updates OpenAI request parameter building to apply `reasoning_effort="low"` for `gpt-5.3-codex`, and refines the UI model selector to better handle router-prefixed model IDs (LiteLLM/Abacus) by mapping display names to the actual returned model id. Tests are extended/updated to cover the new model and the adjusted OpenAI ordering assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5aa525dbb20a8072f08e544140c84245c13efe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->