### PR TITLE
LaTeX Support

### DIFF
--- a/mito-ai/mito_ai/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/agent_system_message.py
@@ -9,6 +9,7 @@ from mito_ai.completions.prompt_builders.prompt_constants import (
     CITATION_RULES,
     CELL_REFERENCE_RULES,
     EXCEL_TO_PYTHON_RULES,
+    LATEX_FORMATTING_RULES,
     get_database_rules
 )
 from mito_ai.completions.prompt_builders.prompt_section_registry.base import PromptSection
@@ -471,7 +472,8 @@ Important information:
     }}
     </Example>"""))
     sections.append(SG.Generic("Cell Reference Rules", CELL_REFERENCE_RULES))
-    
+    sections.append(SG.Generic("LaTeX / math formatting", LATEX_FORMATTING_RULES))
+
     # Database rules
     sections.append(SG.Generic("Database Rules", get_database_rules()))
 

--- a/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
@@ -9,6 +9,7 @@ from mito_ai.completions.prompt_builders.prompt_constants import (
     CHAT_CODE_FORMATTING_RULES,
     CITATION_RULES,
     CELL_REFERENCE_RULES,
+    LATEX_FORMATTING_RULES,
     get_database_rules
 )
 from mito_ai.completions.prompt_builders.prompt_section_registry.base import PromptSection
@@ -43,6 +44,7 @@ Other useful information:
         sections.append(SG.Generic("Default (User Defined) Rules", default_rules))
     sections.append(SG.Generic("Citation Rules", CITATION_RULES))
     sections.append(SG.Generic("Cell Reference Rules", CELL_REFERENCE_RULES))
+    sections.append(SG.Generic("LaTeX / math formatting", LATEX_FORMATTING_RULES))
     
     # Example 1
     sections.append(SG.Example("Example 1", f"""

