### PR TITLE
Mito AI - MCP Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ evals/reports/
 
 # Other 
 mito-ai-mcp/*.mcpb
+mito-ai-mcp/*.ipynb
 
 ## General
 .DS_Store

--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -59,6 +59,7 @@ class AgentRunner:
             "ask_user_question",
             "create_streamlit_app",
             "edit_streamlit_app",
+            "mcp_tool_call",
         }
     )
 
@@ -223,6 +224,7 @@ class AgentRunner:
                 answers=None,
                 scratchpad_code=None,
                 scratchpad_summary=None,
+                mcp_tool_call=None,
             )
         return AgentRunResult(
             final_response=last_response,
@@ -320,6 +322,23 @@ class AgentRunner:
             return await self._tool_executor.edit_streamlit_app(
                 ctx,
                 response.streamlit_app_prompt,
+                response.message,
+            )
+
+        if rtype == "mcp_tool_call":
+            if response.mcp_tool_call is None:
+                return ToolResult(
+                    success=False,
+                    tool_name=rtype,
+                    error_message=(
+                        "Agent returned mcp_tool_call but mcp_tool_call payload is null."
+                    ),
+                )
+            return await self._tool_executor.execute_mcp_tool(
+                ctx,
+                response.mcp_tool_call.mcp_server_id,
+                response.mcp_tool_call.tool_name,
+                response.mcp_tool_call.arguments,
                 response.message,
             )
 

--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -334,11 +334,19 @@ class AgentRunner:
                         "Agent returned mcp_tool_call but mcp_tool_call payload is null."
                     ),
                 )
+            parsed_arguments: dict = {}
+            raw_arguments = response.mcp_tool_call.arguments
+            try:
+                loaded = json.loads(raw_arguments) if raw_arguments else {}
+                if isinstance(loaded, dict):
+                    parsed_arguments = loaded
+            except Exception:
+                parsed_arguments = {}
             return await self._tool_executor.execute_mcp_tool(
                 ctx,
                 response.mcp_tool_call.mcp_server_id,
                 response.mcp_tool_call.tool_name,
-                response.mcp_tool_call.arguments,
+                parsed_arguments,
                 response.message,
             )
 

--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -120,6 +120,7 @@ class AgentRunner:
             self._provider,
             ctx.thread_id,
             self._config.enable_get_cell_output,
+            ctx.mcp_tools,
         )
 
         prompt = create_agent_execution_prompt(ctx, user_input)

--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -335,19 +335,33 @@ class AgentRunner:
                         "Agent returned mcp_tool_call but mcp_tool_call payload is null."
                     ),
                 )
-            parsed_arguments: dict = {}
             raw_arguments = response.mcp_tool_call.arguments
             try:
                 loaded = json.loads(raw_arguments) if raw_arguments else {}
-                if isinstance(loaded, dict):
-                    parsed_arguments = loaded
-            except Exception:
-                parsed_arguments = {}
+            except Exception as e:
+                return ToolResult(
+                    success=False,
+                    tool_name=rtype,
+                    error_message=(
+                        "Invalid arguments for mcp_tool_call: arguments must be valid JSON "
+                        f"object string. Parser error: {e}"
+                    ),
+                )
+
+            if not isinstance(loaded, dict):
+                return ToolResult(
+                    success=False,
+                    tool_name=rtype,
+                    error_message=(
+                        "Invalid arguments for mcp_tool_call: expected a JSON object "
+                        f"but received {type(loaded).__name__}."
+                    ),
+                )
             return await self._tool_executor.execute_mcp_tool(
                 ctx,
                 response.mcp_tool_call.mcp_server_id,
                 response.mcp_tool_call.tool_name,
-                parsed_arguments,
+                loaded,
                 response.message,
             )
 

--- a/mito-ai-core/mito_ai_core/agent/tool_executor.py
+++ b/mito-ai-core/mito_ai_core/agent/tool_executor.py
@@ -11,7 +11,7 @@ object whose methods match the signatures below satisfies the contract.
 
 from __future__ import annotations
 
-from typing import List, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from mito_ai_core.agent.types import AgentContext, ToolResult
 from mito_ai_core.completions.models import CellUpdate
@@ -185,5 +185,30 @@ class ToolExecutor(Protocol):
             Required edit instruction describing the desired app changes.
         message:
             The agent's reasoning/context text for the action.
+        """
+        ...
+
+    async def execute_mcp_tool(
+        self,
+        ctx: AgentContext,
+        mcp_server_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        message: str,
+    ) -> ToolResult:
+        """Execute a configured MCP tool.
+
+        Parameters
+        ----------
+        ctx:
+            Current agent context.
+        mcp_server_id:
+            UUID of the configured MCP server in ``~/.mito/mcp/servers.json``.
+        tool_name:
+            MCP tool name exposed by that server.
+        arguments:
+            JSON arguments object to pass to the tool call.
+        message:
+            Agent's reasoning/context for the call.
         """
         ...

--- a/mito-ai-core/mito_ai_core/agent/types.py
+++ b/mito-ai-core/mito_ai_core/agent/types.py
@@ -96,6 +96,9 @@ class AgentContext:
     additional_context: Optional[List[Dict[str, str]]] = None
     """Extra structured context (e.g. selections, images) from the client."""
 
+    mcp_tools: Optional[List[Dict[str, Any]]] = None
+    """Available MCP tools grouped by configured server."""
+
 
 @runtime_checkable
 class CompletionProvider(Protocol):

--- a/mito-ai-core/mito_ai_core/agent/utils.py
+++ b/mito-ai-core/mito_ai_core/agent/utils.py
@@ -26,6 +26,7 @@ _OPTIONAL_RESPONSE_FIELDS = (
     "answers",
     "scratchpad_code",
     "scratchpad_summary",
+    "mcp_tool_call",
 )
 
 

--- a/mito-ai-core/mito_ai_core/clients/open_ai_utils.py
+++ b/mito-ai-core/mito_ai_core/clients/open_ai_utils.py
@@ -39,6 +39,18 @@ def _openai_strict_schema_fill_required(node: Any) -> None:
             _openai_strict_schema_fill_required(item)
 
 
+def _openai_strict_schema_set_additional_properties_false(node: Any) -> None:
+    """Ensure every object node explicitly declares ``additionalProperties: false``."""
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            node["additionalProperties"] = False
+        for child in node.values():
+            _openai_strict_schema_set_additional_properties_false(child)
+    elif isinstance(node, list):
+        for item in node:
+            _openai_strict_schema_set_additional_properties_false(item)
+
+
 def _prepare_request_data_and_headers(
     last_message_content: Union[str, None],
     ai_completion_data: Dict[str, Any],
@@ -197,15 +209,7 @@ def get_open_ai_completion_function_params(
             json_schema = response_format_info.format.model_json_schema()
 
             _openai_strict_schema_fill_required(json_schema)
-
-            # Add additionalProperties: False to the top-level schema
-            json_schema["additionalProperties"] = False
-
-            # Nested object definitions in $defs need to have additionalProperties set to False also
-            if "$defs" in json_schema:
-                for def_name, def_schema in json_schema["$defs"].items():
-                    if def_schema.get("type") == "object":
-                        def_schema["additionalProperties"] = False
+            _openai_strict_schema_set_additional_properties_false(json_schema)
 
             completion_function_params["response_format"] = {
                 "type": "json_schema",

--- a/mito-ai-core/mito_ai_core/clients/open_ai_utils.py
+++ b/mito-ai-core/mito_ai_core/clients/open_ai_utils.py
@@ -28,8 +28,11 @@ def _openai_strict_schema_fill_required(node: Any) -> None:
     patch the tree after generation.
     """
     if isinstance(node, dict):
-        if node.get("type") == "object" and isinstance(node.get("properties"), dict):
-            props = node["properties"]
+        props = node.get("properties")
+        if isinstance(props, dict):
+            # Some schema producers omit ``type`` even when ``properties`` exists.
+            # OpenAI strict validation still treats this as an object schema.
+            node["type"] = "object"
             if props:
                 node["required"] = sorted(props.keys())
         for child in node.values():
@@ -42,7 +45,9 @@ def _openai_strict_schema_fill_required(node: Any) -> None:
 def _openai_strict_schema_set_additional_properties_false(node: Any) -> None:
     """Ensure every object node explicitly declares ``additionalProperties: false``."""
     if isinstance(node, dict):
-        if node.get("type") == "object":
+        if node.get("type") == "object" or isinstance(node.get("properties"), dict):
+            # Keep object schemas explicit for strict OpenAI JSON schema mode.
+            node["type"] = "object"
             node["additionalProperties"] = False
         for child in node.values():
             _openai_strict_schema_set_additional_properties_false(child)

--- a/mito-ai-core/mito_ai_core/completions/models.py
+++ b/mito-ai-core/mito_ai_core/completions/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import List, Literal, Optional, NewType, Dict, Any
 from openai.types.chat import ChatCompletionMessageParam
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # The ThreadID is the unique identifier for the chat thread.
 ThreadID = NewType('ThreadID', str)
@@ -25,6 +25,12 @@ class CellUpdate(BaseModel):
     cell_type: Optional[Literal['code', 'markdown']] = None
 
 
+class MCPToolCall(BaseModel):
+    mcp_server_id: str
+    tool_name: str
+    arguments: Dict[str, Any] = Field(default_factory=dict)
+
+
 # Using a discriminated Pydantic model doesn't work well with OpenAI's API, 
 # so instead we just combine all of the possible response types into a single class 
 # for now and rely on the AI to respond with the correct types, following the format
@@ -39,6 +45,7 @@ class AgentResponse(BaseModel):
         'edit_streamlit_app', 
         'ask_user_question', 
         'scratchpad',
+        'mcp_tool_call',
     ]
     message: str
     cell_update: Optional[CellUpdate]
@@ -50,6 +57,7 @@ class AgentResponse(BaseModel):
     answers: Optional[List[str]]
     scratchpad_code: Optional[str]
     scratchpad_summary: Optional[str]
+    mcp_tool_call: Optional[MCPToolCall]
     
     
 @dataclass(frozen=True)

--- a/mito-ai-core/mito_ai_core/completions/models.py
+++ b/mito-ai-core/mito_ai_core/completions/models.py
@@ -2,11 +2,12 @@
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
 import traceback
+import json
 from dataclasses import dataclass, field
 from typing import List, Literal, Optional, NewType, Dict, Any
 from openai.types.chat import ChatCompletionMessageParam
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # The ThreadID is the unique identifier for the chat thread.
 ThreadID = NewType('ThreadID', str)
@@ -28,7 +29,23 @@ class CellUpdate(BaseModel):
 class MCPToolCall(BaseModel):
     mcp_server_id: str
     tool_name: str
-    arguments: Dict[str, Any] = Field(default_factory=dict)
+    # Use a JSON string for strict OpenAI schema compatibility.
+    # We still accept dict/list input and coerce it to JSON via validator.
+    arguments: str = "{}"
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def _coerce_arguments_to_json_string(cls, value: Any) -> str:
+        if value is None:
+            return "{}"
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (dict, list)):
+            try:
+                return json.dumps(value)
+            except Exception:
+                return "{}"
+        return str(value)
 
 
 # Using a discriminated Pydantic model doesn't work well with OpenAI's API, 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
@@ -1,11 +1,18 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import List
+import json
+from typing import Any, Dict, List, Optional
 
 from mito_ai_core.agent.types import AgentContext
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
+
+
+def _format_available_mcp_tools(mcp_tools: Optional[List[Dict[str, Any]]]) -> str:
+    if not mcp_tools:
+        return "No MCP tools are currently available."
+    return json.dumps(mcp_tools, indent=2)
 
 
 def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str:
@@ -17,6 +24,10 @@ def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str
         SG.Files(context.files),
         SG.Variables(context.variables),
         SG.SelectedContext(context.additional_context),
+        SG.Generic(
+            "Available MCP Tools",
+            _format_available_mcp_tools(context.mcp_tools),
+        ),
         SG.ActiveCellId(context.active_cell_id),
         SG.Notebook(context.cells),
         SG.Task(f"{user_input}"),

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
@@ -1,18 +1,12 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-import json
-from typing import Any, Dict, List, Optional
+from typing import List
 
 from mito_ai_core.agent.types import AgentContext
+from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
-
-
-def _format_available_mcp_tools(mcp_tools: Optional[List[Dict[str, Any]]]) -> str:
-    if not mcp_tools:
-        return "No MCP tools are currently available."
-    return json.dumps(mcp_tools, indent=2)
 
 
 def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str:
@@ -26,7 +20,7 @@ def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str
         SG.SelectedContext(context.additional_context),
         SG.Generic(
             "Available MCP Tools",
-            _format_available_mcp_tools(context.mcp_tools),
+            format_available_mcp_tools(context.mcp_tools),
         ),
         SG.ActiveCellId(context.active_cell_id),
         SG.Notebook(context.cells),

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
@@ -4,7 +4,6 @@
 from typing import List
 
 from mito_ai_core.agent.types import AgentContext
-from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
 
@@ -18,10 +17,6 @@ def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str
         SG.Files(context.files),
         SG.Variables(context.variables),
         SG.SelectedContext(context.additional_context),
-        SG.Generic(
-            "Available MCP Tools",
-            format_available_mcp_tools(context.mcp_tools),
-        ),
         SG.ActiveCellId(context.active_cell_id),
         SG.Notebook(context.cells),
         SG.Task(f"{user_input}"),

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -346,7 +346,7 @@ Format:
     "mcp_tool_call": {{
         "mcp_server_id": "<string>",
         "tool_name": "<string>",
-        "arguments": {{}}
+        "arguments": "{{}}"
     }}
 }}
 
@@ -354,7 +354,7 @@ Important information:
 1. Only use MCP tools listed in the "Available MCP Tools" section of the current prompt.
 2. The mcp_server_id must exactly match one of the listed server IDs.
 3. The tool_name must exactly match a listed tool for that server.
-4. The arguments object must follow that tool's input_schema. If no arguments are needed, use {}.
+4. The arguments field must be a JSON string whose parsed object follows that tool's input_schema. If no arguments are needed, use "{}".
 5. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
 6. If no suitable MCP tool is available, use ASK_USER_QUESTION or continue with notebook tools as appropriate.
 """))

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -334,6 +334,30 @@ Important information:
     </Example>
 
 """))
+
+    # MCP_TOOL_CALL tool
+    sections.append(SG.Generic("TOOL: MCP_TOOL_CALL", """
+Use this tool when the user's request should be handled by an available MCP tool.
+
+Format:
+{{
+    "type": "mcp_tool_call",
+    "message": "<string>",
+    "mcp_tool_call": {{
+        "mcp_server_id": "<string>",
+        "tool_name": "<string>",
+        "arguments": {{}}
+    }}
+}}
+
+Important information:
+1. Only use MCP tools listed in the "Available MCP Tools" section of the current prompt.
+2. The mcp_server_id must exactly match one of the listed server IDs.
+3. The tool_name must exactly match a listed tool for that server.
+4. The arguments object must follow that tool's input_schema. If no arguments are needed, use {}.
+5. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
+6. If no suitable MCP tool is available, use ASK_USER_QUESTION or continue with notebook tools as appropriate.
+"""))
     
     # CREATE_STREAMLIT_APP tool
     sections.append(SG.Generic("TOOL: CREATE_STREAMLIT_APP", """

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -1,8 +1,9 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import List
+from typing import Any, Dict, List, Optional
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
+from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
 from mito_ai_core.completions.prompt_builders.prompt_constants import (
     ABOUT_MITO,
     CHART_CONFIG_RULES,
@@ -15,7 +16,10 @@ from mito_ai_core.completions.prompt_builders.prompt_constants import (
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
 from mito_ai_core.rules.utils import get_default_rules_content
 
-def create_agent_system_message_prompt(include_cell_output_tool: bool) -> str:
+def create_agent_system_message_prompt(
+    include_cell_output_tool: bool,
+    mcp_tools: Optional[List[Dict[str, Any]]] = None,
+) -> str:
     
     # GET_CELL_OUTPUT requires a Chrome-based browser.
     # This constant helps us replace the phrase 'or GET_CELL_OUTPUT' with ''
@@ -336,6 +340,10 @@ Important information:
 """))
 
     # MCP_TOOL_CALL tool
+    sections.append(
+        SG.Generic("Available MCP Tools", format_available_mcp_tools(mcp_tools))
+    )
+
     sections.append(SG.Generic("TOOL: MCP_TOOL_CALL", """
 Use this tool when the user's request should be handled by an available MCP tool.
 
@@ -357,6 +365,7 @@ Important information:
 4. The arguments field must be a JSON string whose parsed object follows that tool's input_schema. If no arguments are needed, use "{}".
 5. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
 6. If no suitable MCP tool is available, use ASK_USER_QUESTION or continue with notebook tools as appropriate.
+7. This list is fixed for the current chat. If the user adds or removes MCP tools, ask them to start a new chat to refresh available MCP tools.
 """))
     
     # CREATE_STREAMLIT_APP tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -363,8 +363,12 @@ Important information:
 2. The mcp_server_id must exactly match one of the listed server IDs.
 3. The tool_name must exactly match a listed tool for that server.
 4. The arguments field must be a JSON string whose parsed object follows that tool's input_schema. If no arguments are needed, use "{}".
-5. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
-6. This list is fixed for the current chat. If the user adds or removes MCP tools, ask them to start a new chat to refresh available MCP tools.
+5. Treat tool schemas as the source of truth: never invent parameters, and validate arguments before calling.
+6. If a tool call returns isError: true, use the error message to correct arguments and retry at most once. Do not loop.
+7. Treat protocol/transport errors differently from tool execution errors; protocol errors usually require fixing request shape or selecting a valid tool.
+8. For sensitive or side-effecting operations (writes/deletes/external actions), ask for user confirmation before calling.
+9. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
+10. If MCP tool availability appears stale or changed, refresh the available tool list when possible; otherwise ask the user to start a new chat to refresh available MCP tools.
 """))
     
     # CREATE_STREAMLIT_APP tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -364,8 +364,7 @@ Important information:
 3. The tool_name must exactly match a listed tool for that server.
 4. The arguments field must be a JSON string whose parsed object follows that tool's input_schema. If no arguments are needed, use "{}".
 5. Use this tool for tasks outside notebook mutation when an MCP tool is available (e.g. weather lookup, web APIs, external systems).
-6. If no suitable MCP tool is available, use ASK_USER_QUESTION or continue with notebook tools as appropriate.
-7. This list is fixed for the current chat. If the user adds or removes MCP tools, ask them to start a new chat to refresh available MCP tools.
+6. This list is fixed for the current chat. If the user adds or removes MCP tools, ask them to start a new chat to refresh available MCP tools.
 """))
     
     # CREATE_STREAMLIT_APP tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
@@ -1,19 +1,13 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-import json
-from typing import Any, Dict, List, Optional
+from typing import List
 
 from mito_ai_core.agent import ToolResult
 from mito_ai_core.agent.types import AgentContext
+from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
-
-
-def _format_available_mcp_tools(mcp_tools: Optional[List[Dict[str, Any]]]) -> str:
-    if not mcp_tools:
-        return "No MCP tools are currently available."
-    return json.dumps(mcp_tools, indent=2)
 
 
 def format_tool_result(response_type: str, result: ToolResult) -> str:
@@ -58,7 +52,7 @@ def create_agent_tool_result_prompt(context: AgentContext, tool_result: ToolResu
         SG.Variables(context.variables),
         SG.Generic(
             "Available MCP Tools",
-            _format_available_mcp_tools(context.mcp_tools),
+            format_available_mcp_tools(context.mcp_tools),
         ),
         SG.Notebook(context.cells),
         SG.Task("Continue working on the user's task until you have finished"),

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
@@ -1,12 +1,19 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import List
+import json
+from typing import Any, Dict, List, Optional
 
 from mito_ai_core.agent import ToolResult
 from mito_ai_core.agent.types import AgentContext
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
+
+
+def _format_available_mcp_tools(mcp_tools: Optional[List[Dict[str, Any]]]) -> str:
+    if not mcp_tools:
+        return "No MCP tools are currently available."
+    return json.dumps(mcp_tools, indent=2)
 
 
 def format_tool_result(response_type: str, result: ToolResult) -> str:
@@ -49,6 +56,10 @@ def create_agent_tool_result_prompt(context: AgentContext, tool_result: ToolResu
         SG.Rules(context.additional_context),
         SG.Files(context.files),
         SG.Variables(context.variables),
+        SG.Generic(
+            "Available MCP Tools",
+            _format_available_mcp_tools(context.mcp_tools),
+        ),
         SG.Notebook(context.cells),
         SG.Task("Continue working on the user's task until you have finished"),
     ]

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_tool_result_prompt.py
@@ -5,7 +5,6 @@ from typing import List
 
 from mito_ai_core.agent import ToolResult
 from mito_ai_core.agent.types import AgentContext
-from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
 
@@ -50,10 +49,6 @@ def create_agent_tool_result_prompt(context: AgentContext, tool_result: ToolResu
         SG.Rules(context.additional_context),
         SG.Files(context.files),
         SG.Variables(context.variables),
-        SG.Generic(
-            "Available MCP Tools",
-            format_available_mcp_tools(context.mcp_tools),
-        ),
         SG.Notebook(context.cells),
         SG.Task("Continue working on the user's task until you have finished"),
     ]

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/mcp_tools.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/mcp_tools.py
@@ -1,0 +1,8 @@
+import json
+from typing import Any, Dict, List, Optional
+
+
+def format_available_mcp_tools(mcp_tools: Optional[List[Dict[str, Any]]]) -> str:
+    if not mcp_tools:
+        return "No MCP tools are currently available."
+    return json.dumps(mcp_tools, indent=2)

--- a/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
@@ -180,6 +180,23 @@ class FakeToolExecutor:
         }))
         return ToolResult(success=True, output="Edited Streamlit app preview")
 
+    async def execute_mcp_tool(
+        self,
+        ctx: AgentContext,
+        mcp_server_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        message: str,
+    ) -> ToolResult:
+        self.calls.append(("execute_mcp_tool", {
+            "ctx": ctx,
+            "mcp_server_id": mcp_server_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "message": message,
+        }))
+        return ToolResult(success=True, output="MCP tool executed")
+
 
 class FailingCellUpdateToolExecutor(FakeToolExecutor):
     """Tool executor that always fails CELL_UPDATE dispatch."""

--- a/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
@@ -128,6 +128,23 @@ class FakeToolExecutor:
         }))
         return ToolResult(success=True, output="Edited Streamlit app preview")
 
+    async def execute_mcp_tool(
+        self,
+        ctx: AgentContext,
+        mcp_server_id: str,
+        tool_name: str,
+        arguments: dict,
+        message: str,
+    ) -> ToolResult:
+        self.calls.append(("execute_mcp_tool", {
+            "ctx": ctx,
+            "mcp_server_id": mcp_server_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "message": message,
+        }))
+        return ToolResult(success=True, output="MCP tool executed")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -283,6 +300,26 @@ class TestToolResultDefaults:
         r = ToolResult(success=False, error_message="NameError: name 'x' is not defined")
         assert not r.success
         assert "NameError" in (r.error_message or "")
+
+
+class TestExecuteMcpTool:
+    @pytest.mark.asyncio
+    async def test_executes_mcp_tool(self) -> None:
+        executor = FakeToolExecutor()
+        ctx = _make_ctx()
+        result = await executor.execute_mcp_tool(
+            ctx,
+            mcp_server_id="server-1",
+            tool_name="search_docs",
+            arguments={"query": "pandas read_csv"},
+            message="Look up usage examples.",
+        )
+
+        assert result.success
+        assert result.output == "MCP tool executed"
+        assert executor.calls[0][1]["mcp_server_id"] == "server-1"
+        assert executor.calls[0][1]["tool_name"] == "search_docs"
+        assert executor.calls[0][1]["arguments"] == {"query": "pandas read_csv"}
 
 
 class TestAgentContext:

--- a/mito-ai-core/mito_ai_core/tests/create_agent_system_message_prompt_test.py
+++ b/mito-ai-core/mito_ai_core/tests/create_agent_system_message_prompt_test.py
@@ -20,3 +20,24 @@ def test_create_agent_system_message_prompt_browser_conditional() -> None:
     # Enabled (Chrome and not Copilot)
     enabled_prompt = create_agent_system_message_prompt(include_cell_output_tool=True)
     assert "GET_CELL_OUTPUT" in enabled_prompt, "Enabled prompt should contain GET_CELL_OUTPUT"
+
+
+@pytest.mark.parametrize(
+    "mcp_tools, expected_text",
+    [
+        (None, "No MCP tools are currently available."),
+        (
+            [{"server_id": "weather", "tools": [{"name": "get_forecast"}]}],
+            '"server_id": "weather"',
+        ),
+    ],
+)
+def test_create_agent_system_message_prompt_includes_available_mcp_tools(
+    mcp_tools, expected_text
+) -> None:
+    prompt = create_agent_system_message_prompt(
+        include_cell_output_tool=False,
+        mcp_tools=mcp_tools,
+    )
+    assert "Available MCP Tools" in prompt
+    assert expected_text in prompt

--- a/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
+++ b/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
@@ -10,7 +10,11 @@ from mito_ai_core.utils.server_limits import (
     OS_MONTHLY_AUTOCOMPLETE_LIMIT,
 )
 from mito_ai_core.completions.models import AgentResponse, MessageType, ResponseFormatInfo
-from mito_ai_core.clients.open_ai_utils import _prepare_request_data_and_headers
+from mito_ai_core.clients.open_ai_utils import (
+    _openai_strict_schema_fill_required,
+    _openai_strict_schema_set_additional_properties_false,
+    _prepare_request_data_and_headers,
+)
 from mito_ai_core.clients.open_ai_utils import get_open_ai_completion_function_params
 
 REALLY_OLD_DATE = "2020-01-01"
@@ -166,3 +170,25 @@ def test_openai_strict_schema_cell_update_required_matches_properties() -> None:
     assert set(cell["required"]) == set(cell["properties"].keys())
     mcp_tool = schema["$defs"]["MCPToolCall"]
     assert mcp_tool["properties"]["arguments"]["type"] == "string"
+
+
+def test_openai_strict_schema_normalizes_property_nodes_without_type() -> None:
+    """Nodes with properties but missing type should still be strict-object schemas."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "arguments": {
+                "properties": {
+                    "foo": {"type": "string"},
+                }
+            }
+        },
+    }
+
+    _openai_strict_schema_fill_required(schema)
+    _openai_strict_schema_set_additional_properties_false(schema)
+
+    arguments = schema["properties"]["arguments"]
+    assert arguments["type"] == "object"
+    assert arguments["required"] == ["foo"]
+    assert arguments["additionalProperties"] is False

--- a/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
+++ b/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
@@ -3,6 +3,7 @@
 
 import pytest
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import patch
 from mito_ai_core.utils.server_limits import (
     check_mito_server_quota,
@@ -174,7 +175,7 @@ def test_openai_strict_schema_cell_update_required_matches_properties() -> None:
 
 def test_openai_strict_schema_normalizes_property_nodes_without_type() -> None:
     """Nodes with properties but missing type should still be strict-object schemas."""
-    schema = {
+    schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
             "arguments": {

--- a/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
+++ b/mito-ai-core/mito_ai_core/tests/open_ai_utils_test.py
@@ -164,3 +164,5 @@ def test_openai_strict_schema_cell_update_required_matches_properties() -> None:
     schema = rf["json_schema"]["schema"]
     cell = schema["$defs"]["CellUpdate"]
     assert set(cell["required"]) == set(cell["properties"].keys())
+    mcp_tool = schema["$defs"]["MCPToolCall"]
+    assert mcp_tool["properties"]["arguments"]["type"] == "string"

--- a/mito-ai-core/mito_ai_core/tests/providers/test_anthropic_client.py
+++ b/mito-ai-core/mito_ai_core/tests/providers/test_anthropic_client.py
@@ -16,7 +16,7 @@ DUMMY_IMAGE_DATA_URL = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAgMBAp9l9AAAAABJRU5ErkJggg=="
 )
 
-def test_mixed_text_and_image():
+def test_mixed_text_and_image() -> None:
     messages: List[ChatCompletionMessageParam] = [
         ChatCompletionSystemMessageParam(role="system", content="You are a helpful assistant."),
         ChatCompletionUserMessageParam(role="user", content=[
@@ -46,7 +46,7 @@ def test_mixed_text_and_image():
     assert source["type"] == "base64"
     assert source["media_type"] == "image/png"
 
-def test_no_system_instructions_only_content():
+def test_no_system_instructions_only_content() -> None:
     messages: List[ChatCompletionMessageParam] = [
         ChatCompletionUserMessageParam(role="user", content="Hello!"),
         ChatCompletionAssistantMessageParam(role="assistant", content="Hi, how can I help you?")
@@ -60,7 +60,7 @@ def test_no_system_instructions_only_content():
     assert anthropic_messages[1]["role"] == "assistant"
     assert anthropic_messages[1]["content"] == "Hi, how can I help you?"
 
-def test_system_instructions_and_content():
+def test_system_instructions_and_content() -> None:
     messages: List[ChatCompletionMessageParam] = [
         ChatCompletionSystemMessageParam(role="system", content="You are a helpful assistant."),
         ChatCompletionUserMessageParam(role="user", content="What is the weather today?")
@@ -72,7 +72,7 @@ def test_system_instructions_and_content():
     assert anthropic_messages[0]["role"] == "user"
     assert anthropic_messages[0]["content"] == "What is the weather today?"
 
-def test_multiple_system_messages():
+def test_multiple_system_messages() -> None:
     messages: List[ChatCompletionMessageParam] = [
         ChatCompletionSystemMessageParam(role="system", content="First system message."),
         ChatCompletionSystemMessageParam(role="system", content="Second system message."),
@@ -86,7 +86,7 @@ def test_multiple_system_messages():
     assert anthropic_messages[0]["role"] == "user"
     assert anthropic_messages[0]["content"] == "Hello!"
 
-def test_empty_message_content():
+def test_empty_message_content() -> None:
     messages: List[ChatCompletionMessageParam] = [
         cast(ChatCompletionMessageParam, {"role": "user"}),  # Missing content
         ChatCompletionAssistantMessageParam(role="assistant", content="Hi!")
@@ -546,7 +546,7 @@ def test_caching_system_prompt_scenarios(messages, expected_system_type, expecte
     (5, 1),  # 5 messages, cache at index 1 (5 - 3 - 1 = 1)
     (10, 6),  # 10 messages, cache at index 6 (10 - 3 - 1 = 6)
 ])
-def test_caching_conversation_history(message_count, expected_cache_boundary, monkeypatch):
+def test_caching_conversation_history(message_count, expected_cache_boundary, monkeypatch) -> None:
     """Test that conversation history is cached at the keep_recent boundary for different message counts."""
     
     # Mock MAX_TRIM_THRESHOLD to use a fixed value for testing
@@ -581,7 +581,7 @@ def test_caching_conversation_history(message_count, expected_cache_boundary, mo
             else:
                 assert "cache_control" not in str(message)
 
-def test_caching_with_mixed_content():
+def test_caching_with_mixed_content() -> None:
     """Test caching with mixed text and image content."""
     messages: List[ChatCompletionMessageParam] = [
         ChatCompletionSystemMessageParam(role="system", content="You are a helpful assistant."),

--- a/mito-ai-core/mito_ai_core/tests/providers/test_gemini_client.py
+++ b/mito-ai-core/mito_ai_core/tests/providers/test_gemini_client.py
@@ -18,7 +18,7 @@ DUMMY_IMAGE_DATA_URL = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAgMBAp9l9AAAAABJRU5ErkJggg=="
 )
 
-def test_mixed_text_and_image():
+def test_mixed_text_and_image() -> None:
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": [
@@ -36,7 +36,7 @@ def test_mixed_text_and_image():
     # The second part should be a Part object (from google.genai.types)
     assert isinstance(contents[0]["parts"][1], Part)
 
-def test_no_system_instructions_only_content():
+def test_no_system_instructions_only_content() -> None:
     messages: List[Dict[str, Any]] = [
         {"role": "user", "content": "Hello!"},
         {"role": "assistant", "content": "Hi, how can I help you?"}
@@ -49,7 +49,7 @@ def test_no_system_instructions_only_content():
     assert contents[1]["role"] == "model"
     assert contents[1]["parts"][0]["text"] == "Hi, how can I help you?"
 
-def test_system_instructions_and_content():
+def test_system_instructions_and_content() -> None:
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is the weather today?"}

--- a/mito-ai-core/mito_ai_core/tests/test_enterprise_mode.py
+++ b/mito-ai-core/mito_ai_core/tests/test_enterprise_mode.py
@@ -84,7 +84,7 @@ class TestModelValidation:
     @patch('mito_ai_core.utils.model_utils.is_enterprise')
     @patch('mito_ai_core.utils.model_utils.constants')
     @pytest.mark.asyncio
-    async def test_provider_manager_rejects_invalid_model(self, mock_constants, mock_is_enterprise):
+    async def test_provider_manager_rejects_invalid_model(self, mock_constants, mock_is_enterprise) -> None:
         """Test that ProviderManager rejects invalid models."""
         mock_is_enterprise.return_value = True
         mock_constants.LITELLM_BASE_URL = "https://litellm-server.com"
@@ -149,7 +149,7 @@ class TestModelValidation:
     @patch('mito_ai_core.utils.model_utils.constants')
     @patch('mito_ai_core.utils.model_utils.is_abacus_configured')
     @pytest.mark.asyncio
-    async def test_provider_manager_rejects_invalid_abacus_model(self, mock_is_abacus_configured, mock_constants, mock_is_enterprise):
+    async def test_provider_manager_rejects_invalid_abacus_model(self, mock_is_abacus_configured, mock_constants, mock_is_enterprise) -> None:
         """Test that ProviderManager rejects invalid Abacus models."""
         mock_is_abacus_configured.return_value = True
         mock_is_enterprise.return_value = True

--- a/mito-ai-core/mito_ai_core/tests/utils/test_anthropic_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/utils/test_anthropic_utils.py
@@ -29,7 +29,7 @@ def mock_user_functions(monkeypatch):
     monkeypatch.setattr("mito_ai_core.utils.server_limits.set_user_field", mock_set_field)
 
 
-def test_basic_request_preparation():
+def test_basic_request_preparation() -> None:
     """Test basic request preparation with minimal parameters"""
     model = "claude-3-sonnet"
     max_tokens = 100
@@ -66,7 +66,7 @@ def test_basic_request_preparation():
     assert "system" not in inner_data
 
 
-def test_system_message_handling():
+def test_system_message_handling() -> None:
     """Test handling of system message when provided"""
     system = "You are a helpful assistant"
     messages: List[MessageParam] = [{"role": "user", "content": "Hello"}]
@@ -86,7 +86,7 @@ def test_system_message_handling():
     assert data["data"]["system"] == system
 
 
-def test_tools_and_tool_choice():
+def test_tools_and_tool_choice() -> None:
     """Test handling of tools and tool_choice parameters"""
     tools = cast(List[ToolUnionParam], [{
         "type": "function",

--- a/mito-ai-core/mito_ai_core/utils/message_history_utils.py
+++ b/mito-ai-core/mito_ai_core/utils/message_history_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+from typing import Any, Dict, List, Optional
 from openai.types.chat import ChatCompletionMessageParam
 
 from mito_ai_core.agent.types import CompletionProvider
@@ -16,6 +17,7 @@ async def append_agent_system_message(
     provider: CompletionProvider,
     thread_id: ThreadID,
     enable_get_cell_output: bool,
+    mcp_tools: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
 
     # If the system message already exists, do nothing
@@ -25,7 +27,10 @@ async def append_agent_system_message(
     ):
         return
 
-    system_message_prompt = create_agent_system_message_prompt(enable_get_cell_output)
+    system_message_prompt = create_agent_system_message_prompt(
+        enable_get_cell_output,
+        mcp_tools,
+    )
 
     system_message: ChatCompletionMessageParam = {
         "role": "system",

--- a/mito-ai-mcp/tests/test_server_e2e.py
+++ b/mito-ai-mcp/tests/test_server_e2e.py
@@ -117,6 +117,7 @@ class FakeAgentRunner:
                     answers=None,
                     scratchpad_code=None,
                     scratchpad_summary=None,
+                    mcp_tool_call=None,
                 )
             )
 
@@ -136,6 +137,7 @@ class FakeAgentRunner:
                 answers=None,
                 scratchpad_code=None,
                 scratchpad_summary=None,
+                mcp_tool_call=None,
             ),
             finished=True,
             iterations=2,

--- a/mito-ai/mito_ai/__init__.py
+++ b/mito-ai/mito_ai/__init__.py
@@ -20,6 +20,7 @@ from mito_ai_core.utils.litellm_utils import is_litellm_configured
 from mito_ai_core.enterprise.utils import is_abacus_configured
 from mito_ai.version_check import VersionCheckHandler
 from mito_ai.db.urls import get_db_urls
+from mito_ai.mcp.urls import get_mcp_urls  # MCP client endpoints
 from mito_ai.settings.urls import get_settings_urls
 from mito_ai.rules.urls import get_rules_urls
 from mito_ai.auth.urls import get_auth_urls
@@ -133,6 +134,7 @@ def _load_jupyter_server_extension(server_app) -> None: # type: ignore
     
     # REST API endpoints
     handlers.extend(get_db_urls(base_url))  # type: ignore
+    handlers.extend(get_mcp_urls(base_url))  # type: ignore
     handlers.extend(get_settings_urls(base_url))  # type: ignore
     handlers.extend(get_rules_urls(base_url))  # type: ignore
     handlers.extend(get_log_urls(base_url, provider_manager.key_type))  # type: ignore

--- a/mito-ai/mito_ai/completions/agent_loop.py
+++ b/mito-ai/mito_ai/completions/agent_loop.py
@@ -16,6 +16,7 @@ from openai.types.chat import ChatCompletionMessageParam
 
 from mito_ai_core.completions.ai_optimized_message import create_ai_optimized_message
 from mito_ai.completions.jupyter_lab_tool_executor import JupyterLabToolExecutor
+from mito_ai.mcp.utils import get_available_mcp_tools
 from mito_ai_core.completions.message_history import GlobalMessageHistory
 from mito_ai.completions.models import (
     AgentExecutionMetadata,
@@ -147,6 +148,7 @@ async def start_agent_loop(
         files=metadata.files,
         is_chrome_browser=metadata.isChromeBrowser,
         additional_context=metadata.additionalContext,
+        mcp_tools=await get_available_mcp_tools(),
     )
 
     # --- callbacks to persist messages ---

--- a/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
+++ b/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
@@ -135,6 +135,7 @@ class JupyterLabToolExecutor:
             answers=answers,
             scratchpad_code=scratchpad_code,
             scratchpad_summary=scratchpad_summary,
+            mcp_tool_call=None,
         )
 
     # ------------------------------------------------------------------

--- a/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
+++ b/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
@@ -11,16 +11,17 @@ frontend, then waiting for the frontend to respond with a ``tool_result``.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import replace
-from typing import Any, Callable, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 from mito_ai_core.agent.tool_executor import ToolExecutor
 from mito_ai_core.agent.types import AgentContext, ToolResult
 from mito_ai_core.completions.models import AIOptimizedCell, AgentResponse, CellUpdate
 
 from mito_ai.completions.models import RequestToolExecutionMessage
+from mito_ai.mcp.mcp_client import call_server_tool
+from mito_ai.mcp.utils import get_server
 from mito_ai.logger import get_logger
 
 __all__ = ["JupyterLabToolExecutor"]
@@ -110,6 +111,7 @@ class JupyterLabToolExecutor:
             "edit_streamlit_app",
             "ask_user_question",
             "scratchpad",
+            "mcp_tool_call",
         ],
         message: str,
         *,
@@ -251,3 +253,34 @@ class JupyterLabToolExecutor:
             streamlit_app_prompt=streamlit_app_prompt,
         )
         return await self._execute_via_frontend(agent_resp, message)
+
+    async def execute_mcp_tool(
+        self,
+        ctx: AgentContext,
+        mcp_server_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        message: str,
+    ) -> ToolResult:
+        try:
+            server_config = get_server(mcp_server_id)
+        except KeyError as e:
+            return ToolResult(
+                success=False,
+                tool_name="mcp_tool_call",
+                error_message=str(e),
+            )
+
+        result = await call_server_tool(server_config, tool_name, arguments)
+        if result.get("success"):
+            return ToolResult(
+                success=True,
+                tool_name="mcp_tool_call",
+                output=result.get("output"),
+            )
+
+        return ToolResult(
+            success=False,
+            tool_name="mcp_tool_call",
+            error_message=result.get("error", "Unknown MCP tool error"),
+        )

--- a/mito-ai/mito_ai/mcp/__init__.py
+++ b/mito-ai/mito_ai/mcp/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.

--- a/mito-ai/mito_ai/mcp/handlers.py
+++ b/mito-ai/mito_ai/mcp/handlers.py
@@ -1,0 +1,122 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import asyncio
+import json
+import uuid
+from typing import Any, Dict
+
+import tornado
+from jupyter_server.base.handlers import APIHandler
+
+from mito_ai.mcp.mcp_client import list_server_tools
+from mito_ai.mcp.utils import (
+    delete_server,
+    load_servers,
+    save_server,
+)
+
+
+def _validate_server_body(body: Dict[str, Any]) -> str:
+    """Return an error string if invalid, empty string if valid."""
+    if not isinstance(body.get("name"), str) or not body["name"].strip():
+        return "'name' is required"
+    if not isinstance(body.get("command"), str) or not body["command"].strip():
+        return "'command' is required"
+    args = body.get("args", [])
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        return "'args' must be a list of strings"
+    env = body.get("env", {})
+    if not isinstance(env, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+    ):
+        return "'env' must be an object mapping strings to strings"
+    return ""
+
+
+def _normalize_config(body: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": body["name"].strip(),
+        "command": body["command"].strip(),
+        "args": list(body.get("args", [])),
+        "env": dict(body.get("env", {})),
+    }
+
+
+class MCPServersHandler(APIHandler):
+    """Endpoints for working with the MCP servers.json file."""
+
+    @tornado.web.authenticated
+    async def get(self) -> None:
+        """List all configured MCP servers and their currently available tools."""
+        servers = load_servers()
+
+        ids = list(servers.keys())
+        results = await asyncio.gather(
+            *(list_server_tools(servers[sid]) for sid in ids),
+            return_exceptions=True,
+        )
+
+        response: Dict[str, Dict[str, Any]] = {}
+        for sid, result in zip(ids, results):
+            entry: Dict[str, Any] = dict(servers[sid])
+            if isinstance(result, BaseException):
+                entry["tools"] = []
+                entry["error"] = f"{type(result).__name__}: {result}"
+            elif result.get("success"):
+                entry["tools"] = result.get("tools", [])
+            else:
+                entry["tools"] = []
+                entry["error"] = result.get("error", "Unknown error")
+            response[sid] = entry
+
+        self.finish(json.dumps(response))
+
+    @tornado.web.authenticated
+    async def post(self) -> None:
+        """Add a new MCP server after verifying we can list its tools."""
+        try:
+            body = json.loads(self.request.body)
+        except json.JSONDecodeError:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Invalid JSON in request body"}))
+            return
+
+        error = _validate_server_body(body)
+        if error:
+            self.set_status(400)
+            self.finish(json.dumps({"error": error}))
+            return
+
+        config = _normalize_config(body)
+
+        result = await list_server_tools(config)
+        if not result.get("success"):
+            self.set_status(400)
+            self.finish(json.dumps({"error": result.get("error", "Failed to connect to MCP server")}))
+            return
+
+        server_id = str(uuid.uuid4())
+        save_server(server_id, config)
+
+        self.finish(
+            json.dumps(
+                {
+                    "status": "success",
+                    "connection_id": server_id,
+                    "tools": result.get("tools", []),
+                }
+            )
+        )
+
+    @tornado.web.authenticated
+    def delete(self, *args: Any, **kwargs: Any) -> None:
+        """Delete an MCP server by id."""
+        server_id = kwargs.get("uuid")
+        if not server_id:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Server id is required"}))
+            return
+
+        delete_server(server_id)
+        self.finish(json.dumps({"status": "success"}))

--- a/mito-ai/mito_ai/mcp/handlers.py
+++ b/mito-ai/mito_ai/mcp/handlers.py
@@ -89,6 +89,23 @@ class MCPServersHandler(APIHandler):
             return
 
         config = _normalize_config(body)
+        existing_servers = load_servers()
+        if any(
+            existing.get("name", "").strip().lower() == config["name"].lower()
+            for existing in existing_servers.values()
+        ):
+            self.set_status(400)
+            self.finish(
+                json.dumps(
+                    {
+                        "error": (
+                            f"An MCP server named '{config['name']}' already exists. "
+                            "Use a unique name."
+                        )
+                    }
+                )
+            )
+            return
 
         result = await list_server_tools(config)
         if not result.get("success"):

--- a/mito-ai/mito_ai/mcp/handlers.py
+++ b/mito-ai/mito_ai/mcp/handlers.py
@@ -24,6 +24,8 @@ def _validate_server_body(body: Dict[str, Any]) -> str:
     if not isinstance(body.get("command"), str) or not body["command"].strip():
         return "'command' is required"
     args = body.get("args", [])
+    if args is None:
+        args = []
     if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
         return "'args' must be a list of strings"
     env = body.get("env", {})
@@ -35,10 +37,13 @@ def _validate_server_body(body: Dict[str, Any]) -> str:
 
 
 def _normalize_config(body: Dict[str, Any]) -> Dict[str, Any]:
+    args = body.get("args", [])
+    if args is None:
+        args = []
     return {
         "name": body["name"].strip(),
         "command": body["command"].strip(),
-        "args": list(body.get("args", [])),
+        "args": list(args),
         "env": dict(body.get("env", {})),
     }
 

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -1,0 +1,56 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+"""Minimal stdio MCP client used to verify a server and list its tools.
+
+Opens a short-lived session per call; no long-lived process management in v1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+LIST_TOOLS_TIMEOUT_SECONDS = 15
+
+
+async def _list_tools_inner(config: Dict[str, Any]) -> Dict[str, Any]:
+    env = config.get("env") or None
+    params = StdioServerParameters(
+        command=config["command"],
+        args=config.get("args") or [],
+        env=env,
+    )
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            tools = [
+                {"name": t.name, "description": t.description or ""}
+                for t in result.tools
+            ]
+            return {"success": True, "tools": tools}
+
+
+async def list_server_tools(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Connect to an stdio MCP server, list its tools, and disconnect.
+
+    Returns ``{"success": True, "tools": [...]}`` on success, or
+    ``{"success": False, "error": "..."}`` on any failure.
+    """
+    try:
+        return await asyncio.wait_for(
+            _list_tools_inner(config),
+            timeout=LIST_TOOLS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        return {
+            "success": False,
+            "error": f"Timed out connecting to MCP server after {LIST_TOOLS_TIMEOUT_SECONDS}s",
+        }
+    except Exception as e:
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -108,18 +108,23 @@ async def _call_tool_inner(
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.call_tool(tool_name, arguments=arguments)
+            is_error = bool(getattr(result, "isError", False))
             payload = {
-                "is_error": getattr(result, "isError", False),
+                "is_error": is_error,
                 "structured_content": getattr(result, "structuredContent", None),
                 "content": [
                     _serialize_mcp_content_item(item)
                     for item in getattr(result, "content", []) or []
                 ],
             }
-            return {
-                "success": True,
-                "output": json.dumps(payload, ensure_ascii=False),
-            }
+            serialized_payload = json.dumps(payload, ensure_ascii=False)
+            if is_error:
+                return {
+                    "success": False,
+                    "error": serialized_payload,
+                    "output": serialized_payload,
+                }
+            return {"success": True, "output": serialized_payload}
 
 
 async def call_server_tool(

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -9,28 +9,38 @@ Opens a short-lived session per call; no long-lived process management in v1.
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any, Dict
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 LIST_TOOLS_TIMEOUT_SECONDS = 15
+CALL_TOOL_TIMEOUT_SECONDS = 30
 
 
-async def _list_tools_inner(config: Dict[str, Any]) -> Dict[str, Any]:
+def _build_stdio_params(config: Dict[str, Any]) -> StdioServerParameters:
     env = config.get("env") or None
-    params = StdioServerParameters(
+    return StdioServerParameters(
         command=config["command"],
         args=config.get("args") or [],
         env=env,
     )
+
+
+async def _list_tools_inner(config: Dict[str, Any]) -> Dict[str, Any]:
+    params = _build_stdio_params(config)
 
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.list_tools()
             tools = [
-                {"name": t.name, "description": t.description or ""}
+                {
+                    "name": t.name,
+                    "description": t.description or "",
+                    "input_schema": getattr(t, "inputSchema", None),
+                }
                 for t in result.tools
             ]
             return {"success": True, "tools": tools}
@@ -51,6 +61,61 @@ async def list_server_tools(config: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "success": False,
             "error": f"Timed out connecting to MCP server after {LIST_TOOLS_TIMEOUT_SECONDS}s",
+        }
+    except Exception as e:
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+
+
+def _serialize_mcp_content_item(item: Any) -> Dict[str, Any]:
+    if hasattr(item, "model_dump"):
+        dumped = item.model_dump()  # type: ignore[attr-defined]
+        if isinstance(dumped, dict):
+            return dumped
+    if isinstance(item, dict):
+        return item
+    return {"type": type(item).__name__, "value": str(item)}
+
+
+async def _call_tool_inner(
+    config: Dict[str, Any],
+    tool_name: str,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    params = _build_stdio_params(config)
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, arguments=arguments)
+            payload = {
+                "is_error": getattr(result, "isError", False),
+                "structured_content": getattr(result, "structuredContent", None),
+                "content": [
+                    _serialize_mcp_content_item(item)
+                    for item in getattr(result, "content", []) or []
+                ],
+            }
+            return {
+                "success": True,
+                "output": json.dumps(payload, ensure_ascii=False),
+            }
+
+
+async def call_server_tool(
+    config: Dict[str, Any],
+    tool_name: str,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Call a single MCP tool on an stdio server and return serialized output."""
+    try:
+        return await asyncio.wait_for(
+            _call_tool_inner(config, tool_name, arguments),
+            timeout=CALL_TOOL_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        return {
+            "success": False,
+            "error": f"Timed out calling MCP tool after {CALL_TOOL_TIMEOUT_SECONDS}s",
         }
     except Exception as e:
         return {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -19,6 +19,27 @@ LIST_TOOLS_TIMEOUT_SECONDS = 15
 CALL_TOOL_TIMEOUT_SECONDS = 30
 
 
+def _flatten_exceptions(exc: BaseException) -> list[BaseException]:
+    nested = getattr(exc, "exceptions", None)
+    if nested and isinstance(nested, tuple):
+        leaves: list[BaseException] = []
+        for child in nested:
+            if isinstance(child, BaseException):
+                leaves.extend(_flatten_exceptions(child))
+        if len(leaves) > 0:
+            return leaves
+    return [exc]
+
+
+def _format_exception(exc: BaseException) -> str:
+    leaves = _flatten_exceptions(exc)
+    for leaf in leaves:
+        text = str(leaf).strip()
+        if text:
+            return f"{type(leaf).__name__}: {text}"
+    return f"{type(exc).__name__}: {exc}"
+
+
 def _build_stdio_params(config: Dict[str, Any]) -> StdioServerParameters:
     env = config.get("env") or None
     return StdioServerParameters(
@@ -63,7 +84,7 @@ async def list_server_tools(config: Dict[str, Any]) -> Dict[str, Any]:
             "error": f"Timed out connecting to MCP server after {LIST_TOOLS_TIMEOUT_SECONDS}s",
         }
     except Exception as e:
-        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+        return {"success": False, "error": _format_exception(e)}
 
 
 def _serialize_mcp_content_item(item: Any) -> Dict[str, Any]:
@@ -118,4 +139,4 @@ async def call_server_tool(
             "error": f"Timed out calling MCP tool after {CALL_TOOL_TIMEOUT_SECONDS}s",
         }
     except Exception as e:
-        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+        return {"success": False, "error": _format_exception(e)}

--- a/mito-ai/mito_ai/mcp/models.py
+++ b/mito-ai/mito_ai/mcp/models.py
@@ -1,0 +1,11 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from typing import Dict, List, TypedDict
+
+
+class MCPServerConfig(TypedDict, total=False):
+    name: str
+    command: str
+    args: List[str]
+    env: Dict[str, str]

--- a/mito-ai/mito_ai/mcp/urls.py
+++ b/mito-ai/mito_ai/mcp/urls.py
@@ -1,0 +1,28 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from typing import Any, List, Tuple
+
+from jupyter_server.utils import url_path_join
+
+from mito_ai.mcp.handlers import MCPServersHandler
+
+
+def get_mcp_urls(base_url: str) -> List[Tuple[str, Any, dict]]:
+    """Get all MCP related URL patterns.
+
+    Args:
+        base_url: The base URL for the Jupyter server
+
+    Returns:
+        List of (url_pattern, handler_class, handler_kwargs) tuples
+    """
+    BASE_URL = url_path_join(base_url, "mito-ai", "mcp")
+    return [
+        (url_path_join(BASE_URL, "servers"), MCPServersHandler, {}),
+        (
+            url_path_join(BASE_URL, "servers", "(?P<uuid>[^/]+)"),
+            MCPServersHandler,
+            {},
+        ),
+    ]

--- a/mito-ai/mito_ai/mcp/utils.py
+++ b/mito-ai/mito_ai/mcp/utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import json
+import os
+from typing import Any, Dict, Final
+
+from mito_ai_core.utils.schema import MITO_FOLDER
+
+MCP_DIR_PATH: Final[str] = os.path.join(MITO_FOLDER, "mcp")
+SERVERS_PATH: Final[str] = os.path.join(MCP_DIR_PATH, "servers.json")
+
+
+def setup_mcp_dir() -> None:
+    """Ensure the MCP directory and servers.json file exist."""
+    os.makedirs(MCP_DIR_PATH, exist_ok=True)
+    if not os.path.exists(SERVERS_PATH):
+        with open(SERVERS_PATH, "w") as f:
+            json.dump({}, f, indent=4)
+
+
+def load_servers() -> Dict[str, Dict[str, Any]]:
+    """Read all MCP server configs from servers.json."""
+    setup_mcp_dir()
+    with open(SERVERS_PATH, "r") as f:
+        servers: Dict[str, Dict[str, Any]] = json.load(f)
+    return servers
+
+
+def save_server(server_id: str, config: Dict[str, Any]) -> None:
+    """Persist a single MCP server config under the given id."""
+    servers = load_servers()
+    servers[server_id] = config
+    with open(SERVERS_PATH, "w") as f:
+        json.dump(servers, f, indent=4)
+
+
+def delete_server(server_id: str) -> None:
+    """Remove an MCP server config by id."""
+    servers = load_servers()
+    if server_id in servers:
+        del servers[server_id]
+        with open(SERVERS_PATH, "w") as f:
+            json.dump(servers, f, indent=4)

--- a/mito-ai/mito_ai/mcp/utils.py
+++ b/mito-ai/mito_ai/mcp/utils.py
@@ -3,9 +3,11 @@
 
 import json
 import os
-from typing import Any, Dict, Final
+import asyncio
+from typing import Any, Dict, Final, List
 
 from mito_ai_core.utils.schema import MITO_FOLDER
+from mito_ai.mcp.mcp_client import list_server_tools
 
 MCP_DIR_PATH: Final[str] = os.path.join(MITO_FOLDER, "mcp")
 SERVERS_PATH: Final[str] = os.path.join(MCP_DIR_PATH, "servers.json")
@@ -42,3 +44,43 @@ def delete_server(server_id: str) -> None:
         del servers[server_id]
         with open(SERVERS_PATH, "w") as f:
             json.dump(servers, f, indent=4)
+
+
+def get_server(server_id: str) -> Dict[str, Any]:
+    """Return a single server config by id."""
+    servers = load_servers()
+    if server_id not in servers:
+        raise KeyError(f"MCP server '{server_id}' not found")
+    return servers[server_id]
+
+
+async def get_available_mcp_tools() -> List[Dict[str, Any]]:
+    """Return MCP tools grouped by configured server for agent prompts."""
+    servers = load_servers()
+    ids = list(servers.keys())
+    if len(ids) == 0:
+        return []
+
+    results = await asyncio.gather(
+        *(list_server_tools(servers[sid]) for sid in ids),
+        return_exceptions=True,
+    )
+
+    grouped: List[Dict[str, Any]] = []
+    for sid, result in zip(ids, results):
+        server = servers[sid]
+        entry: Dict[str, Any] = {
+            "mcp_server_id": sid,
+            "server_name": server.get("name", ""),
+            "command": server.get("command", ""),
+            "tools": [],
+        }
+        if isinstance(result, BaseException):
+            entry["error"] = f"{type(result).__name__}: {result}"
+        elif result.get("success"):
+            entry["tools"] = result.get("tools", [])
+        else:
+            entry["error"] = result.get("error", "Unknown error")
+        grouped.append(entry)
+
+    return grouped

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "anthropic>=0.6.81",
     "litellm",
     "sseclient-py>=1.8.0",
+    "mcp>=1.0.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/mito-ai/src/Extensions/SettingsManager/SettingsManagerPlugin.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/SettingsManagerPlugin.tsx
@@ -31,7 +31,7 @@ function _activate(
     restorer: ILayoutRestorer | null
 ): WidgetTracker {
     // Create a widget creator function
-    const newWidget = (initialTab?: 'database' | 'general' | 'subscription' | 'rules' | 'profiler' | 'support'): MainAreaWidget => {
+    const newWidget = (initialTab?: 'database' | 'mcp' | 'general' | 'subscription' | 'rules' | 'profiler' | 'support'): MainAreaWidget => {
         const content = new SettingsWidget(contextManager, initialTab);
         const widget = new MainAreaWidget({ content });
         widget.id = 'mito-ai-settings';
@@ -48,7 +48,7 @@ function _activate(
     });
 
     // Reusable function to open settings with a specific tab
-    const openSettingsWithTab = (initialTab?: 'database' | 'general' | 'subscription' | 'rules' | 'profiler' | 'support'): void => {
+    const openSettingsWithTab = (initialTab?: 'database' | 'mcp' | 'general' | 'subscription' | 'rules' | 'profiler' | 'support'): void => {
         // Dispose the old widget and create a new one with the specified tab
         if (widget && !widget.isDisposed) {
             widget.dispose();

--- a/mito-ai/src/Extensions/SettingsManager/SettingsWidget.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/SettingsWidget.tsx
@@ -11,6 +11,7 @@ import { GeneralPage } from './general/GeneralPage';
 import { RulesPage } from './rules/RulesPage';
 import { ProfilerPage } from './profiler/ProfilerPage';
 import { SubscriptionPage } from './subscription/SubscriptionPage';
+import { MCPPage } from './mcp/MCPPage';
 import { IContextManager } from '../ContextManager/ContextManagerPlugin';
 import '../../../style/SettingsWidget.css';
 
@@ -26,6 +27,10 @@ const TABS_CONFIG = (contextManager: IContextManager) => ({
     database: {
         label: 'Database',
         component: DatabasePage
+    },
+    mcp: {
+        label: 'MCP Servers',
+        component: MCPPage
     },
     rules: {
         label: 'Rules',

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -90,7 +90,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
                     name="envText"
                     value={formData.envText}
                     onChange={onInputChange}
-                    placeholder={'API_KEY=...\nOTHER=value'}
+                    placeholder={'API_KEY=sk-123_45'}
                     className="form-control"
                     rows={4}
                 />

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -68,7 +68,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
             </div>
 
             <div className="form-group">
-                <label htmlFor="argsText">Arguments</label>
+                <label htmlFor="argsText">Arguments (optional)</label>
                 <textarea
                     id="argsText"
                     name="argsText"

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -74,7 +74,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
                     name="argsText"
                     value={formData.argsText}
                     onChange={onInputChange}
-                    placeholder={'mito-ai-mcp'}
+                    placeholder={'mcp-server-time'}
                     className="form-control"
                     rows={4}
                 />

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -36,7 +36,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
     };
 
     return (
-        <form onSubmit={handleSubmit} className="connection-form">
+        <form onSubmit={handleSubmit} className="connection-form mcp-form">
             {formError && <p className="error">{formError}</p>}
 
             <div className="form-group">
@@ -76,7 +76,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
                     onChange={onInputChange}
                     placeholder={'mito-ai-mcp'}
                     className="form-control"
-                    rows={3}
+                    rows={4}
                 />
                 <div className="settings-option-description">
                     One argument per line.
@@ -92,7 +92,7 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
                     onChange={onInputChange}
                     placeholder={'API_KEY=...\nOTHER=value'}
                     className="form-control"
-                    rows={3}
+                    rows={4}
                 />
                 <div className="settings-option-description">
                     One KEY=VALUE per line.

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React, { useState } from 'react';
+import { IMCPServerFormData } from './model';
+import '../../../../style/ConnectionForm.css';
+import LoadingCircle from '../../../components/LoadingCircle';
+
+interface IMCPFormProps {
+    formData: IMCPServerFormData;
+    formError: string | null;
+    onInputChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+    onSubmit: (e: React.FormEvent) => Promise<void>;
+    onClose: () => void;
+}
+
+export const MCPForm: React.FC<IMCPFormProps> = ({
+    formData,
+    formError,
+    onInputChange,
+    onSubmit,
+    onClose
+}) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+        e.preventDefault();
+        setIsLoading(true);
+        try {
+            await onSubmit(e);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="connection-form">
+            {formError && <p className="error">{formError}</p>}
+
+            <div className="form-group">
+                <label htmlFor="name">Name</label>
+                <input
+                    id="name"
+                    name="name"
+                    type="text"
+                    value={formData.name}
+                    onChange={onInputChange}
+                    placeholder="mito-ai"
+                    className="form-control"
+                    required
+                />
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="command">Command</label>
+                <input
+                    id="command"
+                    name="command"
+                    type="text"
+                    value={formData.command}
+                    onChange={onInputChange}
+                    placeholder="uvx"
+                    className="form-control"
+                    required
+                />
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="argsText">Arguments</label>
+                <textarea
+                    id="argsText"
+                    name="argsText"
+                    value={formData.argsText}
+                    onChange={onInputChange}
+                    placeholder={'mito-ai-mcp'}
+                    className="form-control"
+                    rows={3}
+                />
+                <div className="settings-option-description">
+                    One argument per line.
+                </div>
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="envText">Environment Variables (optional)</label>
+                <textarea
+                    id="envText"
+                    name="envText"
+                    value={formData.envText}
+                    onChange={onInputChange}
+                    placeholder={'API_KEY=...\nOTHER=value'}
+                    className="form-control"
+                    rows={3}
+                />
+                <div className="settings-option-description">
+                    One KEY=VALUE per line.
+                </div>
+            </div>
+
+            <div className="form-actions">
+                <button
+                    type="button"
+                    className="button-base button-gray"
+                    onClick={onClose}
+                    disabled={isLoading}
+                >
+                    Cancel
+                </button>
+                <button
+                    type="submit"
+                    className="button-base button-purple"
+                    disabled={isLoading}
+                >
+                    {isLoading ? (
+                        <>
+                            Verifying Server<div style={{ color: 'var(--purple-700)' }}>
+                                <LoadingCircle />
+                            </div>
+                        </>
+                    ) : (
+                        'Add Server'
+                    )}
+                </button>
+            </div>
+        </form>
+    );
+};

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPForm.tsx
@@ -39,6 +39,11 @@ export const MCPForm: React.FC<IMCPFormProps> = ({
         <form onSubmit={handleSubmit} className="connection-form mcp-form">
             {formError && <p className="error">{formError}</p>}
 
+            <div className="settings-option-description">
+                Mito currently supports MCP servers that run as a local command-line process and
+                expose tools via stdio.
+            </div>
+
             <div className="form-group">
                 <label htmlFor="name">Name</label>
                 <input

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { requestAPI } from '../../../restAPI/utils';
+import { MCPForm } from './MCPForm';
+import {
+    EMPTY_MCP_FORM,
+    IMCPServerFormData,
+    IMCPServers,
+    parseArgs,
+    parseEnv
+} from './model';
+import '../../../../style/DatabasePage.css';
+import '../../../../style/MCPPage.css';
+
+export const MCPPage = (): JSX.Element => {
+    const [servers, setServers] = useState<IMCPServers>({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showModal, setShowModal] = useState(false);
+    const [formData, setFormData] = useState<IMCPServerFormData>(EMPTY_MCP_FORM);
+    const [formError, setFormError] = useState<string | null>(null);
+    const [clickedDelete, setClickedDelete] = useState<string | null>(null);
+
+    const fetchServers = async (): Promise<void> => {
+        setLoading(true);
+        const resp = await requestAPI<IMCPServers>('mcp/servers');
+        if (resp.error) {
+            setError(resp.error.message);
+            setServers({});
+        } else if (resp.data) {
+            setServers(resp.data);
+            setError(null);
+        }
+        setLoading(false);
+    };
+
+    useEffect(() => {
+        void fetchServers();
+    }, []);
+
+    const handleInputChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    ): void => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+        e.preventDefault();
+        setFormError(null);
+
+        const [env, envError] = parseEnv(formData.envText);
+        if (envError) {
+            setFormError(envError);
+            return;
+        }
+
+        const body = {
+            name: formData.name.trim(),
+            command: formData.command.trim(),
+            args: parseArgs(formData.argsText),
+            env
+        };
+
+        const resp = await requestAPI<{ connection_id: string }>('mcp/servers', {
+            method: 'POST',
+            body: JSON.stringify(body)
+        });
+
+        if (resp.error) {
+            setFormError(resp.error.message);
+            return;
+        }
+
+        await fetchServers();
+        setShowModal(false);
+        setFormData(EMPTY_MCP_FORM);
+    };
+
+    const handleDelete = async (id: string): Promise<void> => {
+        const resp = await requestAPI<{ status: string }>(`mcp/servers/${id}`, {
+            method: 'DELETE'
+        });
+        if (resp.error) {
+            setError(resp.error.message);
+            return;
+        }
+        setClickedDelete(null);
+        await fetchServers();
+    };
+
+    const renderServers = (): JSX.Element => {
+        if (loading) {
+            return <p>Loading MCP servers...</p>;
+        }
+
+        if (error) {
+            return <p className="error">Error: {error}</p>;
+        }
+
+        if (Object.keys(servers).length === 0) {
+            return (
+                <div className="no-connections-container">
+                    <p>No MCP servers configured.</p>
+                    <p>
+                        Add a server to let Mito AI discover tools provided over
+                        the <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">Model Context Protocol</a>.
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className="connections-grid">
+                {Object.entries(servers).map(([id, server]) => (
+                    <div key={id} className="connection-card">
+                        <div className="connection-card-header">
+                            <h3 className="connection-alias">{server.name}</h3>
+                            <span className="connection-type">MCP</span>
+                        </div>
+                        <div className="connection-divider" />
+                        <div className="connection-details">
+                            <p>
+                                <strong>Command:</strong>{' '}
+                                <code>
+                                    {server.command}
+                                    {server.args && server.args.length > 0
+                                        ? ' ' + server.args.join(' ')
+                                        : ''}
+                                </code>
+                            </p>
+                            {server.error ? (
+                                <p className="error">
+                                    <strong>Connection error:</strong> {server.error}
+                                </p>
+                            ) : (
+                                <div className="mcp-tools">
+                                    <strong>Tools ({server.tools?.length ?? 0}):</strong>
+                                    {server.tools && server.tools.length > 0 ? (
+                                        <ul>
+                                            {server.tools.map(tool => (
+                                                <li key={tool.name} title={tool.description}>
+                                                    <code>{tool.name}</code>
+                                                    {tool.description ? ` - ${tool.description}` : ''}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    ) : (
+                                        <p>No tools reported.</p>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                        <div className="connection-actions">
+                            {clickedDelete === id ? (
+                                <div className="confirmation-buttons">
+                                    <button
+                                        className="button-base button-red"
+                                        onClick={() => handleDelete(id)}
+                                    >
+                                        Yes, delete
+                                    </button>
+                                    <button
+                                        className="button-base button-gray"
+                                        onClick={() => setClickedDelete(null)}
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            ) : (
+                                <button
+                                    className="button-base button-red"
+                                    onClick={() => setClickedDelete(id)}
+                                >
+                                    Delete
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        );
+    };
+
+    return (
+        <div className="mcp-servers">
+            <div className="settings-header">
+                <h2>MCP Servers</h2>
+                <div className="header-buttons">
+                    <button
+                        className="button-base button-purple"
+                        onClick={() => {
+                            setFormData(EMPTY_MCP_FORM);
+                            setFormError(null);
+                            setShowModal(true);
+                        }}
+                    >
+                        <b>＋ Add Server</b>
+                    </button>
+                </div>
+            </div>
+
+            {renderServers()}
+
+            {showModal && (
+                <div className="modal-overlay" onClick={() => setShowModal(false)}>
+                    <div className="modal-content" onClick={e => e.stopPropagation()}>
+                        <div className="modal-header">
+                            <h3>Add MCP Server</h3>
+                            <button
+                                className="modal-close-button"
+                                onClick={() => setShowModal(false)}
+                            >
+                                ✕
+                            </button>
+                        </div>
+                        <MCPForm
+                            formData={formData}
+                            formError={formError}
+                            onInputChange={handleInputChange}
+                            onSubmit={handleSubmit}
+                            onClose={() => setShowModal(false)}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
@@ -144,7 +144,7 @@ export const MCPPage = (): JSX.Element => {
                                         <ul>
                                             {server.tools.map(tool => (
                                                 <li key={tool.name} title={tool.description}>
-                                                    <code>{tool.name}</code>
+                                                    <strong>{tool.name}</strong>
                                                     {tool.description ? ` - ${tool.description}` : ''}
                                                 </li>
                                             ))}

--- a/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/MCPPage.tsx
@@ -15,6 +15,7 @@ import {
 } from './model';
 import '../../../../style/DatabasePage.css';
 import '../../../../style/MCPPage.css';
+import '../../../../style/SettingsPage.css';
 
 export const MCPPage = (): JSX.Element => {
     const [servers, setServers] = useState<IMCPServers>({});
@@ -202,6 +203,10 @@ export const MCPPage = (): JSX.Element => {
                         <b>＋ Add Server</b>
                     </button>
                 </div>
+            </div>
+            <div className="settings-page-muted-description">
+                Changes to MCP servers apply to new chats only. Start a new chat to
+                use newly added or updated MCP tools.
             </div>
 
             {renderServers()}

--- a/mito-ai/src/Extensions/SettingsManager/mcp/model.ts
+++ b/mito-ai/src/Extensions/SettingsManager/mcp/model.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+export interface IMCPTool {
+    name: string;
+    description: string;
+}
+
+export interface IMCPServer {
+    name: string;
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+    tools?: IMCPTool[];
+    error?: string;
+}
+
+export interface IMCPServers {
+    [id: string]: IMCPServer;
+}
+
+export interface IMCPServerFormData {
+    name: string;
+    command: string;
+    argsText: string;
+    envText: string;
+}
+
+export const EMPTY_MCP_FORM: IMCPServerFormData = {
+    name: '',
+    command: '',
+    argsText: '',
+    envText: ''
+};
+
+/**
+ * Parse whitespace/newline-separated args, ignoring blank lines.
+ */
+export const parseArgs = (argsText: string): string[] => {
+    return argsText
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0);
+};
+
+/**
+ * Parse KEY=VALUE env vars, one per line. Returns [env, error].
+ */
+export const parseEnv = (envText: string): [Record<string, string>, string | null] => {
+    const env: Record<string, string> = {};
+    const lines = envText.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+    for (const line of lines) {
+        const eqIdx = line.indexOf('=');
+        if (eqIdx <= 0) {
+            return [{}, `Invalid env line: "${line}". Use KEY=VALUE.`];
+        }
+        const key = line.slice(0, eqIdx).trim();
+        const value = line.slice(eqIdx + 1);
+        env[key] = value;
+    }
+    return [env, null];
+};

