### PR TITLE
Give Chat Mode full notebook context

### DIFF
--- a/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
+++ b/mito-ai/mito_ai/completions/completion_handlers/chat_completion_handler.py
@@ -35,21 +35,22 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
         
         # Create the prompt
         prompt = create_chat_prompt(
-            metadata.variables or [], 
+            metadata.variables or [],
             metadata.files or [],
-            metadata.activeCellCode, 
+            metadata.activeCellCode,
             metadata.activeCellId,
             metadata.base64EncodedActiveCellOutput is not None and metadata.base64EncodedActiveCellOutput != '',
             metadata.input,
-            metadata.additionalContext
+            metadata.additionalContext,
+            metadata.aiOptimizedCells
         )
         display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.input}"
-        
+
         # Add the prompt to the message history
         new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.additionalContext)
         new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider, metadata.threadId)
-        
+
         # Get the completion (non-streaming)
         completion = await provider.request_completions(
             messages=message_history.get_ai_optimized_history(metadata.threadId), 
@@ -96,21 +97,22 @@ class ChatCompletionHandler(CompletionHandler[ChatMessageMetadata]):
         
         # Create the prompt
         prompt = create_chat_prompt(
-            metadata.variables or [], 
+            metadata.variables or [],
             metadata.files or [],
-            metadata.activeCellCode, 
+            metadata.activeCellCode,
             metadata.activeCellId,
             metadata.base64EncodedActiveCellOutput is not None and metadata.base64EncodedActiveCellOutput != '',
             metadata.input,
-            metadata.additionalContext
+            metadata.additionalContext,
+            metadata.aiOptimizedCells
         )
         display_prompt = f"```python{metadata.activeCellCode or ''}```{metadata.input}"
-        
+
         # Add the prompt to the message history
         new_ai_optimized_message = create_ai_optimized_message(prompt, metadata.base64EncodedActiveCellOutput, metadata.additionalContext)
         new_display_optimized_message: ChatCompletionMessageParam = {"role": "user", "content": display_prompt}
         await message_history.append_message(new_ai_optimized_message, new_display_optimized_message, provider, metadata.threadId)
-        
+
         # Stream the completions using the provider's stream method
         accumulated_response = await provider.stream_completions(
             message_type=MessageType.CHAT,

--- a/mito-ai/mito_ai/completions/models.py
+++ b/mito-ai/mito_ai/completions/models.py
@@ -95,10 +95,11 @@ class ChatMessageMetadata():
     promptType: Literal['chat']
     threadId: ThreadID
     input: str
-    activeCellCode: str 
+    activeCellCode: str
     activeCellId: str
     variables: Optional[List[str]] = None
     files: Optional[List[str]] = None
+    aiOptimizedCells: Optional[List[AIOptimizedCell]] = None
     base64EncodedActiveCellOutput: Optional[str] = None
     index: Optional[int] = None
     stream: bool = False

--- a/mito-ai/mito_ai/completions/prompt_builders/chat_prompt.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_prompt.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 from typing import List, Optional, Dict
+from mito_ai.completions.models import AIOptimizedCell
 from mito_ai.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai.completions.prompt_builders.prompt_section_registry.base import PromptSection
 
@@ -14,6 +15,7 @@ def create_chat_prompt(
     has_active_cell_output: bool,
     input: str,
     additional_context: Optional[List[Dict[str, str]]] = None,
+    ai_optimized_cells: Optional[List[AIOptimizedCell]] = None,
 ) -> str:
     sections: List[PromptSection] = [
         SG.Rules(additional_context),
@@ -21,11 +23,12 @@ def create_chat_prompt(
         SG.Files(files),
         SG.Variables(variables),
         SG.SelectedContext(additional_context),
+        SG.Notebook(ai_optimized_cells or []),
         SG.ActiveCellId(active_cell_id),
         SG.ActiveCellCode(active_cell_code),
         SG.ActiveCellOutput(has_active_cell_output),
         SG.Task(input),
     ]
-    
+
     prompt = Prompt(sections)
     return str(prompt)

--- a/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatHistoryManager.tsx
@@ -154,6 +154,8 @@ export class ChatHistoryManager {
     async addChatInputMessage(input: string, activeThreadId: string, messageIndex?: number, additionalContext?: Array<{type: string, value: string}>): Promise<IChatMessageMetadata> {
         const activeCellCode = getActiveCellCode(this.notebookTracker) || ''
         const activeCellID = getActiveCellID(this.notebookTracker) || ''
+        const notebookPanel = this.notebookTracker.currentWidget
+        const aiOptimizedCells = getAIOptimizedCellsInNotebookPanel(notebookPanel)
 
         const activeNotebookContext = this.contextManager.getActiveNotebookContext();
         const chatMessageMetadata: IChatMessageMetadata = {
@@ -162,6 +164,7 @@ export class ChatHistoryManager {
             files: activeNotebookContext?.files || [],
             activeCellCode: activeCellCode,
             activeCellId: activeCellID,
+            aiOptimizedCells: aiOptimizedCells,
             input: input,
             threadId: activeThreadId,
             index: messageIndex,

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -488,7 +488,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
             if (!hasActiveCellContext || !hasNotebookContext) {
                 setAdditionalContext(prev => {
-                    let updated = [...prev];
+                    const updated = [...prev];
                     if (!hasActiveCellContext) {
                         updated.push({
                             type: 'active_cell',

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -473,24 +473,32 @@ const ChatInput: React.FC<ChatInputProps> = ({
         }
     };
 
-    // Automatically add active cell context when in Chat mode and there's active cell code
+    // Automatically add context items based on mode
     useEffect(() => {
         if (!agentModeEnabled) {
-            // Check if active cell context is already present
+            // Chat mode: include both active cell and notebook context
             const hasActiveCellContext = additionalContext.some(context => context.type === 'active_cell');
-
-            if (!hasActiveCellContext) {
-                setAdditionalContext(prev => [...prev, {
-                    type: 'active_cell',
-                    value: 'Active Cell',
-                    display: 'Active Cell'
-                }]);
-            }
-
-            // Remove the current notebook context item
             const hasNotebookContext = additionalContext.some(context => context.type === 'notebook');
-            if (hasNotebookContext) {
-                setAdditionalContext(prev => prev.filter(context => context.type !== 'notebook'));
+
+            if (!hasActiveCellContext || !hasNotebookContext) {
+                setAdditionalContext(prev => {
+                    let updated = [...prev];
+                    if (!hasActiveCellContext) {
+                        updated.push({
+                            type: 'active_cell',
+                            value: 'Active Cell',
+                            display: 'Active Cell'
+                        });
+                    }
+                    if (!hasNotebookContext) {
+                        updated.push({
+                            type: 'notebook',
+                            value: 'Notebook',
+                            display: 'Notebook'
+                        });
+                    }
+                    return updated;
+                });
             }
         } else if (agentModeEnabled) {
             // Remove active cell context when in agent mode

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -248,7 +248,7 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                 {message.role === 'user' && additionalContext && additionalContext.length > 0 &&
                                     <>
                                         {additionalContext
-                                            .filter(context => context.type !== 'active_cell') // Hide active cell context in chat messages
+                                            .filter(context => context.type !== 'active_cell' && context.type !== 'notebook') // Hide default context items in chat messages
                                             .map((context, index) => (
                                                 <SelectedContextContainer
                                                     key={`${context.type}-${context.value}-${index}`}

--- a/mito-ai/src/components/SelectedContextContainer.tsx
+++ b/mito-ai/src/components/SelectedContextContainer.tsx
@@ -117,7 +117,7 @@ const SelectedContextContainer: React.FC<SelectedContextContainerProps> = ({
         } else if (type === 'file') {
             return `The path ${title} will be shared with the AI`;
         } else if (type === 'notebook') {
-            return "The AI will be able to read all of the code and markdown in your notebook. It is included by default in Agent mode.";
+            return "The AI will be able to read all of the code and markdown in your notebook. It is included by default.";
         } else if (type === 'active_cell') {
             return "The AI will write its code based on the currently active cell. It is included by default in Chat mode.";
         } else if (type === 'cell') {

--- a/mito-ai/src/tests/AiChat/ChatInput.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatInput.test.tsx
@@ -205,7 +205,8 @@ describe('ChatInput Component', () => {
 
             // Verify handleSubmitUserMessage was called with the input content
             expect(handleSubmitUserMessageMock).toHaveBeenCalledWith(testMessage, undefined, [
-                { type: 'active_cell', value: 'Active Cell' }
+                { type: 'active_cell', value: 'Active Cell' },
+                { type: 'notebook', value: 'Notebook' }
             ]);
 
             // Verify the input was cleared
@@ -319,7 +320,8 @@ describe('ChatInput Component', () => {
 
             // Verify handleSubmitUserMessage was called
             expect(idleHandleSubmitMock).toHaveBeenCalledWith(testMessage, undefined, [
-                { type: 'active_cell', value: 'Active Cell' }
+                { type: 'active_cell', value: 'Active Cell' },
+                { type: 'notebook', value: 'Notebook' }
             ]);
         });
     });
@@ -366,7 +368,8 @@ describe('ChatInput Component', () => {
 
             // Verify handleSubmitUserMessage was called with the updated content
             expect(editHandleSubmitMock).toHaveBeenCalledWith(updatedContent, undefined, [
-                { type: 'active_cell', value: 'Active Cell' }
+                { type: 'active_cell', value: 'Active Cell' },
+                { type: 'notebook', value: 'Notebook' }
             ]);
         });
 
@@ -835,20 +838,16 @@ describe('ChatInput Component', () => {
             jest.clearAllMocks();
         });
 
-        it('shows active cell context automatically in Chat mode when there is active cell code', () => {
+        it('shows active cell and notebook context automatically in Chat mode', () => {
             renderChatInput();
 
-            // Should show the active cell context container
-            const activeCellContainer = screen.getByText('Active Cell');
-            expect(activeCellContainer).toBeInTheDocument();
+            // Should show both the active cell and notebook context containers
+            expect(screen.getByText('Active Cell')).toBeInTheDocument();
+            expect(screen.getByText('Notebook')).toBeInTheDocument();
 
-            // Should be inside a SelectedContextContainer
-            const selectedContextContainer = screen.getByTestId('selected-context-container');
-            expect(selectedContextContainer).toBeInTheDocument();
-            expect(within(selectedContextContainer).getByText('Active Cell')).toBeInTheDocument();
-
-            // Should not show the notebook context container
-            expect(screen.queryByText('Notebook')).not.toBeInTheDocument();
+            // Both should be inside SelectedContextContainers
+            const selectedContextContainers = screen.getAllByTestId('selected-context-container');
+            expect(selectedContextContainers.length).toBe(2);
         });
 
         it('does not show active cell context in Agent mode', () => {
@@ -856,8 +855,8 @@ describe('ChatInput Component', () => {
 
             // Should not show the active cell context container
             expect(screen.queryByText('Active Cell')).not.toBeInTheDocument();
-            
-            // Should show the active cell context container
+
+            // Should show the notebook context container
             const activeCellContainer = screen.getByText('Notebook');
             expect(activeCellContainer).toBeInTheDocument();
 

--- a/mito-ai/src/websockets/completions/CompletionModels.ts
+++ b/mito-ai/src/websockets/completions/CompletionModels.ts
@@ -81,6 +81,7 @@ export interface IChatMessageMetadata {
   files?: File[];
   activeCellCode: string;
   activeCellId: string;
+  aiOptimizedCells?: AIOptimizedCell[];
   base64EncodedActiveCellOutput?: string;
   input: string;
   index?: number;


### PR DESCRIPTION
# Description

Chat Mode now has the context of the entire notebook (all cells), just like Agent Mode. The ChatInput displays both a "Notebook" item and an "Active Cell" item when in Chat Mode. On the backend, the chat prompt now includes the `SG.Notebook` section with all `aiOptimizedCells`. Chat Mode still only edits the active cell — the notebook context is read-only for additional awareness.

# Testing

- [ ] Open a notebook with multiple cells, use Chat Mode, and verify both "Notebook" and "Active Cell" context items appear in the ChatInput
- [ ] Switch to Agent Mode and verify only "Notebook" appears (no "Active Cell")
- [ ] Send a Chat Mode message and confirm the AI can reference code from other cells in the notebook
- [ ] Confirm Chat Mode responses still only modify the active cell
- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

No new documentation needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands Chat Mode prompts to include the entire notebook, which can significantly increase prompt size/cost and may change model behavior across both streaming and non-streaming paths.
> 
> **Overview**
> Chat Mode now sends **full notebook context** alongside the active cell by plumbing `aiOptimizedCells` through `IChatMessageMetadata`/`ChatMessageMetadata` and adding `SG.Notebook(...)` to `create_chat_prompt`.
> 
> The frontend Chat composer auto-includes both *Notebook* and *Active Cell* context items in Chat Mode (and only *Notebook* in Agent Mode), hides these default items in chat history rendering, and updates associated tooltips and tests to match the new default context behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e83b051eaa7dc0650741eb1b1611df8e3216744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->