### PR TITLE
[WIP] One-Click Install Scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -31,7 +31,7 @@ function Get-SystemPython {
     $p = Start-Process -FilePath $cmd.Source -ArgumentList @(
       '-c', 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'
     ) -Wait -PassThru -NoNewWindow
-    if ($p.ExitCode -eq 0) { return $name }
+    if ($p.ExitCode -eq 0) { return $cmd.Source }
   }
   return $null
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,7 +1,7 @@
 # Install Mito (mito-ai + mitosheet) into %USERPROFILE%\.mito\venv using uv.
 # Run from PowerShell: irm https://... | iex   OR   .\install.ps1
-# Requires: Windows. If execution policy blocks scripts, use:
-#   powershell -ExecutionPolicy Bypass -File .\install.ps1
+# If execution policy blocks scripts, use:
+# powershell -ExecutionPolicy Bypass -File .\install.ps1
 
 $ErrorActionPreference = 'Stop'
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,151 @@
+# Install Mito (mito-ai + mitosheet) into %USERPROFILE%\.mito\venv using uv.
+# Run from PowerShell: irm https://... | iex   OR   .\install.ps1
+# Requires: Windows. If execution policy blocks scripts, use:
+#   powershell -ExecutionPolicy Bypass -File .\install.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$MitoHome = if ($env:MITO_HOME) { $env:MITO_HOME } else { Join-Path $env:USERPROFILE '.mito' }
+$VenvPath = Join-Path $MitoHome 'venv'
+$BinDir = Join-Path $MitoHome 'bin'
+$MitoCli = Join-Path $BinDir 'mito.cmd'
+$MitoPythonVersion = if ($env:MITO_PYTHON_VERSION) { $env:MITO_PYTHON_VERSION } else { '3.11' }
+$Packages = @('mito-ai', 'mitosheet')
+
+function Write-Die {
+  param([string]$Message)
+  Write-Error "mito-install: $Message"
+  exit 1
+}
+
+function Test-Windows {
+  if ($env:OS -ne 'Windows_NT') {
+    Write-Die 'This installer only supports Windows. On other systems, use scripts/install.sh (macOS) or: python -m pip install mito-ai mitosheet'
+  }
+}
+
+function Get-SystemPython {
+  foreach ($name in @('python3', 'python')) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if (-not $cmd) { continue }
+    $p = Start-Process -FilePath $cmd.Source -ArgumentList @(
+      '-c', 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'
+    ) -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -eq 0) { return $name }
+  }
+  return $null
+}
+
+function Ensure-Uv {
+  if (Get-Command uv -ErrorAction SilentlyContinue) { return }
+
+  Write-Host 'uv not found; installing from astral.sh ...'
+  $localBin = Join-Path $env:USERPROFILE '.local\bin'
+  $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+  $env:Path = "$localBin;$cargoBin;$env:Path"
+
+  try {
+    Invoke-Expression (Invoke-RestMethod -Uri 'https://astral.sh/uv/install.ps1')
+  } catch {
+    Write-Warning "mito-install: uv install reported an error. Checking for uv ... ($($_.Exception.Message))"
+  }
+
+  if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Die 'uv is not on PATH after install. Add %USERPROFILE%\.local\bin to PATH and run this script again.'
+  }
+}
+
+function Install-Venv {
+  $pyExe = Join-Path $VenvPath 'Scripts\python.exe'
+
+  Write-Host "Creating virtual environment at $VenvPath ..."
+  if (Test-Path $VenvPath) {
+    Remove-Item -LiteralPath $VenvPath -Recurse -Force
+  }
+
+  if ($script:SystemPythonBin) {
+    & uv venv $VenvPath --python $script:SystemPythonBin --no-project
+  } else {
+    Write-Host "System Python 3.9+ not found; downloading Python $MitoPythonVersion via uv ..."
+    & uv venv $VenvPath --python $MitoPythonVersion --no-project
+  }
+
+  Write-Host "Installing $($Packages -join ' ') ..."
+  & uv pip install --no-config --python $pyExe @Packages
+}
+
+function Install-MitoCli {
+  $null = New-Item -ItemType Directory -Force -Path $BinDir
+
+  $jupyter = [System.IO.Path]::GetFullPath((Join-Path $VenvPath 'Scripts\jupyter.exe'))
+  $content = "@echo off`r`n`"$jupyter`" lab %*`r`n"
+  Set-Content -LiteralPath $MitoCli -Value $content -Encoding ASCII
+}
+
+function Add-MitoToUserPath {
+  $pathToAdd = [System.IO.Path]::GetFullPath($BinDir)
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $already = $false
+  if (-not [string]::IsNullOrEmpty($userPath)) {
+    foreach ($seg in $userPath -split ';') {
+      if ([string]::IsNullOrWhiteSpace($seg)) { continue }
+      try {
+        if ([System.IO.Path]::GetFullPath($seg.Trim()) -eq $pathToAdd) {
+          $already = $true
+          break
+        }
+      } catch { }
+    }
+  }
+  if (-not $already) {
+    if ([string]::IsNullOrEmpty($userPath)) {
+      [Environment]::SetEnvironmentVariable('Path', $pathToAdd, 'User')
+    } else {
+      [Environment]::SetEnvironmentVariable('Path', "$userPath;$pathToAdd", 'User')
+    }
+  }
+  $env:Path = "$pathToAdd;$env:Path"
+  return $true
+}
+
+function Write-Success {
+  $pathOk = $false
+  try {
+    $pathOk = Add-MitoToUserPath
+  } catch {
+    Write-Warning "mito-install: could not update user PATH: $($_.Exception.Message)"
+  }
+
+  Write-Host ''
+  Write-Host "Installed at: $VenvPath"
+  if ($pathOk) {
+    Write-Host 'User PATH was updated to include the Mito bin folder.'
+  }
+  Write-Host ''
+  Write-Host 'NEXT STEPS' -ForegroundColor Green
+  Write-Host ''
+  Write-Host 'Congratulations! Mito is installed. One last thing:'
+  Write-Host ''
+  Write-Host '1) Close and reopen your terminal (or sign out/in) so PATH picks up mito.'
+  Write-Host ''
+  Write-Host '2) You can then launch Mito at any time by running:'
+  Write-Host '   mito' -ForegroundColor Cyan
+  Write-Host ''
+  if (-not $pathOk) {
+    Write-Host 'If mito is not found, add this folder to your PATH (one-time):'
+    Write-Host "  $BinDir"
+    Write-Host ''
+  }
+}
+
+function Main {
+  Test-Windows
+  $script:SystemPythonBin = Get-SystemPython
+
+  Ensure-Uv
+  Install-Venv
+  Install-MitoCli
+  Write-Success
+}
+
+Main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Install Mito (mito-ai + mitosheet) on macOS into ~/.mito/venv via pip.
+#
+# One-liner (after this file is hosted):
+#   curl -fsSL https://raw.githubusercontent.com/mito-ds/monorepo/main/scripts/install.sh | bash
+#
+# Custom install root (default ~/.mito):
+#   MITO_HOME="$HOME/my-mito" curl -fsSL ... | bash
+
+set -euo pipefail
+
+MITO_HOME="${MITO_HOME:-$HOME/.mito}"
+VENV_PATH="${MITO_HOME}/venv"
+PACKAGES=(mito-ai mitosheet)
+
+die() {
+  echo "mito-install: $*" >&2
+  exit 1
+}
+
+is_macos() {
+  [[ "$(uname -s)" == "Darwin" ]]
+}
+
+have_python3() {
+  command -v python3 >/dev/null 2>&1
+}
+
+python_ok_version() {
+  python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'
+}
+
+venv_install() {
+  local py="$1"
+  echo "Creating virtual environment at ${VENV_PATH} ..."
+  "${py}" -m venv --clear "${VENV_PATH}"
+  "${VENV_PATH}/bin/python" -m pip install --upgrade pip --quiet
+  echo "Installing ${PACKAGES[*]} ..."
+  "${VENV_PATH}/bin/pip" install "${PACKAGES[@]}"
+}
+
+print_success() {
+  cat <<EOF
+
+Mito is installed in: ${VENV_PATH}
+
+  To use it in this terminal:
+    source ${VENV_PATH}/bin/activate
+    jupyter lab
+
+  Or run Jupyter without activating (one line):
+    ${VENV_PATH}/bin/jupyter lab
+
+  To add jupyter to your PATH for new shells (zsh), you can add:
+    export PATH="${VENV_PATH}/bin:\$PATH"
+EOF
+}
+
+main() {
+  is_macos || die "This installer only supports macOS. On other systems, run: python3 -m pip install mito-ai mitosheet"
+
+  have_python3 || die "Python 3 is required. Install it from https://www.python.org/downloads/macos/ or use Homebrew: brew install python"
+
+  python_ok_version || die "Python 3.9 or newer is required."
+
+  venv_install python3
+  print_success
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,16 +64,50 @@ EOF
   chmod +x "${MITO_CLI_BIN}"
 }
 
-print_success() {
-  local rc_file bold reset cyan
+# Login-shell rc file for PATH (bash vs zsh), same as print_success / docs.
+shell_rc_file() {
   case "$(basename "${SHELL:-/bin/zsh}")" in
     bash)
-      rc_file="${HOME}/.bash_profile"
+      echo "${HOME}/.bash_profile"
       ;;
     *)
-      rc_file="${HOME}/.zprofile"
+      echo "${HOME}/.zprofile"
       ;;
   esac
+}
+
+# Append Mito bin to PATH in the rc file and try to source it in this bash process.
+# Returns 0 if PATH is configured (already or just written), 1 if we could not write the file.
+apply_path_to_rc() {
+  local rc_file
+  rc_file="$(shell_rc_file)"
+
+  if [[ -f "${rc_file}" ]] && grep -qF "${MITO_HOME}/bin" "${rc_file}" 2>/dev/null; then
+    export PATH="${MITO_HOME}/bin:${PATH}"
+    return 0
+  fi
+
+  if ! printf 'export PATH="%s/bin:$PATH"\n' "${MITO_HOME}" >> "${rc_file}" 2>/dev/null; then
+    return 1
+  fi
+
+  set +e
+  # shellcheck disable=1090
+  source "${rc_file}" 2>/dev/null
+  local src=$?
+  set -e
+  if [[ "${src}" -ne 0 ]]; then
+    echo "mito-install: could not source ${rc_file} from bash (often fine for zsh-only files). Open a new terminal or run: source ${rc_file}" >&2
+  fi
+  export PATH="${MITO_HOME}/bin:${PATH}"
+  return 0
+}
+
+print_success() {
+  local rc_file bold reset cyan dim path_ok
+  rc_file="$(shell_rc_file)"
+  path_ok=1
+  apply_path_to_rc || path_ok=0
 
   if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
     bold=$'\033[1m'
@@ -98,9 +132,14 @@ print_success() {
   printf '%s\n' "    Run JupyterLab:"
   printf '%s\n' "      ${MITO_CLI_BIN}"
   printf '\n'
-  printf '%s\n' "    Add the mito command to your PATH (paste both lines):"
-  printf "      echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
-  printf '      source %s\n' "${rc_file}"
+  if [[ "${path_ok}" -eq 1 ]]; then
+    printf '%s\n' "    ${bold}PATH${reset} was updated in ${rc_file}."
+    printf '%s\n' "    Open a ${bold}new terminal${reset}, or in this one run: ${bold}source ${rc_file}${reset}  then: ${bold}mito${reset}"
+  else
+    printf '%s\n' "    Add the mito command to your PATH (paste both lines):"
+    printf "      echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
+    printf '      source %s\n' "${rc_file}"
+  fi
   printf '\n'
   printf '%s\n' "${dim}  Installed at: ${VENV_PATH}${reset}"
   printf '\n'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,6 +109,19 @@ print_success() {
   path_ok=1
   apply_path_to_rc || path_ok=0
 
+  local green cyan bold reset
+  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    bold=$'\033[1m'
+    reset=$'\033[0m'
+    green=$'\033[32m'
+    cyan=$'\033[36m'
+  else
+    bold=''
+    reset=''
+    green=''
+    cyan=''
+  fi
+
   printf '\n'
   printf 'Installed at: %s\n' "${VENV_PATH}"
   if [[ "${path_ok}" -eq 1 ]]; then
@@ -116,18 +129,18 @@ print_success() {
   fi
   printf '\n'
 
-  printf 'NEXT STEPS\n'
+  printf '%sNEXT STEPS%s\n' "${green}" "${reset}"
   printf '\n'
 
-  printf 'Congratulations! Mito is installed. Just last thing:\n'
+  printf 'Congratulations! Mito is installed. One last thing:\n'
   printf '\n'
 
   printf '1) Copy-and-paste this command to complete installation:\n'
-  printf '   source %s\n' "${rc_file}"
+  printf '   %ssource %s%s\n' "${cyan}" "${rc_file}" "${reset}"
   printf '\n'
 
   printf '2) You can now launch Mito at any time by running:\n'
-  printf '   mito\n'
+  printf '   %smito%s\n' "${bold}${cyan}" "${reset}"
   printf '\n'
 
   if [[ "${path_ok}" -ne 1 ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,7 +156,8 @@ main() {
   # Prefer an existing system python3 >= 3.9, but fall back to a uv-managed Python
   # download if the system checks fail (so we don't hard-require python3).
   if have_python3 && python_ok_version; then
-    SYSTEM_PYTHON_BIN="python3"
+    # Resolve now so ensure_uv()'s PATH prepends cannot change which python3 uv uses.
+    SYSTEM_PYTHON_BIN="$(command -v python3)"
   else
     unset SYSTEM_PYTHON_BIN
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,37 +51,26 @@ EOF
 }
 
 print_success() {
+  local rc_file
+  case "$(basename "${SHELL:-/bin/zsh}")" in
+    bash)
+      rc_file="${HOME}/.bash_profile"
+      ;;
+    *)
+      rc_file="${HOME}/.zprofile"
+      ;;
+  esac
+
   cat <<EOF
 
-Mito is installed in: ${VENV_PATH}
-CLI wrapper: ${MITO_CLI_BIN}
+Mito is installed in ${VENV_PATH}.
 
-==> Next steps
+Run JupyterLab:
+  ${MITO_CLI_BIN}
 
-  Run JupyterLab without changing your PATH (always works):
-    ${MITO_CLI_BIN}
-
-  Add the mito command to your PATH (zsh — copy and paste both lines):
-
-    echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ~/.zprofile
-    source ~/.zprofile
-
-  If your shell does not load ~/.zprofile, use ~/.zshrc instead of ~/.zprofile in those two lines.
-
-  If you use bash instead of zsh:
-
-    echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ~/.bash_profile
-    source ~/.bash_profile
-
-  Then in a new terminal:
-    mito
-
-  Same as:
-    ${VENV_PATH}/bin/jupyter lab
-
-  Or activate the venv first:
-    source ${VENV_PATH}/bin/activate
-    jupyter lab
+To use the mito command from your terminal, add it to your PATH (paste both lines):
+  echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ${rc_file}
+  source ${rc_file}
 EOF
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -118,8 +118,9 @@ print_success() {
   fi
 
   printf '\n'
+  printf 'Installed at: %s\n' "${VENV_PATH}"
   if [[ "${path_ok}" -eq 1 ]]; then
-    printf 'PATH was updated in %s.\n' "${rc_file}"
+    printf 'PATH was updated in %s\n' "${rc_file}"
     printf '\n'
   fi
   printf '%sNext steps%s\n' "${bold}" "${reset}"
@@ -133,8 +134,6 @@ print_success() {
     printf "    echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
     printf '    source %s\n' "${rc_file}"
   fi
-  printf '\n'
-  printf 'Installed at: %s\n' "${VENV_PATH}"
   printf '\n'
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 MITO_HOME="${MITO_HOME:-$HOME/.mito}"
 VENV_PATH="${MITO_HOME}/venv"
 MITO_CLI_BIN="${MITO_HOME}/bin/mito"
+MITO_PYTHON_VERSION="${MITO_PYTHON_VERSION:-3.11}"
 PACKAGES=(mito-ai mitosheet)
 
 die() {
@@ -43,7 +44,12 @@ ensure_uv() {
 venv_install() {
   echo "Creating virtual environment at ${VENV_PATH} ..."
   rm -rf "${VENV_PATH}"
-  uv venv "${VENV_PATH}" --python python3 --no-project
+  if [[ -n "${SYSTEM_PYTHON_BIN:-}" ]]; then
+    uv venv "${VENV_PATH}" --python "${SYSTEM_PYTHON_BIN}" --no-project
+  else
+    echo "System python3 not available (or <3.9); downloading Python ${MITO_PYTHON_VERSION} via uv ..."
+    uv venv "${VENV_PATH}" --python "${MITO_PYTHON_VERSION}" --no-project
+  fi
   echo "Installing ${PACKAGES[*]} ..."
   uv pip install --no-config --python "${VENV_PATH}/bin/python" "${PACKAGES[@]}"
 }
@@ -147,10 +153,13 @@ print_success() {
 
 main() {
   is_macos || die "This installer only supports macOS. On other systems, run: python3 -m pip install mito-ai mitosheet"
-
-  have_python3 || die "Python 3 is required. Install it from https://www.python.org/downloads/macos/ or use Homebrew: brew install python"
-
-  python_ok_version || die "Python 3.9 or newer is required."
+  # Prefer an existing system python3 >= 3.9, but fall back to a uv-managed Python
+  # download if the system checks fail (so we don't hard-require python3).
+  if have_python3 && python_ok_version; then
+    SYSTEM_PYTHON_BIN="python3"
+  else
+    unset SYSTEM_PYTHON_BIN
+  fi
 
   ensure_uv
   venv_install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # Install Mito (mito-ai + mitosheet) on macOS into ~/.mito/venv using uv (https://github.com/astral-sh/uv).
-#
-# One-liner (after this file is hosted):
-#   curl -fsSL https://raw.githubusercontent.com/mito-ds/monorepo/main/scripts/install.sh | bash
-#
-# Custom install root (default ~/.mito):
-#   MITO_HOME="$HOME/my-mito" curl -fsSL ... | bash
 
 set -euo pipefail
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,7 +81,7 @@ apply_path_to_rc() {
     return 0
   fi
 
-  if ! printf 'export PATH="%s/bin:$PATH"\n' "${MITO_HOME}" >> "${rc_file}" 2>/dev/null; then
+  if ! printf '\nexport PATH="%s/bin:$PATH"\n' "${MITO_HOME}" >> "${rc_file}" 2>/dev/null; then
     return 1
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,7 +65,7 @@ EOF
 }
 
 print_success() {
-  local rc_file
+  local rc_file bold reset cyan
   case "$(basename "${SHELL:-/bin/zsh}")" in
     bash)
       rc_file="${HOME}/.bash_profile"
@@ -75,17 +75,35 @@ print_success() {
       ;;
   esac
 
-  cat <<EOF
+  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    bold=$'\033[1m'
+    reset=$'\033[0m'
+    cyan=$'\033[36m'
+    dim=$'\033[2m'
+  else
+    bold=''
+    reset=''
+    cyan=''
+    dim=''
+  fi
 
-Mito is installed in ${VENV_PATH}.
-
-Run JupyterLab:
-  ${MITO_CLI_BIN}
-
-To use the mito command from your terminal, add it to your PATH (paste both lines):
-  echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ${rc_file}
-  source ${rc_file}
-EOF
+  # Visually distinct "next steps" block (colors disabled when NO_COLOR is set or stdout is not a TTY).
+  printf '\n'
+  printf '%s\n' "${cyan}${bold}  ────────────────────────────────────────────────────────────────${reset}"
+  printf '\n'
+  printf '%s    %sNext steps%s\n' "${cyan}" "${bold}" "${reset}"
+  printf '\n'
+  printf '%s\n' "${cyan}${bold}  ────────────────────────────────────────────────────────────────${reset}"
+  printf '\n'
+  printf '%s\n' "    Run JupyterLab:"
+  printf '%s\n' "      ${MITO_CLI_BIN}"
+  printf '\n'
+  printf '%s\n' "    Add the mito command to your PATH (paste both lines):"
+  printf "      echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
+  printf '      source %s\n' "${rc_file}"
+  printf '\n'
+  printf '%s\n' "${dim}  Installed at: ${VENV_PATH}${reset}"
+  printf '\n'
 }
 
 main() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,37 +104,38 @@ apply_path_to_rc() {
 }
 
 print_success() {
-  local rc_file bold reset path_ok
+  local rc_file path_ok
   rc_file="$(shell_rc_file)"
   path_ok=1
   apply_path_to_rc || path_ok=0
 
-  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
-    bold=$'\033[1m'
-    reset=$'\033[0m'
-  else
-    bold=''
-    reset=''
-  fi
-
   printf '\n'
   printf 'Installed at: %s\n' "${VENV_PATH}"
   if [[ "${path_ok}" -eq 1 ]]; then
-    printf 'PATH was updated in %s\n' "${rc_file}"
+    printf 'PATH was updated in %s.\n' "${rc_file}"
+  fi
+  printf '\n'
+
+  printf 'NEXT STEPS\n'
+  printf '\n'
+
+  printf 'Congratulations! Mito is installed. Just last thing:\n'
+  printf '\n'
+
+  printf '1) Copy-and-paste this command to complete installation:\n'
+  printf '   source %s\n' "${rc_file}"
+  printf '\n'
+
+  printf '2) You can now launch Mito at any time by running:\n'
+  printf '   mito\n'
+  printf '\n'
+
+  if [[ "${path_ok}" -ne 1 ]]; then
+    printf 'If `mito` is not found, add it to your PATH (one-time):\n'
+    printf "  echo 'export PATH=\"%s/bin:\\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
+    printf "  source %s\n" "${rc_file}"
     printf '\n'
   fi
-  printf '%sNext steps%s\n' "${bold}" "${reset}"
-  printf '\n'
-  if [[ "${path_ok}" -eq 1 ]]; then
-    printf '%s\n' "  Run these in your terminal:"
-    printf '  %ssource %s%s\n' "${bold}" "${rc_file}" "${reset}"
-    printf '  %smito%s\n' "${bold}" "${reset}"
-  else
-    printf '%s\n' "  Paste both lines into your terminal to add mito to your PATH:"
-    printf "    echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
-    printf '    source %s\n' "${rc_file}"
-  fi
-  printf '\n'
 }
 
 main() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install Mito (mito-ai + mitosheet) on macOS into ~/.mito/venv using uv (https://github.com/astral-sh/uv).
+# Install Mito (mito-ai + mitosheet) into ~/.mito/venv using uv.
 
 set -euo pipefail
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 MITO_HOME="${MITO_HOME:-$HOME/.mito}"
 VENV_PATH="${MITO_HOME}/venv"
+MITO_CLI_BIN="${MITO_HOME}/bin/mito"
 PACKAGES=(mito-ai mitosheet)
 
 die() {
@@ -39,20 +40,48 @@ venv_install() {
   "${VENV_PATH}/bin/pip" install "${PACKAGES[@]}"
 }
 
+install_mito_cli() {
+  mkdir -p "${MITO_HOME}/bin"
+  cat > "${MITO_CLI_BIN}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${VENV_PATH}/bin/jupyter" lab "\$@"
+EOF
+  chmod +x "${MITO_CLI_BIN}"
+}
+
 print_success() {
   cat <<EOF
 
 Mito is installed in: ${VENV_PATH}
+CLI wrapper: ${MITO_CLI_BIN}
 
-  To use it in this terminal:
-    source ${VENV_PATH}/bin/activate
-    jupyter lab
+==> Next steps
 
-  Or run Jupyter without activating (one line):
+  Run JupyterLab without changing your PATH (always works):
+    ${MITO_CLI_BIN}
+
+  Add the mito command to your PATH (zsh — copy and paste both lines):
+
+    echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ~/.zprofile
+    source ~/.zprofile
+
+  If your shell does not load ~/.zprofile, use ~/.zshrc instead of ~/.zprofile in those two lines.
+
+  If you use bash instead of zsh:
+
+    echo 'export PATH="${MITO_HOME}/bin:\$PATH"' >> ~/.bash_profile
+    source ~/.bash_profile
+
+  Then in a new terminal:
+    mito
+
+  Same as:
     ${VENV_PATH}/bin/jupyter lab
 
-  To add jupyter to your PATH for new shells (zsh), you can add:
-    export PATH="${VENV_PATH}/bin:\$PATH"
+  Or activate the venv first:
+    source ${VENV_PATH}/bin/activate
+    jupyter lab
 EOF
 }
 
@@ -64,6 +93,7 @@ main() {
   python_ok_version || die "Python 3.9 or newer is required."
 
   venv_install python3
+  install_mito_cli
   print_success
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install Mito (mito-ai + mitosheet) on macOS into ~/.mito/venv via pip.
+# Install Mito (mito-ai + mitosheet) on macOS into ~/.mito/venv using uv (https://github.com/astral-sh/uv).
 #
 # One-liner (after this file is hosted):
 #   curl -fsSL https://raw.githubusercontent.com/mito-ds/monorepo/main/scripts/install.sh | bash
@@ -31,13 +31,24 @@ python_ok_version() {
   python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)'
 }
 
+# Ensure uv is on PATH (installs via Astral's script if missing).
+ensure_uv() {
+  if command -v uv >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "uv not found; installing from astral.sh ..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Install script usually places uv under ~/.local/bin or ~/.cargo/bin.
+  export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
+  command -v uv >/dev/null 2>&1 || die "uv was installed but is not on PATH. Open a new terminal and run this script again, or add ~/.local/bin to PATH."
+}
+
 venv_install() {
-  local py="$1"
   echo "Creating virtual environment at ${VENV_PATH} ..."
-  "${py}" -m venv --clear "${VENV_PATH}"
-  "${VENV_PATH}/bin/python" -m pip install --upgrade pip --quiet
+  rm -rf "${VENV_PATH}"
+  uv venv "${VENV_PATH}" --python python3 --no-project
   echo "Installing ${PACKAGES[*]} ..."
-  "${VENV_PATH}/bin/pip" install "${PACKAGES[@]}"
+  uv pip install --no-config --python "${VENV_PATH}/bin/python" "${PACKAGES[@]}"
 }
 
 install_mito_cli() {
@@ -81,7 +92,8 @@ main() {
 
   python_ok_version || die "Python 3.9 or newer is required."
 
-  venv_install python3
+  ensure_uv
+  venv_install
   install_mito_cli
   print_success
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,10 +37,13 @@ ensure_uv() {
     return 0
   fi
   echo "uv not found; installing from astral.sh ..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  # Install script usually places uv under ~/.local/bin or ~/.cargo/bin.
   export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
-  command -v uv >/dev/null 2>&1 || die "uv was installed but is not on PATH. Open a new terminal and run this script again, or add ~/.local/bin to PATH."
+  # The official installer can exit non-zero after copying uv (e.g. receipt write fails with
+  # "Permission denied" under ~/.config/uv). If `uv` is on PATH, we continue anyway.
+  if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+    echo "mito-install: uv install script reported an error (often ~/.config permissions). Checking for uv ..." >&2
+  fi
+  command -v uv >/dev/null 2>&1 || die "uv is not on PATH after install. Fix permissions on ~/.config if needed, or add ~/.local/bin to PATH and run this script again."
 }
 
 venv_install() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,14 +97,14 @@ apply_path_to_rc() {
   local src=$?
   set -e
   if [[ "${src}" -ne 0 ]]; then
-    echo "mito-install: could not source ${rc_file} from bash (often fine for zsh-only files). Open a new terminal or run: source ${rc_file}" >&2
+    echo "mito-install: could not source ${rc_file} from bash (often fine for zsh-only files). Run: source ${rc_file}" >&2
   fi
   export PATH="${MITO_HOME}/bin:${PATH}"
   return 0
 }
 
 print_success() {
-  local rc_file bold reset cyan dim path_ok
+  local rc_file bold reset path_ok
   rc_file="$(shell_rc_file)"
   path_ok=1
   apply_path_to_rc || path_ok=0
@@ -112,36 +112,29 @@ print_success() {
   if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
     bold=$'\033[1m'
     reset=$'\033[0m'
-    cyan=$'\033[36m'
-    dim=$'\033[2m'
   else
     bold=''
     reset=''
-    cyan=''
-    dim=''
   fi
 
-  # Visually distinct "next steps" block (colors disabled when NO_COLOR is set or stdout is not a TTY).
-  printf '\n'
-  printf '%s\n' "${cyan}${bold}  ────────────────────────────────────────────────────────────────${reset}"
-  printf '\n'
-  printf '%s    %sNext steps%s\n' "${cyan}" "${bold}" "${reset}"
-  printf '\n'
-  printf '%s\n' "${cyan}${bold}  ────────────────────────────────────────────────────────────────${reset}"
-  printf '\n'
-  printf '%s\n' "    Run JupyterLab:"
-  printf '%s\n' "      ${MITO_CLI_BIN}"
   printf '\n'
   if [[ "${path_ok}" -eq 1 ]]; then
-    printf '%s\n' "    ${bold}PATH${reset} was updated in ${rc_file}."
-    printf '%s\n' "    Open a ${bold}new terminal${reset}, or in this one run: ${bold}source ${rc_file}${reset}  then: ${bold}mito${reset}"
+    printf 'PATH was updated in %s.\n' "${rc_file}"
+    printf '\n'
+  fi
+  printf '%sNext steps%s\n' "${bold}" "${reset}"
+  printf '\n'
+  if [[ "${path_ok}" -eq 1 ]]; then
+    printf '%s\n' "  Run these in your terminal:"
+    printf '  %ssource %s%s\n' "${bold}" "${rc_file}" "${reset}"
+    printf '  %smito%s\n' "${bold}" "${reset}"
   else
-    printf '%s\n' "    Add the mito command to your PATH (paste both lines):"
-    printf "      echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
-    printf '      source %s\n' "${rc_file}"
+    printf '%s\n' "  Paste both lines into your terminal to add mito to your PATH:"
+    printf "    echo 'export PATH=\"%s/bin:\$PATH\"' >> %s\n" "${MITO_HOME}" "${rc_file}"
+    printf '    source %s\n' "${rc_file}"
   fi
   printf '\n'
-  printf '%s\n' "${dim}  Installed at: ${VENV_PATH}${reset}"
+  printf 'Installed at: %s\n' "${VENV_PATH}"
   printf '\n'
 }
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Development-only: undo a local install.sh run so you can test again.
+# Removes the venv, the mito CLI wrapper, and PATH lines that point at *mito/bin.
+# Does NOT remove the ~/.mito directory itself (only selected contents).
+#
+#   MITO_HOME=~/.mito bash scripts/reset-mito-dev.sh
+
+set -euo pipefail
+
+MITO_HOME="${MITO_HOME:-$HOME/.mito}"
+VENV_PATH="${MITO_HOME}/venv"
+MITO_CLI_BIN="${MITO_HOME}/bin/mito"
+
+strip_mito_path_lines() {
+  local f="$1"
+  [[ -f "$f" ]] || return 0
+  local tmp
+  tmp="$(mktemp)"
+  # Lines from install.sh look like: export PATH=".../mito.../bin:$PATH"
+  awk '!/^[[:space:]]*export[[:space:]]+PATH=.*mito\/bin/' "${f}" > "${tmp}"
+  mv "${tmp}" "${f}"
+}
+
+echo "MITO_HOME=${MITO_HOME}"
+
+if [[ -d "${VENV_PATH}" ]]; then
+  echo "Removing venv: ${VENV_PATH}"
+  rm -rf "${VENV_PATH}"
+fi
+
+if [[ -f "${MITO_CLI_BIN}" ]]; then
+  echo "Removing CLI: ${MITO_CLI_BIN}"
+  rm -f "${MITO_CLI_BIN}"
+fi
+
+if [[ -d "${MITO_HOME}/bin" ]] && [[ -z "$(ls -A "${MITO_HOME}/bin" 2>/dev/null)" ]]; then
+  rmdir "${MITO_HOME}/bin" 2>/dev/null || true
+fi
+
+for rc in "${HOME}/.zprofile" "${HOME}/.zshrc" "${HOME}/.bash_profile"; do
+  if [[ -f "${rc}" ]] && grep -qE 'export[[:space:]]+PATH=.*mito/bin' "${rc}" 2>/dev/null; then
+    echo "Stripping mito PATH lines from: ${rc}"
+    strip_mito_path_lines "${rc}"
+  fi
+done
+
+echo "Done. The ${MITO_HOME} directory was kept (only venv / bin/mito / PATH lines were cleared)."


### PR DESCRIPTION
# Description

Added scripts so that users can install Mito with one command, similar to bun and uv:

```bash
curl -fsSL https://trymito.io/install | bash
```

The URL above is just an example. The script will take care of:

1. Checking and getting the right version of Python if need (using uv).
2. Setting up a virtual environment.
3. Downloading the pip packages.
4. Adding the `mito` command to the terminal. 

# Testing

Run the install script, make sure the instructions are clear. 

# Documentation

Yes, this is a new download method. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new shell installers that download tooling (`uv`), create/remove a local Python venv, and modify users’ shell rc files, which can fail or have side effects on developer machines if the PATH edit logic is wrong.
> 
> **Overview**
> Adds `scripts/install.sh` to provide a **one-command macOS installer** that ensures `uv` is available (installing it if missing), creates `~/.mito/venv`, installs `mito-ai` + `mitosheet`, and writes a `~/.mito/bin/mito` wrapper that launches `jupyter lab`.
> 
> The installer also **updates the user’s shell rc** (`.zprofile` or `.bash_profile`) to add `~/.mito/bin` to `PATH` and prints post-install next steps.
> 
> Adds `scripts/uninstall.sh` (dev-only) to remove the venv and CLI wrapper and strip previously-added `mito/bin` PATH lines from common rc files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d11a46f6cc1efcb2ebbdbdafe63b18c80e8b1013. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->