--- a/mito-ai/src/Extensions/SettingsManager/rules/RulesPage.tsx
+++ b/mito-ai/src/Extensions/SettingsManager/rules/RulesPage.tsx
@@ -9,6 +9,7 @@ import { Rule } from './models';
 import { deleteRule, getRule, getRules, setRule, RuleListItem } from '../../../restAPI/RestAPI';
 import { slugifyRuleName, stripFileEnding } from '../../../utils/fileName';
 import '../../../../style/button.css';
+import '../../../../style/SettingsPage.css';
 
 export const RulesPage = (): JSX.Element => {
     const [modalStatus, setModalStatus] = useState<'new rule' | 'edit rule' | undefined>(undefined);
@@ -115,7 +116,7 @@ export const RulesPage = (): JSX.Element => {
                     <b>＋ Add Rule</b>
                 </button>
             </div>
-            <p>Rules provide more context to Ai models to help them follow your preferences, adhere to your organization&apos;s style guides, learn niche topics, and be a better colleague.</p>
+            <p className="settings-page-muted-description">Rules provide more context to AI models to help them follow your preferences, adhere to your organization&apos;s style guides, learn niche topics, and be a better colleague.</p>
 
             {error && <p className="error">{error}</p>}
 

--- a/mito-ai/style/MCPPage.css
+++ b/mito-ai/style/MCPPage.css
@@ -28,3 +28,23 @@
     padding: 1px 4px;
     font-size: 0.9em;
 }
+
+.mcp-form .form-group textarea {
+    width: 100%;
+    min-height: 8em;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--jp-border-color1);
+    border-radius: 4px;
+    background: var(--jp-layout-color0);
+    color: var(--jp-ui-font-color1);
+    font-size: 14px;
+    line-height: 1.4;
+    resize: vertical;
+}
+
+.mcp-form .form-group textarea:focus {
+    outline: none;
+    border-color: var(--purple-500);
+    box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.1);
+}

