### PR TITLE
Fix/variable context formatting

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -26,6 +26,8 @@ Use `@pytest.mark.parametrize` when you have multiple test cases that:
 - Follow the same test logic pattern
 - Would otherwise require repetitive test code
 
+### MyPy Typing
+We support Python 3.9 and above. That means instead of using | for union types, you should use Union[type1, type2].
 
 ## Verify Mode
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,5 +1,32 @@
 # Cursor Rules for Mito Project
 
+## Virtual Environment
+- ALWAYS activate the virtual environment before running any Python commands: `cd mito-ai && source venv/bin/activate`
+- For other components: check for venv directories and activate appropriately
+
+## Engineering practices
+
+### Startup mentality
+We're a startup. You're probably used to writing enterprise code -- code that tries to handle every possible edge case and has fallbacks for everything. That's not how we do things around here: our number one rule is to keep things simple. We handle ONLY the most important cases.
+
+We try to only add new functionality that is small (that is, simple and few lines of code) or absolutely necessary. If a change is not small or absolutely necessary, don't make it.
+
+In other words, don't do to much defensive programming. 
+
+### Backwards Compatibility
+Since our app runs locally on a user's machine, we think about backwards compatibility very differently than enterprise code.
+- For things like updating the environment variables structure, we don't need to worry about backwards compatibility because if the enterprise opts in to upgrading, they can update the enviornment variables at the same time. 
+- For things like adding new tool options, we don't need to worry about backwards compatibility because only users on the newest version of the tool are going to have access to the new options.
+- For things like changing how we read in old chat histories, we DO need to worry about backwards compatibility because the chat histories live on the user's machine, so we don't have a way to migrate them to the new format without adding that migration step into the tool.
+
+### Use Parameterized Tests When Appropriate
+Use `@pytest.mark.parametrize` when you have multiple test cases that:
+- Test the same function/method with different inputs
+- Have the same expected output structure
+- Follow the same test logic pattern
+- Would otherwise require repetitive test code
+
+
 ## Verify Mode
 
 When creating plans or implementing features, use verify mode to ensure quality:

--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,3 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 mito-sql-cell/junit.xml
-
-mito-ai/results-2.csv

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 mito-sql-cell/junit.xml
+
+mito-ai/results-2.csv

--- a/agent.md
+++ b/agent.md
@@ -22,3 +22,6 @@ Use `@pytest.mark.parametrize` when you have multiple test cases that:
 - Have the same expected output structure
 - Follow the same test logic pattern
 - Would otherwise require repetitive test code
+
+### MyPy Typing
+We support Python 3.9 and above. That means instead of using | for union types, you should use Union[type1, type2].

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -112,35 +112,47 @@ When a CELL_UPDATE execution fails and you receive an error traceback:
 7. If a package is not installed, install it using pip with the quiet flag --quiet. You do not need to ask for permission to install packages. ie: `!pip install <package_name> --quiet`.
 
     <Cell Modification Example> 
-    Jupyter Notebook:
+    Notebook:
     [
         {{
-            cell_type: 'markdown'
-            id: '9e38c62b-38f8-457d-bb8d-28bfc52edf2c'
-            code: \"\"\" # Used Car Sales Analysis \"\"\"
+            "index": 0,
+            "id": "9e38c62b-38f8-457d-bb8d-28bfc52edf2c",
+            "cell_type": "markdown",
+            "content": "# Used Car Sales Analysis"
         }},
         {{
-            cell_type: 'code'
-            id: 'c68fdf19-db8c-46dd-926f-d90ad35bb3bc'
-            code: \"\"\"import pandas as pd
-    sales_df = pd.read_csv('./sales.csv') 
-    loan_multiplier = 1.5\"\"\"
-        }},
+            "index": 1,
+            "id": "c68fdf19-db8c-46dd-926f-d90ad35bb3bc",
+            "cell_type": "code",
+            "content": "import pandas as pd\\nsales_df = pd.read_csv('./sales.csv')\\nloan_multiplier = 1.5"
+        }}
     ]
 
     Variables:
-    {{
-        'loan_multiplier': 1.5,
-        'sales_df': pd.DataFrame({
-            'transaction_date': ['2024-01-02', '2024-01-02', '2024-01-02', '2024-01-02', '2024-01-03'],
-            'price_per_unit': [10, 9.99, 13.99, 21.00, 100],
-            'units_sold': [1, 2, 1, 4, 5],
-            'total_price': [10, 19.98, 13.99, 84.00, 500]
-        })
-    }}
+    [
+        {{
+            "name": "loan_multiplier",
+            "type": "float",
+            "value": 1.5
+        }},
+        {{
+            "name": "sales_df",
+            "type": "DataFrame",
+            "value": {{
+                "transaction_date": ["2024-01-02", "2024-01-02", "2024-01-02", "2024-01-02", "2024-01-03"],
+                "price_per_unit": [10, 9.99, 13.99, 21.0, 100],
+                "units_sold": [1, 2, 1, 4, 5],
+                "total_price": [10, 19.98, 13.99, 84.0, 500]
+            }}
+        }}
+    ]
         
     Files:
