### PR TITLE
Fix/markdown cell update

### DIFF
--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -79,21 +79,6 @@ class AgentRunner:
         self._max_iterations = max_iterations
         self._config = config or AgentRunnerConfig()
 
-    @staticmethod
-    def _should_emit_tool_result_callback(tool_result: ToolResult) -> bool:
-        """Decide whether a tool result should be forwarded to host UI callbacks.
-
-        Failed ``cell_update`` results are intentionally suppressed here because
-        host frontends may render ``on_tool_result`` payloads directly to users.
-        We still append the tool result to AI-optimized history so the agent can
-        recover and retry with corrected tool arguments.
-        """
-        return not (
-            tool_result.tool_name == "cell_update"
-            and not tool_result.success
-            and tool_result.error_message is not None
-        )
-
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -220,10 +205,7 @@ class AgentRunner:
                 ctx.thread_id,
             )
 
-            if (
-                on_tool_result is not None
-                and self._should_emit_tool_result_callback(tool_result)
-            ):
+            if on_tool_result is not None:
                 await on_tool_result(tool_result)
 
         # Max iterations exhausted. If every completion was malformed, return a

--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -79,6 +79,21 @@ class AgentRunner:
         self._max_iterations = max_iterations
         self._config = config or AgentRunnerConfig()
 
+    @staticmethod
+    def _should_emit_tool_result_callback(tool_result: ToolResult) -> bool:
+        """Decide whether a tool result should be forwarded to host UI callbacks.
+
+        Failed ``cell_update`` results are intentionally suppressed here because
+        host frontends may render ``on_tool_result`` payloads directly to users.
+        We still append the tool result to AI-optimized history so the agent can
+        recover and retry with corrected tool arguments.
+        """
+        return not (
+            tool_result.tool_name == "cell_update"
+            and not tool_result.success
+            and tool_result.error_message is not None
+        )
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -205,7 +220,10 @@ class AgentRunner:
                 ctx.thread_id,
             )
 
-            if on_tool_result is not None:
+            if (
+                on_tool_result is not None
+                and self._should_emit_tool_result_callback(tool_result)
+            ):
                 await on_tool_result(tool_result)
 
         # Max iterations exhausted. If every completion was malformed, return a