--- a/mito-ai/style/MCPPage.css
+++ b/mito-ai/style/MCPPage.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+.mcp-tools {
+    margin-top: 8px;
+}
+
+.mcp-tools ul {
+    list-style: disc;
+    margin: 4px 0 0 0;
+    padding-left: 20px;
+    max-height: 160px;
+    overflow-y: auto;
+}
+
+.mcp-tools li {
+    font-size: 0.85em;
+    color: var(--jp-ui-font-color2);
+    margin: 2px 0;
+}
+
+.mcp-tools code,
+.connection-details code {
+    background: var(--jp-layout-color2);
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 0.9em;
+}

--- a/mito-ai/style/MCPPage.css
+++ b/mito-ai/style/MCPPage.css
@@ -48,3 +48,7 @@
     border-color: var(--purple-500);
     box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.1);
 }
+
+.mcp-form .settings-option-description {
+    margin-left: 0;
+}

--- a/mito-ai/style/MCPPage.css
+++ b/mito-ai/style/MCPPage.css
@@ -51,4 +51,5 @@
 
 .mcp-form .settings-option-description {
     margin-left: 0;
+    margin-bottom: 12px;
 }

--- a/mito-ai/style/SettingsPage.css
+++ b/mito-ai/style/SettingsPage.css
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+.settings-page-muted-description {
+    margin: 4px 0 12px 0;
+    color: var(--jp-ui-font-color2);
+}