-    "file_name: sales.csv"
+    [
+        {{
+            "path": "sales.csv"
+        }}
+    ]
 
     Your task: 
     Convert the transaction_date column to datetime and then multiply the total_price column by the sales_multiplier.
@@ -161,34 +173,42 @@ When a CELL_UPDATE execution fails and you receive an error traceback:
     </Cell Modification Example>
     <Cell Addition Example>
     
-    Jupyter Notebook:
+    Notebook:
     [
         {{
-            cell_type: 'markdown'
-            id: '9e38c62b-38f8-457d-bb8d-28bfc52edf2c'
-            code: \"\"\"# Used Car Sales Analysis \"\"\"
+            "index": 0,
+            "id": "9e38c62b-38f8-457d-bb8d-28bfc52edf2c",
+            "cell_type": "markdown",
+            "content": "# Used Car Sales Analysis"
         }},
         {{
-            cell_type: 'code'
-            id: 'c68fdf19-db8c-46dd-926f-d90ad35bb3bc'
-            code: \"\"\"import pandas as pd
-    sales_df = pd.read_csv('./sales.csv')
-    sales_df['transaction_date'] = pd.to_datetime(sales_df['transaction_date'])\"\"\"
-        }},
-    ]}
+            "index": 1,
+            "id": "c68fdf19-db8c-46dd-926f-d90ad35bb3bc",
+            "cell_type": "code",
+            "content": "import pandas as pd\\nsales_df = pd.read_csv('./sales.csv')\\nsales_df['transaction_date'] = pd.to_datetime(sales_df['transaction_date'])"
+        }}
+    ]
 
     Variables:
-    {{
-        'sales_df': pd.DataFrame({
-            'transaction_date': ['2024-01-02', '2024-01-02', '2024-01-02', '2024-01-02', '2024-01-03'],
-            'price_per_unit': [10, 9.99, 13.99, 21.00, 100],
-            'units_sold': [1, 2, 1, 4, 5],
-            'total_price': [10, 19.98, 13.99, 84.00, 500]
-        }})
-    }}
+    [
+        {{
+            "name": "sales_df",
+            "type": "DataFrame",
+            "value": {{
+                "transaction_date": ["2024-01-02", "2024-01-02", "2024-01-02", "2024-01-02", "2024-01-03"],
+                "price_per_unit": [10, 9.99, 13.99, 21.0, 100],
+                "units_sold": [1, 2, 1, 4, 5],
+                "total_price": [10, 19.98, 13.99, 84.0, 500]
+            }}
+        }}
+    ]
     
     Files:
-    "file_name: sales.csv"
+    [
+        {{
+            "path": "sales.csv"
+        }}
+    ]
 
     Your task: 
     Graph the total_price for each sale
