### PR TITLE
Hide context chips on sent user messages

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -31,7 +31,6 @@ import { AgentResponse } from '../../../websockets/completions/CompletionModels'
 import { getCellIdFromCellUpdate } from '../cellUpdateUtils';
 import GetCellOutputToolUI from '../../../components/AgentComponents/GetCellOutputToolUI'
 import AssumptionToolUI from '../../../components/AgentComponents/AssumptionToolUI';
-import SelectedContextContainer from '../../../components/SelectedContextContainer';
 import RunAllCellsToolUI from '../../../components/AgentComponents/RunAllCellsToolUI';
 import AskUserQuestionToolUI from '../../../components/AgentComponents/AskUserQuestionToolUI';
 import ScratchpadToolUI from '../../../components/AgentComponents/ScratchpadToolUI';
@@ -86,7 +85,6 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
     codeReviewStatus,
     setNextSteps,
     agentModeEnabled,
-    additionalContext,
     handleSubmitUserMessage,
     scratchpadResult,
     canSendMessages = true,
@@ -247,20 +245,6 @@ const ChatMessage: React.FC<IChatMessageProps> = ({
                                         />
                                     </div>
 
-                                }
-                                {message.role === 'user' && additionalContext && additionalContext.length > 0 &&
-                                    <>
-                                        {additionalContext
-                                            .filter(context => context.type !== 'active_cell' && context.type !== 'notebook') // Hide default context items in chat messages
-                                            .map((context, index) => (
-                                                <SelectedContextContainer
-                                                    key={`${context.type}-${context.value}-${index}`}
-                                                    title={`${context.value}`}
-                                                    type={context.type}
-                                                    onRemove={() => { }} // Read-only in chat history
-                                                />
-                                            ))}
-                                    </>
                                 }
                             </>
                         )

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatMessage.tsx
@@ -58,7 +58,6 @@ interface IChatMessageProps {
     codeReviewStatus: CodeReviewStatus
     setNextSteps: (nextSteps: string[]) => void
     agentModeEnabled: boolean
-    additionalContext?: Array<{ type: string, value: string }>
     handleSubmitUserMessage: (newContent: string, messageIndex?: number, additionalContext?: Array<{ type: string, value: string }>) => void
     scratchpadResult?: string
     canSendMessages?: boolean

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -1181,7 +1181,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                                 codeReviewStatus={codeReviewStatus}
                                 setNextSteps={setNextSteps}
                                 agentModeEnabled={agentModeEnabled}
-                                additionalContext={displayOptimizedChat.additionalContext}
                                 scratchpadResult={displayOptimizedChat.scratchpadResult}
                             />
                         )

--- a/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
+++ b/mito-ai/src/tests/AiChat/ChatMessage.test.tsx
@@ -308,7 +308,7 @@ describe('ChatMessage Component', () => {
             expect(handleSubmitUserMessageMock).toHaveBeenCalledWith('Updated message content', 0, undefined);
         });
 
-        it('passes additionalContext when editing a message with context', () => {
+        it('forwards additionalContext to handleSubmitUserMessage when edit submit includes context', () => {
             const handleSubmitUserMessageMock = jest.fn();
             const mockAdditionalContext = [
                 { type: 'variable', value: 'df' },
@@ -317,8 +317,7 @@ describe('ChatMessage Component', () => {
 
             renderChatMessage({
                 message: createMockMessage('user', 'Hello, can you help me with pandas?'),
-                handleSubmitUserMessage: handleSubmitUserMessageMock,
-                additionalContext: mockAdditionalContext
+                handleSubmitUserMessage: handleSubmitUserMessageMock
             });
 
             // Find the message text element
@@ -389,32 +388,6 @@ describe('ChatMessage Component', () => {
             // Verify that ChatInput was called with agentModeEnabled=false
             const chatInputProps = (window as any).__chatInputProps;
             expect(chatInputProps.agentModeEnabled).toBe(false);
-        });
-
-        it('displays additionalContext containers in user messages', () => {
-            const mockAdditionalContext = [
-                { type: 'variable', value: 'df' },
-                { type: 'file', value: 'data.csv' },
-                { type: 'rule', value: 'Use pandas for data manipulation' }
-            ];
-
-            renderChatMessage({
-                message: createMockMessage('user', 'Hello, can you help me with pandas?\n```python\nimport pandas as pd\n```'),
-                additionalContext: mockAdditionalContext
-            });
-
-            // Check that the message content is displayed
-            expect(screen.getByText('Hello, can you help me with pandas?')).toBeInTheDocument();
-
-            // Check that SelectedContextContainer components are rendered for each context item
-            // The SelectedContextContainer renders the value as text content
-            expect(screen.getByText('df')).toBeInTheDocument();
-            expect(screen.getByText('data.csv')).toBeInTheDocument();
-            expect(screen.getByText('Use pandas for data manipulation')).toBeInTheDocument();
-
-            // Check that the containers have the correct test IDs
-            const contextContainers = screen.getAllByTestId('selected-context-container');
-            expect(contextContainers).toHaveLength(3);
         });
 
         it('shows code action buttons for the last AI message with code', () => {

--- a/mitosheet/src/viewer/dataframeViewerAiContext.ts
+++ b/mitosheet/src/viewer/dataframeViewerAiContext.ts
@@ -39,8 +39,6 @@ export function buildDataframeViewerSelectionContext(
     dataframeName?: string
 ): { display: string; value: string } {
     const { minRow, maxRow, minCol, maxCol } = bounds;
-    const rowCount = maxRow - minRow + 1;
-    const colCount = maxCol - minCol + 1;
     const headers: string[] = [];
     for (let c = minCol; c <= maxCol; c++) {
         headers.push(columnHeaderLabel(columns[c]));
@@ -67,9 +65,10 @@ export function buildDataframeViewerSelectionContext(
             ? `DataFrame: \`${dataframeName.trim()}\`\n\n`
             : "";
     const value = nameLine + markdownTable;
+    const trimmedDataframeName = dataframeName?.trim();
     const display =
-        dataframeName !== undefined && dataframeName.trim() !== ""
-            ? `\`${dataframeName.trim()}\` (${rowCount}×${colCount})`
-            : `DataFrame selection (${rowCount}×${colCount})`;
+        trimmedDataframeName !== undefined && trimmedDataframeName !== ""
+            ? `${trimmedDataframeName} selection`
+            : "DataFrame selection";
     return { display, value };
 }


### PR DESCRIPTION
# Description

Sent user messages in Mito AI chat no longer render selection chips (e.g. dataframe column selections, rules, database connections) below the message. Context is still attached for the request; only the display of those items as chips in the chat transcript is removed.

This also cleans up the text for the dataframe selection chip.  

# Testing

Send a message in chat mode, attach a rule, database or df selection. Make sure you can't see the selection chip in the sent message.

# Documentation

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering/label changes; no changes to how context is attached/sent or to any security/data-processing logic.
> 
> **Overview**
> Sent user chat messages no longer render attached *additional context* chips in the transcript (removes `SelectedContextContainer` usage and stops passing/handling `additionalContext` in `ChatMessage`).
> 
> Updates dataframe viewer AI selection context display text to a simpler label (e.g. `"<df> selection"` / `"DataFrame selection"`), dropping the previously included row/column dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1258bf4e5e28338c8cb960c0e5b9122c989c09c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->