### PR TITLE
Copilot Helper Package - Deploy Workflow

### DIFF
--- a/.github/workflows/deploy-mito-ai-helper-github-copilot.yml
+++ b/.github/workflows/deploy-mito-ai-helper-github-copilot.yml
@@ -1,0 +1,57 @@
+name: Deploy - Mito AI Helper GitHub Copilot
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish the package"
+        required: true
+        default: "pypi"
+        type: choice
+        options:
+          - pypi
+          - testpypi
+
+jobs:
+  deploy-helper:
+    name: Deploy mito-ai-helper-github-copilot
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: |
+          cd mitosheet-helpers/mito_ai_helper_github_copilot
+          rm -rf dist
+          python -m build
+
+      - name: Publish to TestPyPI
+        if: ${{ github.event.inputs.target == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          cd mitosheet-helpers/mito_ai_helper_github_copilot
+          python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.target == 'pypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          cd mitosheet-helpers/mito_ai_helper_github_copilot
+          python -m twine upload dist/*


### PR DESCRIPTION
# Description

Added a new Github action for manually deploying the Copilot helper package. 

Right now this action can only be triggered manually. However, this package should be seldomly updated, so it shouldn't be an issue. 

# Testing

Only way to really test this is to trigger a deployment. 

# Documentation

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new manual GitHub Actions workflow and does not change runtime code, but it can publish packages to PyPI/TestPyPI if secrets/inputs are misused.
> 
> **Overview**
> Adds a new manually triggered GitHub Actions workflow (`deploy-mito-ai-helper-github-copilot.yml`) to build and publish the `mito_ai_helper_github_copilot` Python package.
> 
> The workflow builds from `mitosheet-helpers/mito_ai_helper_github_copilot` on Ubuntu with Python 3.11, then conditionally uploads to **PyPI** or **TestPyPI** based on a `workflow_dispatch` input, using Twine and repository secrets for API tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432f0c0b7bc3514dd4615900b57548fcf79dd144. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->