### PR TITLE
Fixed Imports in Mitosheet (VS Code)

### DIFF
--- a/mitosheet/mitosheet/vscode/v1/spreadsheet.py
+++ b/mitosheet/mitosheet/vscode/v1/spreadsheet.py
@@ -80,6 +80,25 @@ class _MitoVSCodeHandler(BaseHTTPRequestHandler):
             return
 
         msg_id = msg.get('id', '')
+        event_type = msg.get('event', '')
+
+        # log_event messages are fire-and-forget telemetry: the Mito backend
+        # never calls mito_send for them, so polling for a matching response
+        # would block this HTTP connection until _MAX_DELAY elapses. Browsers
+        # cap the number of concurrent HTTP/1.1 connections per origin (~6),
+        # so as log_events pile up (e.g. while navigating the file browser),
+        # we exhaust the connection pool and subsequent API calls hang — this
+        # is what caused "Loading folder contents..." to never resolve after
+        # a couple of directory navigations.
+        #
+        # Process the log event synchronously and respond immediately.
+        if event_type == 'log_event':
+            try:
+                self.server.mito_backend.receive_message(msg)
+            except Exception:
+                pass
+            self._send_json({'event': 'response', 'id': msg_id, 'data': None})
+            return
 
         # Process the message on the backend
         self.server.mito_backend.receive_message(msg)


### PR DESCRIPTION
# Description

In vs code, imports get stcuk after the second or third directory jump. For example if you go up or down a few directories, you'll get stuck on a "Loading folder contents..." message. 

Fixes https://github.com/mito-ds/mito/issues/2223. 

# Testing

In VS Code, use the Mitosheet import menu to navigate around your computer. Make sure imports work.

Also make sure imports work in Jupyter Lab.

# Documentation

N/A - This fixes a bug. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VS Code HTTP message handling by short-circuiting `log_event` requests to avoid long-poll blocking; risk is limited but could affect telemetry delivery or response expectations for that event type.
> 
> **Overview**
> Fixes a VS Code import hang by treating frontend `log_event` telemetry as **fire-and-forget**: the handler now processes these messages synchronously and returns an immediate `response` instead of long-polling for a backend reply.
> 
> This prevents accumulated telemetry POSTs from exhausting the browser connection pool (and stalling other API calls like folder navigation) while keeping existing request/response polling behavior unchanged for all other events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef51cd5080c803f8869c0a15dbef2186f999582e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->