@@ -434,41 +454,61 @@ Important information:
     sections.append(SG.Generic("Citation Rules", f"""{CITATION_RULES}
                                         
     <Example>
-    Jupyter Notebook:
+    Notebook:
     [
         {{
-            cell_type: 'markdown'
-            id: '9e38c62b-38f8-457d-bb8d-28bfc52edf2c'
-            code: \"\"\" # Used Car Sales Analysis \"\"\"
+            "index": 0,
+            "id": "9e38c62b-38f8-457d-bb8d-28bfc52edf2c",
+            "cell_type": "markdown",
+            "content": "# Used Car Sales Analysis"
         }},
         {{
-            cell_type: 'code'
-            id: 'c68fdf19-db8c-46dd-926f-d90ad35bb3bc'
-            code: \"\"\"import pandas as pd
-    tesla_stock_prices_df = pd.read_csv('./tesla_stock_prices.csv)\"\"\"
+            "index": 1,
+            "id": "c68fdf19-db8c-46dd-926f-d90ad35bb3bc",
+            "cell_type": "code",
+            "content": "import pandas as pd\\ntesla_stock_prices_df = pd.read_csv('./tesla_stock_prices.csv')"
         }},
         {{
-            cell_type: 'code',
-            id: '9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8',
-            code: \"\"\"all_time_high_row_idx = tesla_stock_prices_df['closing_price'].idxmax()
-    all_time_high_date = tesla_stock_prices_df.at[all_time_high_row_idx, 'Date']
-    all_time_high_price = tesla_stock_prices_df.at[all_time_high_row_idx, 'closing_price']\"\"\"
+            "index": 2,
+            "id": "9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8",
+            "cell_type": "code",
+            "content": "all_time_high_row_idx = tesla_stock_prices_df['closing_price'].idxmax()\\nall_time_high_date = tesla_stock_prices_df.at[all_time_high_row_idx, 'Date']\\nall_time_high_price = tesla_stock_prices_df.at[all_time_high_row_idx, 'closing_price']"
         }}
     ]
 
     Variables:
-    {{
-        'tesla_stock_prices_df': pd.DataFrame({{
-            'Date': ['2025-01-02', '2024-01-03', '2024-01-04', '2024-01-05', '2024-01-06'],
-            'closing_price': [249.98, 251.03, 250.11, 249.97, 251.45]
-        }}),
-        'all_time_high_row_idx': 501,
-        'all_time_high_date': '2025-03-16',
-        'all_time_high_price': 265.91
-    }}
+    [
+        {{
+            "name": "tesla_stock_prices_df",
+            "type": "DataFrame",
+            "value": {{
+                "Date": ["2025-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06"],
+                "closing_price": [249.98, 251.03, 250.11, 249.97, 251.45]
+            }}
+        }},
+        {{
+            "name": "all_time_high_row_idx",
+            "type": "int",
+            "value": 501
+        }},
+        {{
+            "name": "all_time_high_date",
+            "type": "str",
+            "value": "2025-03-16"
+        }},
+        {{
+            "name": "all_time_high_price",
+            "type": "float",
+            "value": 265.91
+        }}
+    ]
 
     Files:
-    "file_name: tesla_stock_prices.csv"
+    [
+        {{
+            "path": "tesla_stock_prices.csv"
+        }}
+    ]
 
     Your task: Given the dataframe `tesla_stock_prices_df`, what day was Tesla's all time high closing price?
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/chat_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/chat_system_message.py
@@ -22,7 +22,9 @@ def create_chat_system_message_prompt() -> str:
 
 The user is going to ask you for help writing code, debugging code, explaining code, or drawing conclusions from their data/graphs. It is your job to help them accomplish their goal. 
 
-The user will give you a set of variables, existing code, and a task to complete. 
+The user will give you a full notebook snapshot, a set of variables, existing active cell code, and a task to complete.
+
+The full notebook is shared for context only. You MUST only edit the active cell.
 
 There are three possible types of responses you might give:
 1. Code Update: If the task requires modifying or extending the existing code, respond with the updated active code cell and a short explanation of the changes made. 
@@ -84,19 +86,53 @@ Other useful information:
     
     
     sections.append(SG.Example("Example 3", """
+    Notebook:
+    [
+        {{
+            "index": 0,
+            "id": "9e38c62b-38f8-457d-bb8d-28bfc52edf2c",
+            "cell_type": "markdown",
+            "content": "# Used Car Sales Analysis"
+        }},
+        {{
+            "index": 1,
+            "id": "c68fdf19-db8c-46dd-926f-d90ad35bb3bc",
+            "cell_type": "code",
+            "content": "import pandas as pd\\nsales_df = pd.read_csv('./sales.csv')\\nloan_multiplier = 1.5"
+        }},
+        {{
+            "index": 2,
+            "id": "9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8",
+            "cell_type": "code",
+            "content": "import pandas as pd\\nsales_df = pd.read_csv('./sales.csv')"
+        }}
+    ]
+
     Files:
-    "file_name: sales.csv"
+    [
+        {{
+            "path": "sales.csv"
+        }}
+    ]
 
     Variables:
-    {{
-        'loan_multiplier': 1.5,
-        'sales_df': pd.DataFrame({
-            'transaction_date': ['2024-01-02', '2024-01-02', '2024-01-02', '2024-01-02', '2024-01-03'],
-            'price_per_unit': [10, 9.99, 13.99, 21.00, 100],
-            'units_sold': [1, 2, 1, 4, 5],
-            'total_price': [10, 19.98, 13.99, 84.00, 500]
-        })
-    }}
+    [
+        {{
+            "name": "loan_multiplier",
+            "type": "float",
+            "value": 1.5
+        }},
+        {{
+            "name": "sales_df",
+            "type": "DataFrame",
+            "value": {{
+                "transaction_date": ["2024-01-02", "2024-01-02", "2024-01-02", "2024-01-02", "2024-01-03"],
+                "price_per_unit": [10, 9.99, 13.99, 21.0, 100],
+                "units_sold": [1, 2, 1, 4, 5],
+                "total_price": [10, 19.98, 13.99, 84.0, 500]
+            }}
+        }}
+    ]
 
     Active Cell ID: '9c0d5fda-2b16-4f52-a1c5-a48892f3e2e8'
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/base.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/base.py
@@ -1,8 +1,9 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import json
 from abc import ABC
-from typing import Optional, List
+from typing import Any, List, Optional
 
 
 class PromptSection(ABC):
@@ -17,10 +18,33 @@ class PromptSection(ABC):
     def __init__(self, content: str):
         self.content = content
         self.name = self.__class__.__name__.replace("Section", "")
+
+    @staticmethod
+    def _is_empty_content(content: Any) -> bool:
+        if content is None:
+            return True
+
+        if isinstance(content, (list, tuple, set, dict)):
+            return len(content) == 0
+
+        if isinstance(content, str):
+            stripped_content = content.strip()
+            if stripped_content == "":
+                return True
+
+            # Handle stringified JSON empty states such as [] and {}
+            try:
+                parsed_content = json.loads(stripped_content)
+            except json.JSONDecodeError:
+                return False
+
+            return parsed_content in (None, "", [], {})
+
+        return False
     
     def __str__(self) -> str:
         # If exclude_if_empty is True and content is empty, return empty string
-        if self.exclude_if_empty and (self.content is None or self.content.strip() == ""):
+        if self.exclude_if_empty and self._is_empty_content(self.content):
             return ""
         return f"<{self.name}>\n{self.content}\n</{self.name}>"
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/files.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/files.py
@@ -1,6 +1,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import json
 from typing import List, Optional
 from .base import PromptSection
 
@@ -12,6 +13,10 @@ class FilesSection(PromptSection):
     
     def __init__(self, files: Optional[List[str]]):
         self.files = files
-        self.content = '\n'.join([f"file_name: {file}" for file in files or []])
+        self.content = json.dumps(self._normalize_files(files), indent=2)
         self.name = "Files"
+
+    @staticmethod
+    def _normalize_files(files: Optional[List[str]]) -> List[dict[str, str]]:
+        return [{"path": path} for path in files or []]
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/notebook.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/notebook.py
@@ -1,7 +1,8 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import List
+import json
+from typing import List, Optional
 
 from mito_ai_core.completions.models import AIOptimizedCell
 from .base import PromptSection
@@ -12,8 +13,24 @@ class NotebookSection(PromptSection):
     trim_after_messages: int = 6
     exclude_if_empty: bool = False
     
-    def __init__(self, cells: List[AIOptimizedCell]):
+    def __init__(self, cells: Optional[List[AIOptimizedCell]]):
         self.cells = cells
-        self.content = '\n'.join([f"{cell}" for cell in cells or []])
+        self.content = json.dumps(self._normalize_cells(cells), indent=2)
         self.name = "Notebook"
+
+    @staticmethod
+    def _normalize_cells(cells: Optional[List[AIOptimizedCell]]) -> List[dict[str, str | int]]:
+        normalized_cells: List[dict[str, str | int]] = []
+        for index, cell in enumerate(cells or []):
+            normalized_cells.append(NotebookSection._normalize_cell(cell, index))
+        return normalized_cells
+
+    @staticmethod
+    def _normalize_cell(cell: AIOptimizedCell, fallback_index: int) -> dict[str, str | int]:
+        return {
+            "index": fallback_index,
+            "id": cell.id,
+            "cell_type": cell.cell_type,
+            "content": cell.code,
+        }
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/notebook.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/notebook.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 import json
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from mito_ai_core.completions.models import AIOptimizedCell
 from .base import PromptSection
@@ -19,14 +19,14 @@ class NotebookSection(PromptSection):
         self.name = "Notebook"
 
     @staticmethod
-    def _normalize_cells(cells: Optional[List[AIOptimizedCell]]) -> List[dict[str, str | int]]:
-        normalized_cells: List[dict[str, str | int]] = []
+    def _normalize_cells(cells: Optional[List[AIOptimizedCell]]) -> List[dict[str, Union[str, int]]]:
+        normalized_cells: List[dict[str, Union[str, int]]] = []
         for index, cell in enumerate(cells or []):
             normalized_cells.append(NotebookSection._normalize_cell(cell, index))
         return normalized_cells
 
     @staticmethod
-    def _normalize_cell(cell: AIOptimizedCell, fallback_index: int) -> dict[str, str | int]:
+    def _normalize_cell(cell: AIOptimizedCell, fallback_index: int) -> dict[str, Union[str, int]]:
         return {
             "index": fallback_index,
             "id": cell.id,

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/variables.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/variables.py
@@ -1,12 +1,12 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import Optional, List
+import json
+from typing import Any, List, Optional
 
 from mito_ai_core.completions.models import KernelVariable
 
 from .base import PromptSection
-
 
 class VariablesSection(PromptSection):
     """Section for defined variables."""
@@ -15,7 +15,24 @@ class VariablesSection(PromptSection):
     
     def __init__(self, variables: Optional[List[KernelVariable]]) -> None:
         self.variables = variables
-        self.content = '\n'.join([f"{variable}" for variable in variables or []])
+        self.content = json.dumps(self._normalize_variables(variables), indent=2)
         self.name = "Variables"
+
+    @staticmethod
+    def _normalize_variables(
+        variables: Optional[List[KernelVariable]],
+    ) -> List[dict[str, Any]]:
+        normalized_variables: List[dict[str, Any]] = []
+        for variable in variables or []:
+            normalized_variables.append(VariablesSection._normalize_variable(variable))
+        return normalized_variables
+
+    @staticmethod
+    def _normalize_variable(variable: KernelVariable) -> dict[str, Any]:
+        return {
+            "name": variable.variable_name,
+            "type": variable.type,
+            "value": variable.value,
+        }
 
 

--- a/mito-ai-core/mito_ai_core/logger.py
+++ b/mito-ai-core/mito_ai_core/logger.py
@@ -18,3 +18,4 @@ def get_logger() -> logging.Logger:
     if _LOGGER is None:
         _LOGGER = logging.getLogger("mito_ai_core")
 
+    return _LOGGER

--- a/mito-ai-core/mito_ai_core/logger.py
+++ b/mito-ai-core/mito_ai_core/logger.py
@@ -1,21 +1,18 @@
-# Copyright (c) Saga Inc.
-# Distributed under the terms of the GNU Affero General Public License v3.0 License.
-
 import logging
+from typing import Optional
+
+from traitlets.config import Application
 
 
-_LOGGER = None  # type: logging.Logger | None
+_LOGGER: Optional[logging.Logger] = None
 
 
 def get_logger() -> logging.Logger:
-    """Create a logger for the Mito AI Core module.
-
-    Returns a standard Python logger named ``mito_ai_core``.  When the
-    library is used inside Jupyter the caller can attach a handler to
-    ``mito_ai_core`` to integrate with the server log.
-    """
+    """Return a cached logger namespaced under the Jupyter server logger."""
     global _LOGGER
     if _LOGGER is None:
-        _LOGGER = logging.getLogger("mito_ai_core")
+        app = Application.instance()
+        _LOGGER = logging.getLogger("{!s}.mito_ai_core".format(app.log.name))
+        Application.clear_instance()
 
     return _LOGGER

--- a/mito-ai-core/mito_ai_core/logger.py
+++ b/mito-ai-core/mito_ai_core/logger.py
@@ -1,18 +1,20 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
 import logging
-from typing import Optional
-
-from traitlets.config import Application
 
 
-_LOGGER: Optional[logging.Logger] = None
+_LOGGER = None  # type: logging.Logger | None
 
 
 def get_logger() -> logging.Logger:
-    """Return a cached logger namespaced under the Jupyter server logger."""
+    """Create a logger for the Mito AI Core module.
+
+    Returns a standard Python logger named ``mito_ai_core``.  When the
+    library is used inside Jupyter the caller can attach a handler to
+    ``mito_ai_core`` to integrate with the server log.
+    """
     global _LOGGER
     if _LOGGER is None:
-        app = Application.instance()
-        _LOGGER = logging.getLogger("{!s}.mito_ai_core".format(app.log.name))
-        Application.clear_instance()
+        _LOGGER = logging.getLogger("mito_ai_core")
 
-    return _LOGGER

--- a/mito-ai-core/mito_ai_core/tests/completions/test_prompt_section_registry.py
+++ b/mito-ai-core/mito_ai_core/tests/completions/test_prompt_section_registry.py
@@ -1,12 +1,14 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import json
 import pytest
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import (
     get_max_trim_after_messages,
     get_all_section_classes,
     SectionRegistry
 )
+from mito_ai_core.completions.models import AIOptimizedCell, KernelVariable
 
 def test_get_max_trim_after_messages_returns_actual_max():
     """Test that get_max_trim_after_messages returns the correct maximum value from all sections."""
@@ -41,4 +43,67 @@ def test_get_all_section_classes():
         assert section_class in SectionRegistry.__dict__.values()
         # Verify they have trim_after_messages attribute
         assert hasattr(section_class, 'trim_after_messages')
+
+
+def test_files_section_normalizes_file_entries_to_json() -> None:
+    files = [
+        "results.csv",
+        "sales.csv",
+        "data/clean.parquet",
+    ]
+
+    section = SectionRegistry.Files(files)
+
+    assert json.loads(section.content) == [
+        {"path": "results.csv"},
+        {"path": "sales.csv"},
+        {"path": "data/clean.parquet"},
+    ]
+
+
+def test_variables_section_normalizes_kernel_variables() -> None:
+    variables = [
+        KernelVariable(variable_name="df", type="pd.DataFrame", value={"rows": 10}),
+        KernelVariable(variable_name="threshold", type="int", value=5),
+        KernelVariable(variable_name="series", type="pd.Series", value=[1, 2, 3]),
+    ]
+
+    section = SectionRegistry.Variables(variables)
+
+    assert json.loads(section.content) == [
+        {"name": "df", "type": "pd.DataFrame", "value": {"rows": 10}},
+        {"name": "threshold", "type": "int", "value": 5},
+        {"name": "series", "type": "pd.Series", "value": [1, 2, 3]},
+    ]
+
+
+def test_notebook_section_normalizes_cells_with_required_fields() -> None:
+    cells = [
+        AIOptimizedCell(cell_type="code", id="cell-1", code="import pandas as pd"),
+        AIOptimizedCell(cell_type="markdown", id="cell-2", code="# Title"),
+        AIOptimizedCell(cell_type="code", id="cell-3", code="df.head()"),
+    ]
+
+    section = SectionRegistry.Notebook(cells)
+
+    assert json.loads(section.content) == [
+        {
+            "index": 0,
+            "id": "cell-1",
+            "cell_type": "code",
+            "content": "import pandas as pd",
+        },
+        {
+            "index": 1,
+            "id": "cell-2",
+            "cell_type": "markdown",
+            "content": "# Title",
+        },
+        {
+            "index": 2,
+            "id": "cell-3",
+            "cell_type": "code",
+            "content": "df.head()",
+        },
+    ]
 

--- a/mito-ai-core/mito_ai_core/tests/completions/test_prompt_section_registry.py
+++ b/mito-ai-core/mito_ai_core/tests/completions/test_prompt_section_registry.py
@@ -61,6 +61,14 @@ def test_files_section_normalizes_file_entries_to_json() -> None:
     ]
 
 
+@pytest.mark.parametrize("files", [None, []])
+def test_files_section_is_excluded_when_empty(files) -> None:
+    section = SectionRegistry.Files(files)
+
+    assert section.content == "[]"
+    assert str(section) == ""
+
+
 def test_variables_section_normalizes_kernel_variables() -> None:
     variables = [
         KernelVariable(variable_name="df", type="pd.DataFrame", value={"rows": 10}),
@@ -75,6 +83,14 @@ def test_variables_section_normalizes_kernel_variables() -> None:
         {"name": "threshold", "type": "int", "value": 5},
         {"name": "series", "type": "pd.Series", "value": [1, 2, 3]},
     ]
+
+
+@pytest.mark.parametrize("variables", [None, []])
+def test_variables_section_empty_representation_is_empty_list_json(variables) -> None:
+    section = SectionRegistry.Variables(variables)
+
+    assert section.content == "[]"
+    assert str(section) != ""
 
 
 def test_notebook_section_normalizes_cells_with_required_fields() -> None:

--- a/mito-ai-core/mito_ai_core/utils/telemetry_utils.py
+++ b/mito-ai-core/mito_ai_core/utils/telemetry_utils.py
@@ -275,7 +275,7 @@ def log_ai_completion_success(
         'model': model,
     }
 
-    num_usages = -1
+    num_usages: Optional[Any] = -1
     code_cell_input = ""
     
     try:

--- a/mito-ai/mito_ai/completions/handlers.py
+++ b/mito-ai/mito_ai/completions/handlers.py
@@ -53,7 +53,7 @@ from mito_ai_core.utils.telemetry_utils import identify
 from mito_ai_core.utils.version_utils import is_github_copilot_helper_installed
 from mito_ai.copilot import ws_notifier as copilot_ws_notifier
 from mito_ai_core.agent import ToolResult
-from mito_ai_core.completions.models import AIOptimizedCell as CoreAIOptimizedCell
+from mito_ai_core.completions.models import AIOptimizedCell as CoreAIOptimizedCell, ThreadID
 from mito_ai.completions.metadata_validation_utils import validate_metadata_types
 
 
@@ -204,8 +204,8 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
         if type == MessageType.FETCH_HISTORY:
             
             # If a thread_id is provided, use that thread's history; otherwise, use newest.
-            thread_id = metadata_dict.get('thread_id')
-            display_history = self._message_history.get_display_history(thread_id)
+            thread_id_for_history = ThreadID(str(metadata_dict.get('thread_id', '')))
+            display_history = self._message_history.get_display_history(thread_id_for_history)
             
             reply = FetchHistoryReply(
                 parent_id=parsed_message.get('message_id'),

--- a/mito-ai/mito_ai/completions/handlers.py
+++ b/mito-ai/mito_ai/completions/handlers.py
@@ -54,30 +54,7 @@ from mito_ai_core.utils.version_utils import is_github_copilot_helper_installed
 from mito_ai.copilot import ws_notifier as copilot_ws_notifier
 from mito_ai_core.agent import ToolResult
 from mito_ai_core.completions.models import AIOptimizedCell as CoreAIOptimizedCell
-from mito_ai_core.completions.models import KernelVariable
-
-
-def _coerce_kernel_variables(raw: Any) -> Optional[List[KernelVariable]]:
-    """JSON gives list of dicts; normalize to ``KernelVariable`` instances."""
-    if raw is None:
-        return None
-    out: List[KernelVariable] = []
-    for item in raw:
-        if isinstance(item, KernelVariable):
-            out.append(item)
-        elif isinstance(item, dict):
-            out.append(
-                KernelVariable(
-                    variable_name=str(item.get("variable_name", "")),
-                    type=str(item.get("type", "")),
-                    value=item.get("value"),
-                )
-            )
-        elif isinstance(item, str):
-            out.append(KernelVariable(variable_name=item, type="", value=None))
-        else:
-            raise ValueError(f"Invalid kernel variable payload: {item!r}")
-    return out
+from mito_ai.completions.metadata_validation_utils import validate_metadata_types
 
 
 # This handler is responsible for the mito_ai/completions endpoint.
@@ -168,6 +145,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
             parsed_message = json.loads(message)
             metadata_dict = parsed_message.get('metadata', {})
             type: MessageType = MessageType(parsed_message.get('type'))
+            metadata_dict = validate_metadata_types(metadata_dict)
             
             # Extract environment information from the message
             environment = parsed_message.get('environment', {})
@@ -314,10 +292,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
 
         # Handle tool_result messages from the frontend
         if type == MessageType.TOOL_RESULT:
-            md_tool = dict(metadata_dict)
-            if "variables" in md_tool:
-                md_tool["variables"] = _coerce_kernel_variables(md_tool.get("variables"))
-            tool_result_metadata = ToolResultMetadata(**md_tool)
+            tool_result_metadata = ToolResultMetadata(**metadata_dict)
             if self._active_tool_executor is not None:
                 cells = None
                 if tool_result_metadata.cells is not None:
@@ -399,8 +374,7 @@ class CompletionHandler(JupyterHandler, WebSocketHandler):
                 md = dict(metadata_dict)
                 # Legacy clients may still send this; cell images come from get_cell_output only.
                 md.pop("base64EncodedActiveCellOutput", None)
-                if "variables" in md:
-                    md["variables"] = _coerce_kernel_variables(md.get("variables"))
+
                 agent_execution_metadata = AgentExecutionMetadata(**md)
                 self.log.info(
                     "Starting agent execution (background), thread_id=%s",

--- a/mito-ai/mito_ai/completions/metadata_validation_utils.py
+++ b/mito-ai/mito_ai/completions/metadata_validation_utils.py
@@ -1,0 +1,84 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from typing import Any, Dict, List, Optional
+
+from mito_ai_core.completions.models import AIOptimizedCell as CoreAIOptimizedCell
+from mito_ai_core.completions.models import KernelVariable
+
+
+def _coerce_kernel_variables(raw: Any) -> Optional[List[KernelVariable]]:
+    """JSON gives list of dicts; normalize to ``KernelVariable`` instances."""
+    if raw is None:
+        return None
+    out: List[KernelVariable] = []
+    for item in raw:
+        if isinstance(item, KernelVariable):
+            out.append(item)
+        elif isinstance(item, dict):
+            out.append(
+                KernelVariable(
+                    variable_name=str(item.get("variable_name", "")),
+                    type=str(item.get("type", "")),
+                    value=item.get("value"),
+                )
+            )
+        elif isinstance(item, str):
+            out.append(KernelVariable(variable_name=item, type="", value=None))
+        else:
+            raise ValueError(f"Invalid kernel variable payload: {item!r}")
+    return out
+
+
+def _coerce_files(raw: Any) -> Optional[List[str]]:
+    """Normalize frontend file payloads to path strings."""
+    if raw is None:
+        return None
+    out: List[str] = []
+    for item in raw:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            out.append(str(item.get("file_name", "")))
+        else:
+            raise ValueError(f"Invalid file payload: {item!r}")
+    return out
+
+
+def _coerce_ai_optimized_cells(raw: Any) -> Optional[List[CoreAIOptimizedCell]]:
+    """Normalize frontend notebook cell payloads to ``AIOptimizedCell`` instances."""
+    if raw is None:
+        return None
+    out: List[CoreAIOptimizedCell] = []
+    for item in raw:
+        if isinstance(item, CoreAIOptimizedCell):
+            out.append(item)
+        elif isinstance(item, dict):
+            out.append(
+                CoreAIOptimizedCell(
+                    cell_type=str(item.get("cell_type", "")),
+                    id=str(item.get("id", "")),
+                    code=str(item.get("code", "")),
+                )
+            )
+        else:
+            raise ValueError(f"Invalid aiOptimizedCells payload: {item!r}")
+    return out
+
+
+def validate_metadata_types(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Return metadata with known structured fields coerced to backend types."""
+    normalized_metadata = dict(metadata)
+
+    if "variables" in normalized_metadata:
+        normalized_metadata["variables"] = _coerce_kernel_variables(
+            normalized_metadata.get("variables")
+        )
+    if "files" in normalized_metadata:
+        normalized_metadata["files"] = _coerce_files(normalized_metadata.get("files"))
+    if "aiOptimizedCells" in normalized_metadata:
+        normalized_metadata["aiOptimizedCells"] = _coerce_ai_optimized_cells(
+            normalized_metadata.get("aiOptimizedCells")
+        )
+
+    return normalized_metadata

--- a/mito-ai/mito_ai/logger.py
+++ b/mito-ai/mito_ai/logger.py
@@ -2,9 +2,7 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 import logging
-
 from traitlets.config import Application
-
 
 _LOGGER = None  # type: logging.Logger | None
 

--- a/mito-ai/mito_ai/tests/completions/metadata_validation_utils_test.py
+++ b/mito-ai/mito_ai/tests/completions/metadata_validation_utils_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import pytest
+
+from mito_ai.completions.metadata_validation_utils import validate_metadata_types
+from mito_ai_core.completions.models import AIOptimizedCell, KernelVariable
+
+
+def test_validate_metadata_types_coerces_supported_fields() -> None:
+    raw_metadata = {
+        "variables": [{"variable_name": "df", "type": "pd.DataFrame", "value": None}],
+        "files": [{"file_name": "sales.csv"}],
+        "aiOptimizedCells": [{"cell_type": "code", "id": "1", "code": "print('hi')"}],
+        "input": "hello",
+    }
+
+    metadata = validate_metadata_types(raw_metadata)
+
+    assert isinstance(metadata["variables"][0], KernelVariable)
+    assert isinstance(metadata["files"][0], str)
+    assert isinstance(metadata["aiOptimizedCells"][0], AIOptimizedCell)
+    assert metadata["input"] == "hello"
+
+
+def test_validate_metadata_types_returns_copy() -> None:
+    raw_metadata = {"input": "hello"}
+
+    metadata = validate_metadata_types(raw_metadata)
+
+    assert metadata == raw_metadata
+    assert metadata is not raw_metadata
+
+
+def test_validate_metadata_types_raises_for_invalid_payload() -> None:
+    with pytest.raises(ValueError, match="Invalid file payload"):
+        validate_metadata_types({"files": [123]})


### PR DESCRIPTION
# Description

Format variables better for LLM

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-wire metadata coercion and the exact prompt context format, so mismatches with older/third-party clients or downstream prompt parsing could cause runtime errors or behavior shifts despite the changes being mostly structural.
> 
> **Overview**
> Standardizes the LLM context payloads by emitting **JSON-formatted** `Notebook`, `Variables`, and `Files` sections (including adding cell `index` and using `{path: ...}` / `{name,type,value}` shapes) and updates the agent/chat system-message examples/instructions to match (including clarifying chat mode only edits the active cell).
> 
> Improves prompt section rendering by treating *empty* content more robustly (including stringified empty JSON) to decide when to omit sections, and adds tests covering the new normalization/exclusion behavior.
> 
> On the Jupyter websocket side, introduces `validate_metadata_types` to coerce incoming `variables`/`files`/`aiOptimizedCells` metadata into backend model types before pydantic parsing, and tightens thread history lookup to always use `ThreadID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abb06dc5170e4f2cdbf442876524f4be2b564a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->