--- a/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
@@ -96,6 +96,16 @@ Cell Reference Rules:
 5. You only need to provide a cell reference when you want to make it easy for the user to navigate to a specific cell in the notebook. For example you should use a MITO_CELL_REF when you are stating things like: "I've loaded the sales data in [MITO_CELL_REF:c68fdf19-db8c-46dd-926f-d90ad35bb3bc]" or "[MITO_CELL_REF:a91fde20-cc7f-g6ee-146g-e10bc34abdbh] creates the graph showing the total highest closing stock price for each company". If you are not referencing an entire code block and instead of providing justification for a specific conclucions that you drew like "The most common used car in the lot is a 2005 Honda CRV", then you should instead use a MITO_CITATION.
 """
 
+LATEX_FORMATTING_RULES = """
+When your message includes mathematical notation, the chat UI renders it with KaTeX. Follow these rules so it displays correctly:
+
+1. Use `$...$` for inline math and `$$...$$` for display (block) math. Do not use `\\( ... \\)` or `\\[ ... \\]`—stick to `$` / `$$`.
+2. Inline math (`$...$`) must be on a single line: do not put line breaks inside a pair of single `$` delimiters. For multi-line expressions, use display math with `$$...$$` instead.
+3. Do not put LaTeX inside Markdown code fences (```) if you want it rendered as math; fenced code shows as plain text.
+4. Keep delimiters balanced and unambiguous: avoid stray `$` characters in normal text (e.g. currency). Prefer spelling out "USD" or escaping intent in words if a lone `$` would break parsing.
+5. Use standard LaTeX math syntax supported by KaTeX. If something might not render, give a short plain-text restatement alongside the formula.
+"""
+
 ABOUT_MITO = """
 Mito is the company behind this AI assistant. Our website is trymito.io and our docs are at docs.trymito.io.
 

--- a/mito-ai/package.json
+++ b/mito-ai/package.json
@@ -84,6 +84,7 @@
     "@types/react-dom": "^18.0.10",
     "aws-amplify": "^6.0.0",
     "html2canvas": "^1.4.1",
+    "katex": "^0.16.45",
     "openai": "^4.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
@@ -187,7 +187,7 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
         });
 
         // Extract inline math ($...$) — single-line only, not preceded or followed by another $.
-        processedMarkdown = processedMarkdown.replace(/(?<!\$)\$([^\$\n]+?)\$(?!\$)/g, (match, content) => {
+        processedMarkdown = processedMarkdown.replace(/(?<!\$)\$([^$\n]+?)\$(?!\$)/g, (match, content) => {
             const id = `latex-${latexCounter++}`;
             latexExprs.push({ id, content: content.trim(), isDisplay: false });
             return `{{${id}}}`;

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
@@ -10,6 +10,8 @@ import { Citation, CitationProps, CitationLine } from './Citation';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { scrollToCell, highlightCodeCell } from '../../../utils/notebook';
 import { useCellOrder } from '../../../hooks/useCellOrder';
+import katex from 'katex';
+import 'katex/dist/katex.min.css';
 import '../../../../style/CellReference.css';
 
 /**
@@ -75,6 +77,12 @@ interface CellRef {
     cellId: string;
 }
 
+interface ILatexExpr {
+    id: string;
+    content: string;
+    isDisplay: boolean;
+}
+
 const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegistry, notebookTracker }) => {
     const [citationPortals, setCitationPortals] = useState<React.ReactElement[]>([]);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -120,22 +128,25 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
         }
     };
 
-    // Extract citations and cell references from the markdown, returning the markdown with 
-    // placeholders and arrays of citation/cell reference objects.
-    const extractCitationsAndCellRefs = useCallback((text: string): { 
-        processedMarkdown: string; 
+    // Extract citations, cell references, and LaTeX expressions from the markdown, returning
+    // the markdown with placeholders and arrays of each object type.
+    const extractCitationsAndCellRefs = useCallback((text: string): {
+        processedMarkdown: string;
         citations: Citation[];
         cellRefs: CellRef[];
+        latexExprs: ILatexExpr[];
     } => {
         // Regex for citations: [MITO_CITATION:cell_id:line_number] or [MITO_CITATION:cell_id:start_line-end_line]
         const citationRegex = /\[MITO_CITATION:([^:]+):(\d+(?:-\d+)?)\]/g;
         // Regex for cell references: [MITO_CELL_REF:cell_id]
         const cellRefRegex = /\[MITO_CELL_REF:([^\]]+)\]/g;
-        
+
         const citations: Citation[] = [];
         const cellRefs: CellRef[] = [];
+        const latexExprs: ILatexExpr[] = [];
         let citationCounter = 0;
         let cellRefCounter = 0;
+        let latexCounter = 0;
 
         // First, replace citations with placeholders
         let processedMarkdown = text.replace(citationRegex, (match, cellId, lineStr) => {
@@ -167,7 +178,22 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
             return `{{${id}}}`;
         });
 
-        return { processedMarkdown, citations, cellRefs };
+        // Extract display math ($$...$$) before inline math to avoid double-matching.
+        // The [\s\S]+? matches any character including newlines, non-greedy.
+        processedMarkdown = processedMarkdown.replace(/\$\$([\s\S]+?)\$\$/g, (match, content) => {
+            const id = `latex-${latexCounter++}`;
+            latexExprs.push({ id, content: content.trim(), isDisplay: true });
+            return `{{${id}}}`;
+        });
+
+        // Extract inline math ($...$) — single-line only, not preceded or followed by another $.
+        processedMarkdown = processedMarkdown.replace(/(?<!\$)\$([^\$\n]+?)\$(?!\$)/g, (match, content) => {
+            const id = `latex-${latexCounter++}`;
+            latexExprs.push({ id, content: content.trim(), isDisplay: false });
+            return `{{${id}}}`;
+        });
+
+        return { processedMarkdown, citations, cellRefs, latexExprs };
     }, []);
 
     // Uses the Jupyter markdowm MimeRenderer to render the markdown content as normal HTML
@@ -191,24 +217,24 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
     }, [renderMimeRegistry]);
 
 
-    // Replace the citation and cell reference placeholders with components in the DOM
+    // Replace the citation, cell reference, and LaTeX placeholders with components/rendered HTML in the DOM
     const createPortalsFromPlaceholders = useCallback((
-        citations: Citation[], 
-        cellRefs: CellRef[]
+        citations: Citation[],
+        cellRefs: CellRef[],
+        latexExprs: ILatexExpr[]
     ): React.ReactElement[] => {
-        if (!containerRef.current || (citations.length === 0 && cellRefs.length === 0)) return [];
+        if (!containerRef.current || (citations.length === 0 && cellRefs.length === 0 && latexExprs.length === 0)) return [];
 
         const newPortals: React.ReactElement[] = [];
 
         // Create maps for faster lookup
         const citationMap = new Map(citations.map(citation => [`{{${citation.id}}}`, citation]));
         const cellRefMap = new Map(cellRefs.map(ref => [`{{${ref.id}}}`, ref]));
+        const latexMap = new Map(latexExprs.map(expr => [`{{${expr.id}}}`, expr]));
 
-        // Find all text nodes that contain our placeholder like {{citation-id}}).
-        // Since these placeholders exist within the text content (not as separate DOM elements):
-        //  - Find all text nodes in the rendered markdown
-        //  - Check each one to see if it contains any of your placeholders
-        //  - Process those that do contain placeholders
+        const allPlaceholders = [...citationMap.keys(), ...cellRefMap.keys(), ...latexMap.keys()];
+
+        // Find all text nodes that contain our placeholders.
         const textNodes: Text[] = [];
         const walker = document.createTreeWalker(containerRef.current, NodeFilter.SHOW_TEXT);
 
@@ -223,7 +249,7 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
 
             // Check if this node contains any placeholders
             let containsPlaceholder = false;
-            for (const placeholder of [...citationMap.keys(), ...cellRefMap.keys()]) {
+            for (const placeholder of allPlaceholders) {
                 if (node.nodeValue.includes(placeholder)) {
                     containsPlaceholder = true;
                     break;
@@ -232,8 +258,8 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
 
             if (!containsPlaceholder) return;
 
-            // Create a regex to match all placeholders (citations and cell refs)
-            const placeholderPattern = /\{\{(citation|cellref)-\d+\}\}/g;
+            // Create a regex to match all placeholder types (citations, cell refs, and latex)
+            const placeholderPattern = /\{\{(citation|cellref|latex)-\d+\}\}/g;
             const matches = [...node.nodeValue.matchAll(placeholderPattern)];
 
             if (matches.length === 0) return;
@@ -253,9 +279,9 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
                     );
                 }
 
-                // Check if it's a citation or cell reference
                 const citation = citationMap.get(placeholder);
                 const cellRef = cellRefMap.get(placeholder);
+                const latexExpr = latexMap.get(placeholder);
 
                 if (citation) {
                     // Create span for the citation
@@ -280,14 +306,14 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
                     const cellNumber = cellOrder.get(cellRef.cellId);
                     const isMissing = cellNumber === undefined;
                     const displayText = isMissing ? 'Cell' : `Cell ${cellNumber}`;
-                    
+
                     const span = document.createElement('span');
                     span.className = isMissing ? 'cell-reference cell-reference-missing' : 'cell-reference';
                     span.textContent = displayText;
-                    span.title = isMissing 
+                    span.title = isMissing
                         ? 'Cell not found (may have been deleted or is in a different notebook)'
                         : `Click to navigate to ${displayText}`;
-                    
+
                     // Only add click handler if cell exists
                     if (!isMissing) {
                         span.addEventListener('click', (e) => {
@@ -303,6 +329,23 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
                         });
                     }
 
+                    fragment.appendChild(span);
+                } else if (latexExpr) {
+                    // Render LaTeX with KaTeX directly into a span
+                    const span = document.createElement('span');
+                    span.className = latexExpr.isDisplay ? 'latex-display' : 'latex-inline';
+                    try {
+                        katex.render(latexExpr.content, span, {
+                            displayMode: latexExpr.isDisplay,
+                            throwOnError: false,
+                            output: 'html'
+                        });
+                    } catch (e) {
+                        // Fall back to raw LaTeX text on unexpected error
+                        span.textContent = latexExpr.isDisplay
+                            ? `$$${latexExpr.content}$$`
+                            : `$${latexExpr.content}$`;
+                    }
                     fragment.appendChild(span);
                 }
 
@@ -329,14 +372,14 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
     // cellOrderKey triggers re-render when notebook loads or cells are reordered (fixes race condition on refresh)
     useEffect(() => {
         const processMarkdown = async (): Promise<void> => {
-            // Step 1: Extract citations and cell references, get processed markdown
-            const { processedMarkdown, citations, cellRefs } = extractCitationsAndCellRefs(markdown);
+            // Step 1: Extract citations, cell references, and LaTeX expressions; get processed markdown
+            const { processedMarkdown, citations, cellRefs, latexExprs } = extractCitationsAndCellRefs(markdown);
 
             // Step 2: Render markdown with placeholders
             await renderMarkdownContent(processedMarkdown);
 
-            // Step 3: Create and insert portals for citations and cell references
-            const portals = createPortalsFromPlaceholders(citations, cellRefs);
+            // Step 3: Create and insert portals for citations, cell references, and LaTeX
+            const portals = createPortalsFromPlaceholders(citations, cellRefs, latexExprs);
             setCitationPortals(portals);
         };
 

--- a/mito-ai/style/MarkdownMessage.css
+++ b/mito-ai/style/MarkdownMessage.css
@@ -17,3 +17,16 @@
     overflow-wrap: anywhere;
     white-space: pre-line;
 }
+
+/* LaTeX display math: block-level, centered */
+.latex-display {
+    display: block;
+    text-align: center;
+    margin: 0.5em 0;
+    overflow-x: auto;
+}
+
+/* LaTeX inline math: stays in the text flow */
+.latex-inline {
+    display: inline;
+}

--- a/mito-ai/yarn.lock
+++ b/mito-ai/yarn.lock
@@ -7654,6 +7654,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
+  languageName: node
+  linkType: hard
+
 "commander@npm:^9.4.1":
   version: 9.5.0
   resolution: "commander@npm:9.5.0"
@@ -10816,6 +10823,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"katex@npm:^0.16.45":
+  version: 0.16.45
+  resolution: "katex@npm:0.16.45"
+  dependencies:
+    commander: ^8.3.0
+  bin:
+    katex: cli.js
+  checksum: fe0a88485a1135268c2f1cc7d3dec8d124c85282a2d1184fed6728b729b2dcbcb738d73098cdfa87d120dd0657417ef818e4acc845c305c05f2fdec10910c1eb
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -11419,6 +11437,7 @@ __metadata:
     eslint-plugin-react-hooks: ^5.2.0
     html2canvas: ^1.4.1
     jest: ^29.7.0
+    katex: ^0.16.45
     npm-run-all: ^4.1.5
     openai: ^4.1.0
     prettier: ^3.0.0


### PR DESCRIPTION
# Description

Added support for LaTeX formatted responses in mito-ai.

# Testing

Have the AI generate LaTeX code, make sure it is formatted properly. 

# Documentation

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds KaTeX-based parsing/rendering into the markdown message pipeline, which could affect how chat content is rendered (regex edge cases, performance, and styling) and introduces a new third-party dependency.
> 
> **Overview**
> Adds LaTeX support to AI chat markdown messages by detecting inline `$...$` and display `$$...$$` math, replacing them with placeholders during markdown rendering, then post-processing the DOM to render those expressions via KaTeX.
> 
> Updates styling with new `.latex-display` and `.latex-inline` rules, and adds the `katex` dependency (plus lockfile updates) so KaTeX CSS is bundled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebe33db1755cc9ccd6d29c15e98b68c8c63f5c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->