### PR TITLE
Fix/windows GitHub pytests

### DIFF
--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test-mitoai-backend:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]

--- a/.github/workflows/test-mito-ai-cli.yml
+++ b/.github/workflows/test-mito-ai-cli.yml
@@ -22,7 +22,7 @@ jobs:
   test-mito-ai-cli:
     name: ${{ matrix.os }} / Py ${{ matrix.python-version }} / ${{ matrix.llm-backend }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]

--- a/.github/workflows/test-mito-ai-core-backend.yml
+++ b/.github/workflows/test-mito-ai-core-backend.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test-mito-ai-core-backend:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]

--- a/.github/workflows/test-mito-ai-mcp.yml
+++ b/.github/workflows/test-mito-ai-mcp.yml
@@ -22,7 +22,7 @@ jobs:
   test-mito-ai-mcp:
     name: ${{ matrix.os }} / Py ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]

--- a/.github/workflows/test-mito-sql-cell.yml
+++ b/.github/workflows/test-mito-sql-cell.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test-mito-sql-cell-jupyterlab:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ['3.10', '3.12']

--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test-mitoinstaller:
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   test-mitosheet-python:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/mito-ai-cli/pyproject.toml
+++ b/mito-ai-cli/pyproject.toml
@@ -20,10 +20,12 @@ mito-ai = "mito_ai_cli.main:main"
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-timeout",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+timeout = 30
 markers = [
     "integration: live CLI / full stack (opt-in via MITO_AI_CLI_E2E=1)",
 ]

--- a/mito-ai-core/pyproject.toml
+++ b/mito-ai-core/pyproject.toml
@@ -47,9 +47,13 @@ litellm = ["litellm"]
 test = [
     "pytest",
     "pytest-asyncio",
+    "pytest-timeout",
     "mypy",
     "types-requests",
 ]
+
+[tool.pytest.ini_options]
+timeout = 30
 
 [tool.hatch.build.targets.wheel]
 packages = ["mito_ai_core"]

--- a/mito-ai-mcp/pyproject.toml
+++ b/mito-ai-mcp/pyproject.toml
@@ -23,10 +23,12 @@ mito-ai-mcp = "mito_ai_mcp.server:main"
 test = [
     "pytest",
     "pytest-asyncio",
+    "pytest-timeout",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+timeout = 30
 markers = [
     "integration: live MCP / full stack",
 ]

--- a/mito-ai-mcp/pyproject.toml
+++ b/mito-ai-mcp/pyproject.toml
@@ -28,7 +28,7 @@ test = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-timeout = 30
+timeout = 60
 markers = [
     "integration: live MCP / full stack",
 ]

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -57,6 +57,7 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 test = [
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
+    "pytest-timeout",
     "mypy>=1.8.0",
     "types-tornado>=5.1.1",
     "types-requests>=2.25.0",
@@ -114,3 +115,4 @@ ignore = ["W002"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
+timeout = 30

--- a/mito-sql-cell/pyproject.toml
+++ b/mito-sql-cell/pyproject.toml
@@ -42,11 +42,15 @@ test = [
     "coverage",
     "Faker",
     "pytest",
+    "pytest-timeout",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-jupyter[server]>=0.6.0",
     "mito_sql_cell[optional_features]",
 ]
+
+[tool.pytest.ini_options]
+timeout = 30
 
 [tool.hatch.version]
 source = "nodejs"

--- a/mitoinstaller/pytest.ini
+++ b/mitoinstaller/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+timeout = 30

--- a/mitoinstaller/requirements.txt
+++ b/mitoinstaller/requirements.txt
@@ -1,4 +1,5 @@
 analytics-python
 pytest
+pytest-timeout
 colorama
 termcolor

--- a/mitosheet/pytest.ini
+++ b/mitosheet/pytest.ini
@@ -3,3 +3,4 @@
 
 [pytest]
 testpaths = mitosheet/tests
+timeout = 30

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -96,6 +96,7 @@ setup_args = dict(
     extras_require = {
         'test': [
             'pytest',
+            'pytest-timeout',
             'flake8',
             'types-chardet',
             'types-requests',

--- a/tests/mac-setup.sh
+++ b/tests/mac-setup.sh
@@ -11,16 +11,18 @@ pip install -r requirements.txt;
 # Install necessary node packages
 jlpm install
 
-# Install playwright. If the user provides a browser, install only that browser
-# Otherwise, install all browsers. This is primarily used so that the CI can
-# install only the necessary browsers.
-if [ $# -eq 0 ]
-  then
-    npx playwright install chromium webkit firefox || echo "Warning: Failed to install some browsers"
-    npx playwright install chrome || echo "Warning: Failed to install Chrome"
-  else
-    npx playwright install $1 || echo "Warning: Failed to install specified browser"
-    npx playwright install || echo "Warning: Failed to install additional browsers"
+# Install Playwright browsers.
+# In CI, default to chromium only to reduce setup time.
+# Locally, preserve broad browser install behavior unless a browser is provided.
+if [ "${CI:-}" = "true" ]; then
+  BROWSER_TO_INSTALL="${1:-chromium}"
+  npx playwright install "$BROWSER_TO_INSTALL" || echo "Warning: Failed to install specified browser"
+elif [ $# -eq 0 ]; then
+  npx playwright install chromium webkit firefox || echo "Warning: Failed to install some browsers"
+  npx playwright install chrome || echo "Warning: Failed to install Chrome"
+else
+  npx playwright install "$1" || echo "Warning: Failed to install specified browser"
+  npx playwright install || echo "Warning: Failed to install additional browsers"
 fi
 
 


### PR DESCRIPTION
# Description

Reduces GitHub action credit usage:
1. Adds per-test timeouts to pytests to prevent windows from running for 60 minutes and then failing when specific tests hang
2. Adds 20 minute timeout for pytests suites
3. Reduces playwright test setup costs by only installing Chromium instead of all browsers. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to CI configuration and test harness settings, but timeouts may introduce new flakes if legitimate slow tests exceed the new limits.
> 
> **Overview**
> Adds `pytest-timeout` across multiple Python packages and configures per-test timeouts (generally `timeout = 30`, `mito-ai-mcp` at `60`) via `pyproject.toml`/`pytest.ini` to prevent hung tests from consuming long CI runs.
> 
> Reduces GitHub Actions workflow job timeouts to **20 minutes** for the various test suites, and updates `tests/mac-setup.sh` to install **only Chromium in CI** (while keeping broader local installs) to cut Playwright setup time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a1c52545fde83d27ef7f6830fe3df0533b23a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->