### PR DESCRIPTION
# Description

Adds an MCP client to Mito AI. 
 
# Testing

Go to the settings page, add a new MCP server. 

As an example:

```
command: uvx
arguments: mcp-server-time
```

Then ask the Agent to get the time anywhere in the world, it should use the [time](https://github.com/modelcontextprotocol/servers/tree/main/src/time) MCP server.

# Documentation

Yes, we definitely need to update the docs, making clear the MCP server vs client distinction. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new authenticated REST endpoints and agent/tooling paths that can spawn and call external MCP stdio servers, which is security- and stability-sensitive. Also changes strict OpenAI JSON-schema generation, which could impact completion parsing across providers if mismatched.
> 
> **Overview**
> Adds **Model Context Protocol (MCP) integration** end-to-end: the agent can now choose a new `mcp_tool_call` response type, see *available MCP tools* in prompts, and dispatch calls via the `ToolExecutor.execute_mcp_tool` contract.
> 
> Introduces a backend MCP client and config store (`~/.mito/mcp/servers.json`) plus authenticated Jupyter server endpoints to **list/add/delete MCP servers**, verifying connectivity by listing tools and exposing those tools in the Settings UI.
> 
> Tightens OpenAI `json_schema.strict` handling by normalizing object nodes (even when `type` is missing) and recursively forcing `additionalProperties: false`; updates models/tests accordingly, and adds `mcp>=1.0.0` as a dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb2136b3207946e1ee825fbf0e8ee81a55431bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->