### PR TITLE
mito-ai: add latex rendering

### DIFF
--- a/mito-ai/mito_ai/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/agent_system_message.py
@@ -9,6 +9,7 @@ from mito_ai.completions.prompt_builders.prompt_constants import (
     CITATION_RULES,
     CELL_REFERENCE_RULES,
     EXCEL_TO_PYTHON_RULES,
+    LATEX_RULES,
     get_database_rules
 )
 from mito_ai.completions.prompt_builders.prompt_section_registry.base import PromptSection
@@ -36,6 +37,7 @@ Each time you use a tool, except for the finished_task tool, the user will execu
     
     sections.append(SG.Generic("Chart Config Rules", CHART_CONFIG_RULES))
     sections.append(SG.Generic("Excel to Python Rules", EXCEL_TO_PYTHON_RULES))
+    sections.append(SG.Generic("LaTeX Rules", LATEX_RULES))
 
     sections.append(SG.Generic("TOOL: CELL_UPDATE", """
 

--- a/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/chat_system_message.py
@@ -9,6 +9,7 @@ from mito_ai.completions.prompt_builders.prompt_constants import (
     CHAT_CODE_FORMATTING_RULES,
     CITATION_RULES,
     CELL_REFERENCE_RULES,
+    LATEX_RULES,
     get_database_rules
 )
 from mito_ai.completions.prompt_builders.prompt_section_registry.base import PromptSection
@@ -37,6 +38,7 @@ Other useful information:
     sections.append(SG.Generic("About Mito", ABOUT_MITO))
     
     sections.append(SG.Generic("Chart Config Rules", CHART_CONFIG_RULES))
+    sections.append(SG.Generic("LaTeX Rules", LATEX_RULES))
     sections.append(SG.Generic("DatabaseRules", get_database_rules()))
     default_rules = get_default_rules_content()
     if default_rules:

--- a/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai/mito_ai/completions/prompt_builders/prompt_constants.py
@@ -58,6 +58,17 @@ FIGURE_SIZE = (12, 6)
 # === END CONFIG ===
 """
 
+LATEX_RULES = """
+
+- Rendering engine is MathJax, not a LaTeX compiler. Only math/equation syntax is supported — no custom packages, document-level commands, or non-math environments.
+- LaTeX only renders in Markdown cells, not code cells.
+- Use $...$ for inline math and $$...$$ (on its own line) for centered display math.
+- No spaces directly inside the delimiters — $x^2$ works, $ x^2 $ may not.
+- If generating markdown programmatically in Python, use raw strings (r"...") or double-escape backslashes (\\frac) to avoid broken syntax.
+- Stray underscores outside math delimiters can break rendering — keep _ inside $...$ only.
+- Avoid mixing LaTeX display blocks inside HTML tags in the same cell.
+"""
+
 CITATION_RULES = """
 It is important that the user is able to verify any insights that you share with them about their data. To make this easy for the user, you must cite the lines of code that you are drawing the insight from. To provide a citation, use one of the following formats inline in your response:
 

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/MarkdownBlock.tsx
@@ -338,10 +338,18 @@ const MarkdownBlock: React.FC<IMarkdownCodeProps> = ({ markdown, renderMimeRegis
             // Step 3: Create and insert portals for citations and cell references
             const portals = createPortalsFromPlaceholders(citations, cellRefs);
             setCitationPortals(portals);
+
+            // Step 4: Run MathJax on the chat container. The ephemeral markdown renderer from
+            // createRenderer is not a Lumino-attached widget, so RenderedMarkdown passes
+            // shouldTypeset: false and skips typesetting; cloning the node also bypasses
+            // onAfterAttach. The app registry's latexTypesetter is the same MathJax used in notebooks.
+            if (containerRef.current && renderMimeRegistry.latexTypesetter) {
+                renderMimeRegistry.latexTypesetter.typeset(containerRef.current);
+            }
         };
 
         void processMarkdown();
-    }, [markdown, extractCitationsAndCellRefs, renderMarkdownContent, createPortalsFromPlaceholders, cellOrderKey]);
+    }, [markdown, extractCitationsAndCellRefs, renderMarkdownContent, createPortalsFromPlaceholders, cellOrderKey, renderMimeRegistry]);
 
     return (
         <div ref={containerRef} className="markdown-block-with-citations">


### PR DESCRIPTION
# Description

Uses the same latex rendering as Jupyter markdown cells. I think this makes it less lines of code and more robust (we don't need to limit the types of latex we support)

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat markdown rendering to invoke JupyterLab’s MathJax typesetter, which could affect performance or rendering stability for all chat messages. Prompt updates are low risk but may change model output formatting expectations.
> 
> **Overview**
> Adds first-class LaTeX support across Mito AI prompts and the chat UI.
> 
> The system prompts for both chat and agent modes now include new `LATEX_RULES` guidance, and `prompt_constants.py` defines those rules for consistent instruction.
> 
> In the JupyterLab extension’s `MarkdownBlock`, the rendered chat markdown is now post-processed with `renderMimeRegistry.latexTypesetter.typeset(...)` so MathJax equations are typeset in chat messages (and the effect dependencies were updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d718508c9ff632858d11dfe0803745f936312b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->