--- a/mito-ai-core/mito_ai_core/agent/utils.py
+++ b/mito-ai-core/mito_ai_core/agent/utils.py
@@ -147,7 +147,7 @@ def create_display_optimized_tool_result_message(
     if tool_result.tool_name == "scratchpad" and tool_result.success and tool_result.output:
         content = tool_result.output
     elif (
-        tool_result.tool_name in {"cell_update", "run_all_cells"}
+        tool_result.tool_name == "run_all_cells"
         and not tool_result.success
         and tool_result.error_message
     ):

--- a/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
@@ -181,6 +181,27 @@ class FakeToolExecutor:
         return ToolResult(success=True, output="Edited Streamlit app preview")
 
 
+class FailingCellUpdateToolExecutor(FakeToolExecutor):
+    """Tool executor that always fails CELL_UPDATE dispatch."""
+
+    async def execute_cell_update(
+        self,
+        ctx: AgentContext,
+        cell_update: CellUpdate,
+        message: str,
+    ) -> ToolResult:
+        self.calls.append(("execute_cell_update", {
+            "ctx": ctx,
+            "cell_update": cell_update,
+            "message": message,
+        }))
+        return ToolResult(
+            success=False,
+            tool_name="cell_update",
+            error_message="CELL_UPDATE failed: simulated invalid after_cell_id.",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -530,6 +551,35 @@ class TestCallbacks:
         # 1 dispatchable tool → 1 tool result callback
         assert len(tool_results) == 1
         assert tool_results[0].success is True
+
+    @pytest.mark.asyncio
+    async def test_failed_cell_update_callback_suppressed(self) -> None:
+        provider = FakeProviderManager([
+            _cell_update_response(),
+            _finished_response(),
+        ])
+        executor = FailingCellUpdateToolExecutor()
+        mh, ctx = _new_history_and_ctx()
+        runner = AgentRunner(provider, executor, mh)  # type: ignore[arg-type]
+
+        tool_results: list[ToolResult] = []
+
+        async def on_tool(result: ToolResult) -> None:
+            tool_results.append(result)
+
+        await runner.run(
+            ctx,
+            "",
+            on_tool_result=on_tool,
+        )
+
+        # Failed cell_update tool results should not be emitted to host callbacks.
+        assert len(tool_results) == 0
+        # But the failed result should still be visible to the model in history.
+        assert len(provider.messages_per_call) == 2
+        tool_msg_content = str(provider.messages_per_call[1][3]["content"])
+        assert "Tool 'cell_update' failed" in tool_msg_content
+        assert "simulated invalid after_cell_id" in tool_msg_content
 
 
 class TestMaxIterations:

--- a/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
@@ -553,7 +553,7 @@ class TestCallbacks:
         assert tool_results[0].success is True
 
     @pytest.mark.asyncio
-    async def test_failed_cell_update_callback_suppressed(self) -> None:
+    async def test_failed_cell_update_callback_emitted(self) -> None:
         provider = FakeProviderManager([
             _cell_update_response(),
             _finished_response(),
@@ -573,9 +573,12 @@ class TestCallbacks:
             on_tool_result=on_tool,
         )
 
-        # Failed cell_update tool results should not be emitted to host callbacks.
-        assert len(tool_results) == 0
-        # But the failed result should still be visible to the model in history.
+        # Failed cell_update tool results should be emitted to host callbacks.
+        assert len(tool_results) == 1
+        assert tool_results[0].success is False
+        assert tool_results[0].tool_name == "cell_update"
+        assert tool_results[0].error_message is not None
+        # Failed results should also be visible to the model in history.
         assert len(provider.messages_per_call) == 2
         tool_msg_content = str(provider.messages_per_call[1][3]["content"])
         assert "Tool 'cell_update' failed" in tool_msg_content

--- a/mito-ai/src/Extensions/AiChat/AgentReviewUtils.ts
+++ b/mito-ai/src/Extensions/AiChat/AgentReviewUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { scrollToNextCellWithDiff, writeCodeToCellByIDInNotebookPanel, deleteCellByIDInNotebookPanel } from '../../utils/notebook';
+import { scrollToNextCellWithDiff, writeContentToCellByIDInNotebookPanel, deleteCellByIDInNotebookPanel } from '../../utils/notebook';
 import { turnOffDiffsForCell } from '../../utils/codeDiff';
 import { runCellByIDInBackground } from '../../utils/notebook';
 import { AgentReviewStatus, ChangedCell } from './ChatTaskpane';
@@ -24,7 +24,12 @@ const revertCellChanges = (
         deleteCellByIDInNotebookPanel(notebookPanel, changedCell.cellId);
     } else {
         // Cell existed before — restore original code
-        writeCodeToCellByIDInNotebookPanel(notebookPanel, changedCell.originalCode, changedCell.cellId);
+        writeContentToCellByIDInNotebookPanel(
+            notebookPanel,
+            changedCell.originalCode,
+            changedCell.cellId,
+            changedCell.cellType,
+        );
 
         // Re-run the rejected cell in background. We want to make sure that the agent has the
         // most up-to-date version of every variable.
@@ -51,7 +56,12 @@ export const acceptSingleCellEdit = (
     }
 
     // Write the final code to the cell and turn off diffs
-    writeCodeToCellByIDInNotebookPanel(notebookPanel, edit?.code || '', cellId);
+    writeContentToCellByIDInNotebookPanel(
+        notebookPanel,
+        edit?.code || '',
+        cellId,
+        edit?.cell_type || changedCell?.cellType || 'code',
+    );
     turnOffDiffsForCell(notebookPanel, cellId, codeDiffStripesCompartments.current);
 
     // Scroll to the next cell with a diff if in agent mode
@@ -117,7 +127,12 @@ export const acceptAllCellEdits = (
             // Mark as reviewed
             changedCell.reviewed = true;
             // Write the final code to the cell and turn off diffs
-            writeCodeToCellByIDInNotebookPanel(notebookPanel, edit.code, changedCell.cellId);
+            writeContentToCellByIDInNotebookPanel(
+                notebookPanel,
+                edit.code,
+                changedCell.cellId,
+                edit.cell_type,
+            );
             turnOffDiffsForCell(notebookPanel, changedCell.cellId, codeDiffStripesCompartments.current);
         }
     });

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -132,6 +132,7 @@ export type { CodeReviewStatus, AgentReviewStatus, LoadingStatus } from './hooks
 export type AgentExecutionStatus = 'working' | 'stopping' | 'idle'
 export interface ChangedCell {
     cellId: string;
+    cellType: string;
     originalCode: string;
     currentCode: string;
     reviewed: boolean;

--- a/mito-ai/src/Extensions/AiChat/hooks/agentToolExecutor.ts
+++ b/mito-ai/src/Extensions/AiChat/hooks/agentToolExecutor.ts
@@ -91,10 +91,19 @@ export const executeAgentTool = async ({
             }
 
             setLoadingStatus('running-code');
+            let applyResult;
             try {
-                await acceptAndRunCellUpdate(agentResponse.cell_update, notebookPanel);
+                applyResult = await acceptAndRunCellUpdate(agentResponse.cell_update, notebookPanel);
             } finally {
                 setLoadingStatus(undefined);
+            }
+
+            if (!applyResult.success) {
+                return {
+                    success: false,
+                    errorMessage: applyResult.errorMessage || 'CELL_UPDATE failed before execution.',
+                    toolType: 'cell_update',
+                };
             }
 
             const cells = getAIOptimizedCellsInNotebookPanel(notebookPanel);

--- a/mito-ai/src/Extensions/AiChat/hooks/useAgentReview.ts
+++ b/mito-ai/src/Extensions/AiChat/hooks/useAgentReview.ts
@@ -19,7 +19,7 @@ import {
     getAIOptimizedCellsInNotebookPanel,
     highlightCodeCellInNotebookPanel,
     scrollToCell,
-    writeCodeToCellByIDInNotebookPanel
+    writeContentToCellByIDInNotebookPanel
 } from '../../../utils/notebook';
 import { AgentReviewStatus, ChangedCell } from '../ChatTaskpane';
 import { NotebookPanel } from '@jupyterlab/notebook';
@@ -128,6 +128,7 @@ export const useAgentReview = ({
                 if (originalCell.code !== currentCell.code) {
                     changedCells.push({
                         cellId: currentCell.id,
+                        cellType: currentCell.cell_type,
                         originalCode: originalCell.code,
                         currentCode: currentCell.code,
                         reviewed: false,
@@ -139,6 +140,7 @@ export const useAgentReview = ({
                 // Cell was added (doesn't exist in original snapshot)
                 changedCells.push({
                     cellId: currentCell.id,
+                    cellType: currentCell.cell_type,
                     originalCode: '',
                     currentCode: currentCell.code,
                     reviewed: false,
@@ -155,6 +157,7 @@ export const useAgentReview = ({
                 // Cell was removed
                 changedCells.push({
                     cellId: originalCell.id,
+                    cellType: originalCell.cell_type,
                     originalCode: originalCell.code,
                     currentCode: '',
                     reviewed: false,
@@ -262,7 +265,12 @@ export const useAgentReview = ({
             const { unifiedCodeString, unifiedDiffs } = getCodeDiffsAndUnifiedCodeString(change.originalCode, change.currentCode);
 
             // Write the unified code string to the cell
-            writeCodeToCellByIDInNotebookPanel(agentTargetNotebookPanelRef.current, unifiedCodeString, change.cellId);
+            writeContentToCellByIDInNotebookPanel(
+                agentTargetNotebookPanelRef.current,
+                unifiedCodeString,
+                change.cellId,
+                change.cellType,
+            );
 
             // Apply diff stripes to this cell
             applyDiffStripesToCell(agentTargetNotebookPanelRef.current, change.cellId, unifiedDiffs, codeDiffStripesCompartments.current);

--- a/mito-ai/src/Extensions/AiChat/hooks/useCodeReview.ts
+++ b/mito-ai/src/Extensions/AiChat/hooks/useCodeReview.ts
@@ -15,7 +15,7 @@ import {
     getCellCodeByID,
     getActiveCellID,
     setActiveCellByID,
-    writeCodeToCellByID,
+    writeContentToCellByID,
     highlightCodeCell,
     scrollToCell,
 } from '../../../utils/notebook';
@@ -91,7 +91,7 @@ export const useCodeReview = ({
 
         // Temporarily write the unified code string to the active cell so we can display
         // the code diffs to the user
-        writeCodeToCellByID(notebookTracker, unifiedCodeString, updateCellID);
+        writeContentToCellByID(notebookTracker, unifiedCodeString, updateCellID, 'code');
         updateCodeCellsExtensions(unifiedDiffs);
 
         // Briefly highlight the code cell to draw the user's attention to it
@@ -127,7 +127,7 @@ export const useCodeReview = ({
         cellStateBeforeDiff.current = undefined;
 
         if (codeCellID !== undefined) {
-            writeCodeToCellByID(notebookTracker, code, codeCellID);
+            writeContentToCellByID(notebookTracker, code, codeCellID, 'code');
             updateCellToolbarButtons();
         }
     };

--- a/mito-ai/src/Extensions/ChartWizard/hooks/useDebouncedNotebookUpdate.ts
+++ b/mito-ai/src/Extensions/ChartWizard/hooks/useDebouncedNotebookUpdate.ts
@@ -6,7 +6,7 @@
 import { useRef, useEffect, useCallback } from 'react';
 import { NotebookActions } from '@jupyterlab/notebook';
 import { ChartWizardData } from '../ChartWizardPlugin';
-import { writeCodeToCellByIDInNotebookPanel } from '../../../utils/notebook';
+import { writeContentToCellByIDInNotebookPanel } from '../../../utils/notebook';
 
 interface UseDebouncedNotebookUpdateProps {
     chartData: ChartWizardData | null;
@@ -49,7 +49,7 @@ export const useDebouncedNotebookUpdate = ({
             if (!notebookPanel) return;
 
             // Update the cell code
-            writeCodeToCellByIDInNotebookPanel(notebookPanel, updatedCode, chartData.cellId);
+            writeContentToCellByIDInNotebookPanel(notebookPanel, updatedCode, chartData.cellId, 'code');
 
             // Re-execute the cell to show updated chart
             const notebook = notebookPanel.content;

--- a/mito-ai/src/tests/AiChat/AgentReviewUtils.test.tsx
+++ b/mito-ai/src/tests/AiChat/AgentReviewUtils.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { NotebookPanel } from '@jupyterlab/notebook';
+import {
+    acceptAllCellEdits,
+    acceptSingleCellEdit,
+    rejectSingleCellEdit
+} from '../../Extensions/AiChat/AgentReviewUtils';
+import { ChangedCell } from '../../Extensions/AiChat/ChatTaskpane';
+import * as notebookUtils from '../../utils/notebook';
+
+jest.mock('../../utils/notebook', () => ({
+    scrollToNextCellWithDiff: jest.fn(),
+    writeContentToCellByIDInNotebookPanel: jest.fn(),
+    deleteCellByIDInNotebookPanel: jest.fn(),
+    runCellByIDInBackground: jest.fn(),
+}));
+
+jest.mock('../../utils/codeDiff', () => ({
+    turnOffDiffsForCell: jest.fn(),
+}));
+
+describe('AgentReviewUtils markdown handling', () => {
+    const notebookPanel = {} as NotebookPanel;
+    const codeDiffStripesCompartments = { current: new Map<string, any>() };
+    const setAgentReviewStatus = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('acceptSingleCellEdit preserves markdown content', () => {
+        const changedCells: ChangedCell[] = [
+            {
+                cellId: 'cell-1',
+                cellType: 'markdown',
+                originalCode: '# old',
+                currentCode: '# new',
+                reviewed: false,
+                isNewCell: false,
+            },
+        ];
+
+        acceptSingleCellEdit(
+            'cell-1',
+            notebookPanel,
+            [
+                {
+                    id: 'cell-1',
+                    cell_type: 'markdown',
+                    code: '# Header\n\n```python\nprint("x")\n```',
+                },
+            ],
+            codeDiffStripesCompartments as any,
+            changedCells,
+            setAgentReviewStatus,
+        );
+
+        expect(notebookUtils.writeContentToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+            notebookPanel,
+            '# Header\n\n```python\nprint("x")\n```',
+            'cell-1',
+            'markdown',
+        );
+    });
+
+    test('acceptAllCellEdits preserves markdown content', () => {
+        const changedCells: ChangedCell[] = [
+            {
+                cellId: 'cell-1',
+                cellType: 'markdown',
+                originalCode: '# old',
+                currentCode: '# new',
+                reviewed: false,
+                isNewCell: false,
+            },
+        ];
+
+        acceptAllCellEdits(
+            notebookPanel,
+            [
+                {
+                    id: 'cell-1',
+                    cell_type: 'markdown',
+                    code: '# Header\n\n```python\nprint("x")\n```',
+                },
+            ],
+            codeDiffStripesCompartments as any,
+            changedCells,
+        );
+
+        expect(notebookUtils.writeContentToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+            notebookPanel,
+            '# Header\n\n```python\nprint("x")\n```',
+            'cell-1',
+            'markdown',
+        );
+    });
+
+    test('rejectSingleCellEdit preserves markdown content when reverting', () => {
+        const changedCells: ChangedCell[] = [
+            {
+                cellId: 'cell-1',
+                cellType: 'markdown',
+                originalCode: '# Header\n\n```python\nprint("old")\n```',
+                currentCode: '# Header\n\n```python\nprint("new")\n```',
+                reviewed: false,
+                isNewCell: false,
+            },
+        ];
+
+        rejectSingleCellEdit(
+            'cell-1',
+            notebookPanel,
+            codeDiffStripesCompartments as any,
+            changedCells,
+            setAgentReviewStatus,
+        );
+
+        expect(notebookUtils.writeContentToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+            notebookPanel,
+            '# Header\n\n```python\nprint("old")\n```',
+            'cell-1',
+            'markdown',
+        );
+    });
+});

--- a/mito-ai/src/tests/utils/agentActions.test.tsx
+++ b/mito-ai/src/tests/utils/agentActions.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
+import { acceptAndRunCellUpdate } from '../../utils/agentActions';
+import * as notebookUtils from '../../utils/notebook';
+
+jest.mock('@jupyterlab/notebook', () => ({
+    NotebookActions: {
+        changeCellType: jest.fn(),
+        run: jest.fn(() => Promise.resolve()),
+    },
+}));
+
+jest.mock('../../utils/sleep', () => ({
+    sleep: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/notebook', () => ({
+    createCodeCellAfterCellIDAndActivate: jest.fn(),
+    didCellExecutionError: jest.fn(),
+    getActiveCellIDInNotebookPanel: jest.fn(() => 'active-cell-id'),
+    getCellIndexByIDInNotebookPanel: jest.fn(() => 0),
+    setActiveCellByIDInNotebookPanel: jest.fn(),
+    writeCodeToCellByIDInNotebookPanel: jest.fn(),
+    scrollToCell: jest.fn(),
+}));
+
+describe('acceptAndRunCellUpdate', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const createNotebookPanel = (): NotebookPanel =>
+        ({
+            content: {},
+            context: {
+                sessionContext: {},
+            },
+        } as unknown as NotebookPanel);
+
+    test('passes removeCodeFormatting=false for markdown cell updates', async () => {
+        const notebookPanel = createNotebookPanel();
+
+        const result = await acceptAndRunCellUpdate(
+            {
+                type: 'new',
+                after_cell_id: 'new cell',
+                code: '# Title\n\n```python\nprint("x")\n```',
+                cell_type: 'markdown',
+            } as any,
+            notebookPanel,
+        );
+
+        expect(result).toEqual({ success: true });
+        expect(notebookUtils.writeCodeToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+            notebookPanel,
+            '# Title\n\n```python\nprint("x")\n```',
+            'active-cell-id',
+            false,
+        );
+        expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'markdown');
+    });
+
+    test('passes removeCodeFormatting=true for code cell updates', async () => {
+        const notebookPanel = createNotebookPanel();
+
+        const result = await acceptAndRunCellUpdate(
+            {
+                type: 'new',
+                after_cell_id: 'new cell',
+                code: '```python\nprint("x")\n```',
+                cell_type: 'code',
+            } as any,
+            notebookPanel,
+        );
+
+        expect(result).toEqual({ success: true });
+        expect(notebookUtils.writeCodeToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+            notebookPanel,
+            '```python\nprint("x")\n```',
+            'active-cell-id',
+            true,
+        );
+        expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'code');
+    });
+});

--- a/mito-ai/src/tests/utils/agentActions.test.tsx
+++ b/mito-ai/src/tests/utils/agentActions.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../../utils/notebook', () => ({
     getActiveCellIDInNotebookPanel: jest.fn(() => 'active-cell-id'),
     getCellIndexByIDInNotebookPanel: jest.fn(() => 0),
     setActiveCellByIDInNotebookPanel: jest.fn(),
-    writeCodeToCellByIDInNotebookPanel: jest.fn(),
+    writeContentToCellByIDInNotebookPanel: jest.fn(),
     scrollToCell: jest.fn(),
 }));
 
@@ -41,7 +41,7 @@ describe('acceptAndRunCellUpdate', () => {
             },
         } as unknown as NotebookPanel);
 
-    test('passes removeCodeFormatting=false for markdown cell updates', async () => {
+    test('passes markdown cell_type for markdown cell updates', async () => {
         const notebookPanel = createNotebookPanel();
 
         const result = await acceptAndRunCellUpdate(
@@ -55,16 +55,16 @@ describe('acceptAndRunCellUpdate', () => {
         );
 
         expect(result).toEqual({ success: true });
-        expect(notebookUtils.writeCodeToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+        expect(notebookUtils.writeContentToCellByIDInNotebookPanel).toHaveBeenCalledWith(
             notebookPanel,
             '# Title\n\n```python\nprint("x")\n```',
             'active-cell-id',
-            false,
+            'markdown',
         );
         expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'markdown');
     });
 
-    test('passes removeCodeFormatting=true for code cell updates', async () => {
+    test('passes code cell_type for code cell updates', async () => {
         const notebookPanel = createNotebookPanel();
 
         const result = await acceptAndRunCellUpdate(
@@ -78,11 +78,11 @@ describe('acceptAndRunCellUpdate', () => {
         );
 
         expect(result).toEqual({ success: true });
-        expect(notebookUtils.writeCodeToCellByIDInNotebookPanel).toHaveBeenCalledWith(
+        expect(notebookUtils.writeContentToCellByIDInNotebookPanel).toHaveBeenCalledWith(
             notebookPanel,
             '```python\nprint("x")\n```',
             'active-cell-id',
-            true,
+            'code',
         );
         expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'code');
     });

--- a/mito-ai/src/tests/utils/notebook.test.tsx
+++ b/mito-ai/src/tests/utils/notebook.test.tsx
@@ -4,9 +4,9 @@
  */
 
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { writeCodeToCellByIDInNotebookPanel } from '../../utils/notebook';
+import { writeContentToCellByIDInNotebookPanel } from '../../utils/notebook';
 
-describe('writeCodeToCellByIDInNotebookPanel', () => {
+describe('writeContentToCellByIDInNotebookPanel', () => {
     const cellId = 'cell-1';
 
     const createMockNotebookPanel = () => {
@@ -28,19 +28,20 @@ describe('writeCodeToCellByIDInNotebookPanel', () => {
         return { notebookPanel, cell };
     };
 
-    test('strips markdown code fences by default', () => {
+    test('strips markdown code fences for code cells', () => {
         const { notebookPanel, cell } = createMockNotebookPanel();
 
-        writeCodeToCellByIDInNotebookPanel(
+        writeContentToCellByIDInNotebookPanel(
             notebookPanel,
             "```python\nprint('hello')\n```",
             cellId,
+            'code',
         );
 
         expect(cell.model.sharedModel.source).toBe("print('hello')");
     });
 
-    test('preserves full markdown content when removeCodeFormatting is false', () => {
+    test('preserves full markdown content for markdown cells', () => {
         const { notebookPanel, cell } = createMockNotebookPanel();
         const markdown = `# Header
 
@@ -52,7 +53,7 @@ print('hello')
 
 Some text after code.`;
 
-        writeCodeToCellByIDInNotebookPanel(notebookPanel, markdown, cellId, false);
+        writeContentToCellByIDInNotebookPanel(notebookPanel, markdown, cellId, 'markdown');
 
         expect(cell.model.sharedModel.source).toBe(markdown);
     });

--- a/mito-ai/src/tests/utils/notebook.test.tsx
+++ b/mito-ai/src/tests/utils/notebook.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { writeCodeToCellByIDInNotebookPanel } from '../../utils/notebook';
+
+describe('writeCodeToCellByIDInNotebookPanel', () => {
+    const cellId = 'cell-1';
+
+    const createMockNotebookPanel = () => {
+        const cell = {
+            model: {
+                id: cellId,
+                sharedModel: {
+                    source: '',
+                },
+            },
+        };
+
+        const notebookPanel = {
+            content: {
+                widgets: [cell],
+            },
+        } as unknown as NotebookPanel;
+
+        return { notebookPanel, cell };
+    };
+
+    test('strips markdown code fences by default', () => {
+        const { notebookPanel, cell } = createMockNotebookPanel();
+
+        writeCodeToCellByIDInNotebookPanel(
+            notebookPanel,
+            "```python\nprint('hello')\n```",
+            cellId,
+        );
+
+        expect(cell.model.sharedModel.source).toBe("print('hello')");
+    });
+
+    test('preserves full markdown content when removeCodeFormatting is false', () => {
+        const { notebookPanel, cell } = createMockNotebookPanel();
+        const markdown = `# Header
+
+Some text before code.
+
+\`\`\`python
+print('hello')
+\`\`\`
+
+Some text after code.`;
+
+        writeCodeToCellByIDInNotebookPanel(notebookPanel, markdown, cellId, false);
+
+        expect(cell.model.sharedModel.source).toBe(markdown);
+    });
+});

--- a/mito-ai/src/utils/agentActions.tsx
+++ b/mito-ai/src/utils/agentActions.tsx
@@ -14,7 +14,7 @@ import {
     getActiveCellIDInNotebookPanel, 
     getCellIndexByIDInNotebookPanel,
     setActiveCellByIDInNotebookPanel, 
-    writeCodeToCellByIDInNotebookPanel, 
+    writeContentToCellByIDInNotebookPanel, 
     scrollToCell, 
 } from "./notebook"
 import { CellUpdate } from "../websockets/completions/CompletionModels"
@@ -85,11 +85,11 @@ export const acceptAndRunCellUpdate = async (
         };
     }
 
-    writeCodeToCellByIDInNotebookPanel(
+    writeContentToCellByIDInNotebookPanel(
         notebookPanel,
         cellUpdate.code,
         cellID,
-        cellUpdate.cell_type !== 'markdown',
+        cellUpdate.cell_type,
     )
 
     // We always create code cells, and then convert to markdown if necessary.

--- a/mito-ai/src/utils/agentActions.tsx
+++ b/mito-ai/src/utils/agentActions.tsx
@@ -12,16 +12,22 @@ import {
     createCodeCellAfterCellIDAndActivate,
     didCellExecutionError, 
     getActiveCellIDInNotebookPanel, 
+    getCellIndexByIDInNotebookPanel,
     setActiveCellByIDInNotebookPanel, 
     writeCodeToCellByIDInNotebookPanel, 
     scrollToCell, 
 } from "./notebook"
 import { CellUpdate } from "../websockets/completions/CompletionModels"
 
+export interface ICellUpdateApplyResult {
+    success: boolean;
+    errorMessage?: string;
+}
+
 export const acceptAndRunCellUpdate = async (
     cellUpdate: CellUpdate,
     notebookPanel: NotebookPanel,
-): Promise<void> => {
+): Promise<ICellUpdateApplyResult> => {
 
     // If the cellUpdate is creating a new code cell, insert it 
     // before previewing and accepting the code. It is safe to do this 
@@ -30,11 +36,34 @@ export const acceptAndRunCellUpdate = async (
     if (cellUpdate.type === 'new' ) {
         // makes the cell the active cell
         if (cellUpdate.after_cell_id === undefined || cellUpdate.after_cell_id === null) {
-            console.error('after_cell_id is required for new cell creation')
-            return
+            return {
+                success: false,
+                errorMessage: 'CELL_UPDATE failed: `after_cell_id` is required for new cell creation.',
+            };
+        }
+        if (
+            cellUpdate.after_cell_id !== 'new cell' &&
+            getCellIndexByIDInNotebookPanel(notebookPanel, cellUpdate.after_cell_id) === undefined
+        ) {
+            return {
+                success: false,
+                errorMessage: `CELL_UPDATE failed: after_cell_id '${cellUpdate.after_cell_id}' was not found in the current notebook.`,
+            };
         }
         createCodeCellAfterCellIDAndActivate(notebookPanel, cellUpdate.after_cell_id)
     } else {
+        if (!cellUpdate.id) {
+            return {
+                success: false,
+                errorMessage: 'CELL_UPDATE failed: `id` is required for modification updates.',
+            };
+        }
+        if (getCellIndexByIDInNotebookPanel(notebookPanel, cellUpdate.id) === undefined) {
+            return {
+                success: false,
+                errorMessage: `CELL_UPDATE failed: target cell id '${cellUpdate.id}' was not found in the current notebook.`,
+            };
+        }
         setActiveCellByIDInNotebookPanel(notebookPanel, cellUpdate.id)
     }
 
@@ -42,10 +71,19 @@ export const acceptAndRunCellUpdate = async (
     const context = notebookPanel.context;
 
     if (notebook === undefined) {
-        return;
+        return {
+            success: false,
+            errorMessage: 'CELL_UPDATE failed: notebook is unavailable.',
+        };
     }
 
     const cellID = getActiveCellIDInNotebookPanel(notebookPanel)
+    if (!cellID) {
+        return {
+            success: false,
+            errorMessage: 'CELL_UPDATE failed: no active cell could be resolved for writing.',
+        };
+    }
 
     writeCodeToCellByIDInNotebookPanel(notebookPanel, cellUpdate.code, cellID)
 
@@ -73,6 +111,7 @@ export const acceptAndRunCellUpdate = async (
     // has updated the state of the variables. This ensures that on the next Ai message
     // gets the most up to date data.
     await sleep(1000)
+    return { success: true };
 }
 
 export const runAllCells = async (

--- a/mito-ai/src/utils/agentActions.tsx
+++ b/mito-ai/src/utils/agentActions.tsx
@@ -85,7 +85,12 @@ export const acceptAndRunCellUpdate = async (
         };
     }
 
-    writeCodeToCellByIDInNotebookPanel(notebookPanel, cellUpdate.code, cellID)
+    writeCodeToCellByIDInNotebookPanel(
+        notebookPanel,
+        cellUpdate.code,
+        cellID,
+        cellUpdate.cell_type !== 'markdown',
+    )
 
     // We always create code cells, and then convert to markdown if necessary.
     if (cellUpdate.cell_type === 'markdown') {

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -115,21 +115,23 @@ export const writeCodeToCellByID = (
     notebookTracker: INotebookTracker,
     code: string | undefined,
     codeCellID: string,
+    removeCodeFormatting: boolean = true,
 ): void => {
     const notebookPanel = notebookTracker.currentWidget
-    writeCodeToCellByIDInNotebookPanel(notebookPanel, code, codeCellID)
+    writeCodeToCellByIDInNotebookPanel(notebookPanel, code, codeCellID, removeCodeFormatting)
 }
 
 export const writeCodeToCellByIDInNotebookPanel = (
     notebookPanel: NotebookPanel | null,
     code: string | undefined,
     codeCellID: string | undefined,
+    removeCodeFormatting: boolean = true,
 ): void => {
     if (code === undefined || codeCellID === undefined) {
         return;
     }
 
-    const codeMirrorValidCode = removeMarkdownCodeFormatting(code);
+    const codeMirrorValidCode = removeCodeFormatting ? removeMarkdownCodeFormatting(code) : code;
     const notebook = notebookPanel?.content;
     const cell = notebook?.widgets.find(cell => cell.model.id === codeCellID);
 

--- a/mito-ai/src/utils/notebook.tsx
+++ b/mito-ai/src/utils/notebook.tsx
@@ -111,29 +111,33 @@ export const setActiveCellByIDInNotebookPanel = (notebookPanel: NotebookPanel | 
     }
 }
 
-export const writeCodeToCellByID = (
-    notebookTracker: INotebookTracker,
-    code: string | undefined,
-    codeCellID: string,
-    removeCodeFormatting: boolean = true,
-): void => {
-    const notebookPanel = notebookTracker.currentWidget
-    writeCodeToCellByIDInNotebookPanel(notebookPanel, code, codeCellID, removeCodeFormatting)
+const shouldRemoveCodeFormatting = (cellType: string): boolean => {
+    return cellType !== 'markdown';
 }
 
-export const writeCodeToCellByIDInNotebookPanel = (
-    notebookPanel: NotebookPanel | null,
-    code: string | undefined,
-    codeCellID: string | undefined,
-    removeCodeFormatting: boolean = true,
+export const writeContentToCellByID = (
+    notebookTracker: INotebookTracker,
+    content: string | undefined,
+    cellID: string,
+    cellType: string,
 ): void => {
-    if (code === undefined || codeCellID === undefined) {
+    const notebookPanel = notebookTracker.currentWidget
+    writeContentToCellByIDInNotebookPanel(notebookPanel, content, cellID, cellType)
+}
+
+export const writeContentToCellByIDInNotebookPanel = (
+    notebookPanel: NotebookPanel | null,
+    content: string | undefined,
+    cellID: string | undefined,
+    cellType: string,
+): void => {
+    if (content === undefined || cellID === undefined) {
         return;
     }
 
-    const codeMirrorValidCode = removeCodeFormatting ? removeMarkdownCodeFormatting(code) : code;
+    const codeMirrorValidCode = shouldRemoveCodeFormatting(cellType) ? removeMarkdownCodeFormatting(content) : content;
     const notebook = notebookPanel?.content;
-    const cell = notebook?.widgets.find(cell => cell.model.id === codeCellID);
+    const cell = notebook?.widgets.find(cell => cell.model.id === cellID);
 
     if (cell) {
         cell.model.sharedModel.source = codeMirrorValidCode;
@@ -520,7 +524,7 @@ export const deleteCellByIDInNotebookPanel = (notebookPanel: NotebookPanel | nul
     // Guard: don't delete the very last cell in the notebook
     if (notebook.widgets.length <= 1) {
         // Just clear the cell's content instead
-        writeCodeToCellByIDInNotebookPanel(notebookPanel, '', cellId);
+        writeContentToCellByIDInNotebookPanel(notebookPanel, '', cellId, 'code');
         return true;
     }
 

--- a/tests/mitoai_ui_tests/agent.spec.ts
+++ b/tests/mitoai_ui_tests/agent.spec.ts
@@ -7,6 +7,7 @@ import { test, expect } from '../fixtures';
 import {
     createAndRunNotebookWithCells,
     waitForIdle,
+    typeInNotebookCell,
 } from '../jupyter_utils/jupyterlab_utils';
 import {
     sendMessageToAgent,
@@ -136,8 +137,10 @@ test.describe.parallel("Stop Agent", () => {
     });
 
     test("Stop agent during error fixup", async ({ page }) => {
-        // This is hopefully an impossible thing for the agent to pass. 
-        await sendMessageToAgent(page, "Import the file nba_data.csv. IMPORTANT: THIS CODE IS GOING TO ERROR. NEVER GENERATE A CORRECT VERSION OF THIS CODE.");
+        // Seed the notebook with invalid code so "Run all cells" triggers auto-fixup.
+        await typeInNotebookCell(page, 0, "print(1", true);
+
+        await sendMessageToAgent(page, "Run all cells");
         await waitForIdle(page);
 
         // Wait for the "trying again" message to appear
@@ -202,8 +205,10 @@ test.describe.parallel("Agent mode auto error fixup", () => {
     });
 
     test("Auto Error Fixup", async ({ page }) => {
+        // Seed the notebook with invalid code so "Run all cells" triggers auto-fixup.
+        await typeInNotebookCell(page, 0, "print(1", true);
 
-        await sendMessageToAgent(page, "Import the file nba_data.csv");
+        await sendMessageToAgent(page, "Run all cells");
         await waitForIdle(page);
 
         // Check that the agent eventually sends a message that says it is trying again


### PR DESCRIPTION
# Description

- When a cell_update writing markdown contained a python codeblock, we previously only wrote the python code into the markdown cell and ignored everything else! We now write the entire markdown cell. 
- When a cell_update fails because (ie: the cell we try to insert after does not exist in the notebook) we tell the agent about it and still don't show it to the user so we can retry with the additional information about why the tool failed. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent edit application and review workflows (cell type handling + tool failure paths), which could affect notebook mutation behavior and agent retry loops, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes agent-driven notebook edits so **markdown cell updates preserve full markdown content**, including fenced code blocks, by introducing `writeContentToCellByID(InNotebookPanel)` (cell-type aware) and plumbing `cellType` through agent review and code review flows.
> 
> Tightens `cell_update` execution: `acceptAndRunCellUpdate` now validates target/after-cell IDs and returns structured failure details; the frontend tool executor propagates these failures, while the core UI-optimized history no longer persists failed `cell_update` messages (only failed `run_all_cells`), enabling silent retries. Adds targeted unit tests (TS + core runner) and updates UI tests to deterministically trigger auto error-fixup via a seeded syntax error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d4bf862e621c98a188c952cc34da589d160005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->