### PR TITLE
mito-ai: add support for gpt-5.5

### DIFF
--- a/mito-ai-cli/mito_ai_cli/model_name_utils.py
+++ b/mito-ai-cli/mito_ai_cli/model_name_utils.py
@@ -13,6 +13,7 @@ _COMMON_MODEL_PREFIX_ALIASES = {
     "claudehaiku45": "claude-haiku-4-5",
     "gpt41": "gpt-4.1",
     "gpt52": "gpt-5.2",
+    "gpt55": "gpt-5.5",
     "gemini3flash": "gemini-3-flash",
     "gemini31pro": "gemini-3.1-pro",
 }

--- a/mito-ai-cli/tests/test_model_name_resolution.py
+++ b/mito-ai-cli/tests/test_model_name_resolution.py
@@ -13,6 +13,7 @@ from mito_ai_cli.model_name_utils import resolve_cli_model_name
     [
         ("gpt-4.1", "gpt-4.1"),
         ("GPT-4.1", "gpt-4.1"),
+        ("gpt 5.5", "gpt-5.5"),
         ("haiku-4.5", "claude-haiku-4-5-20251001"),
         ("haiku 4.5", "claude-haiku-4-5-20251001"),
         ("gemini 3.1 pro", "gemini-3.1-pro-preview"),

--- a/mito-ai-core/mito_ai_core/tests/test_model_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/test_model_utils.py
@@ -7,6 +7,7 @@ from mito_ai_core.copilot.model_ids import get_fallback_copilot_models_prefixed
 from mito_ai_core.utils.model_utils import (
     get_available_models,
     get_fast_model_for_selected_model,
+    get_smartest_model_for_selected_model,
     STANDARD_MODELS,
     ANTHROPIC_MODEL_ORDER,
     OPENAI_MODEL_ORDER,
@@ -396,3 +397,17 @@ class TestGetFastModelForSelectedModel:
         result = get_fast_model_for_selected_model(selected_model)
         
         assert result == expected_result
+
+
+class TestGetSmartestModelForSelectedModel:
+    """Tests for get_smartest_model_for_selected_model() function."""
+
+    def test_anthropic_haiku_returns_sonnet_4_6(self):
+        """Claude Haiku should resolve to the smartest Anthropic model."""
+        result = get_smartest_model_for_selected_model("claude-haiku-4-5-20251001")
+        assert result == "claude-sonnet-4-6"
+
+    def test_anthropic_sonnet_4_6_returns_itself(self):
+        """Claude Sonnet 4.6 should remain selected as smartest Anthropic model."""
+        result = get_smartest_model_for_selected_model("claude-sonnet-4-6")
+        assert result == "claude-sonnet-4-6"

--- a/mito-ai-core/mito_ai_core/tests/test_model_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/test_model_utils.py
@@ -402,12 +402,13 @@ class TestGetFastModelForSelectedModel:
 class TestGetSmartestModelForSelectedModel:
     """Tests for get_smartest_model_for_selected_model() function."""
 
-    def test_anthropic_haiku_returns_sonnet_4_6(self):
-        """Claude Haiku should resolve to the smartest Anthropic model."""
-        result = get_smartest_model_for_selected_model("claude-haiku-4-5-20251001")
-        assert result == "claude-sonnet-4-6"
-
-    def test_anthropic_sonnet_4_6_returns_itself(self):
-        """Claude Sonnet 4.6 should remain selected as smartest Anthropic model."""
-        result = get_smartest_model_for_selected_model("claude-sonnet-4-6")
-        assert result == "claude-sonnet-4-6"
+    # Temporarily disabled while "claude-sonnet-4-6" is commented out of ANTHROPIC_MODEL_ORDER
+    # def test_anthropic_haiku_returns_sonnet_4_6(self):
+    #     """Claude Haiku should resolve to the smartest Anthropic model."""
+    #     result = get_smartest_model_for_selected_model("claude-haiku-4-5-20251001")
+    #     assert result == "claude-sonnet-4-6"
+    #
+    # def test_anthropic_sonnet_4_6_returns_itself(self):
+    #     """Claude Sonnet 4.6 should remain selected as smartest Anthropic model."""
+    #     result = get_smartest_model_for_selected_model("claude-sonnet-4-6")
+    #     assert result == "claude-sonnet-4-6"

--- a/mito-ai-core/mito_ai_core/utils/model_utils.py
+++ b/mito-ai-core/mito_ai_core/utils/model_utils.py
@@ -10,7 +10,7 @@ from mito_ai_core.copilot.model_ids import get_fallback_copilot_models_prefixed
 # Model ordering: [fastest, ..., slowest] for each provider
 ANTHROPIC_MODEL_ORDER = [
     "claude-haiku-4-5-20251001",  # Fastest
-    "claude-sonnet-4-6",          # Smarter
+    # "claude-sonnet-4-6",          # Smarter
 ]
 
 OPENAI_MODEL_ORDER = [
@@ -31,7 +31,7 @@ STANDARD_MODELS = [
     "gpt-5.2",
     "gpt-5.5",
     "claude-haiku-4-5-20251001",
-    "claude-sonnet-4-6",
+    # "claude-sonnet-4-6",
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
 ]

--- a/mito-ai-core/mito_ai_core/utils/model_utils.py
+++ b/mito-ai-core/mito_ai_core/utils/model_utils.py
@@ -15,7 +15,8 @@ ANTHROPIC_MODEL_ORDER = [
 OPENAI_MODEL_ORDER = [
     "gpt-4.1",      # Fastest
     "gpt-5",
-    "gpt-5.2",      # Slower
+    "gpt-5.2",
+    "gpt-5.5",      # Slower
 ]
 
 GEMINI_MODEL_ORDER = [
@@ -27,6 +28,7 @@ GEMINI_MODEL_ORDER = [
 STANDARD_MODELS = [
     "gpt-4.1",
     "gpt-5.2",
+    "gpt-5.5",
     "claude-haiku-4-5-20251001",
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",

--- a/mito-ai-core/mito_ai_core/utils/model_utils.py
+++ b/mito-ai-core/mito_ai_core/utils/model_utils.py
@@ -10,6 +10,7 @@ from mito_ai_core.copilot.model_ids import get_fallback_copilot_models_prefixed
 # Model ordering: [fastest, ..., slowest] for each provider
 ANTHROPIC_MODEL_ORDER = [
     "claude-haiku-4-5-20251001",  # Fastest
+    "claude-sonnet-4-6",          # Smarter
 ]
 
 OPENAI_MODEL_ORDER = [
@@ -30,6 +31,7 @@ STANDARD_MODELS = [
     "gpt-5.2",
     "gpt-5.5",
     "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-6",
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
 ]

--- a/mito-ai/src/components/ModelSelector.tsx
+++ b/mito-ai/src/components/ModelSelector.tsx
@@ -16,6 +16,8 @@ import {
   GPT_4_1_MODEL_NAME,
   GPT_5_2_DISPLAY_NAME,
   GPT_5_2_MODEL_NAME,
+  GPT_5_5_DISPLAY_NAME,
+  GPT_5_5_MODEL_NAME,
   GEMINI_3_FLASH_MODEL_NAME,
   GEMINI_3_FLASH_DISPLAY_NAME,
   GEMINI_3_1_PRO_DISPLAY_NAME,
@@ -72,6 +74,16 @@ const MODEL_MAPPINGS: ModelMapping[] = [
     tokenLimit: '400K',
     speed: 'Fast',
     complexityHandling: 'Medium'
+  },
+  {
+    displayName: GPT_5_5_DISPLAY_NAME,
+    fullName: GPT_5_5_MODEL_NAME,
+    type: 'smart',
+    goodFor: [...GOOD_FOR_SMART],
+    provider: 'OpenAI',
+    tokenLimit: '1M',
+    speed: 'Slow',
+    complexityHandling: 'High'
   },
   {
     displayName: CLAUDE_HAIKU_DISPLAY_NAME,

--- a/mito-ai/src/components/ModelSelector.tsx
+++ b/mito-ai/src/components/ModelSelector.tsx
@@ -12,6 +12,8 @@ import LightningIcon from '../icons/LightningIcon';
 import { 
   CLAUDE_HAIKU_DISPLAY_NAME, 
   CLAUDE_HAIKU_MODEL_NAME,
+  CLAUDE_SONNET_4_6_DISPLAY_NAME,
+  CLAUDE_SONNET_4_6_MODEL_NAME,
   GPT_4_1_DISPLAY_NAME,
   GPT_4_1_MODEL_NAME,
   GPT_5_2_DISPLAY_NAME,
@@ -99,6 +101,16 @@ const MODEL_MAPPINGS: ModelMapping[] = [
     tokenLimit: '200K',
     speed: 'Fast',
     complexityHandling: 'Medium'
+  },
+  {
+    displayName: CLAUDE_SONNET_4_6_DISPLAY_NAME,
+    fullName: CLAUDE_SONNET_4_6_MODEL_NAME,
+    type: 'smart',
+    goodFor: [...GOOD_FOR_SMART],
+    provider: 'Anthropic',
+    tokenLimit: '1M',
+    speed: 'Slow',
+    complexityHandling: 'High'
   },
   {
     displayName: GEMINI_3_FLASH_DISPLAY_NAME,

--- a/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
+++ b/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
@@ -9,6 +9,8 @@ import { render, fireEvent, screen, waitFor, within } from '@testing-library/rea
 import ModelSelector from '../../components/ModelSelector';
 import { DEFAULT_MODEL } from '../../components/ModelSelector';
 import { 
+  CLAUDE_SONNET_4_6_DISPLAY_NAME,
+  CLAUDE_SONNET_4_6_MODEL_NAME,
   GPT_4_1_DISPLAY_NAME, 
   GPT_4_1_MODEL_NAME,
   GPT_5_5_DISPLAY_NAME,
@@ -46,6 +48,7 @@ describe('ModelSelector', () => {
           GPT_5_2_MODEL_NAME,
           GPT_5_5_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
+          CLAUDE_SONNET_4_6_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_1_PRO_MODEL_NAME,
         ]
@@ -106,6 +109,30 @@ describe('ModelSelector', () => {
     });
   });
 
+  it('calls onConfigChange when Claude Sonnet 4.6 is selected', async () => {
+    render(<ModelSelector onConfigChange={mockOnConfigChange} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+    });
+
+    const dropdown = screen.getByText(DEFAULT_MODEL).closest('.model-selector-dropdown');
+    if (!dropdown) throw new Error('Dropdown element not found');
+    fireEvent.click(dropdown);
+
+    const modelOptionsContainer = await waitFor(() => {
+      return screen.getByTestId('model-selector').querySelector('.model-options');
+    });
+    if (!modelOptionsContainer) throw new Error('Model options container not found');
+
+    const modelOption = within(modelOptionsContainer as HTMLElement).getByText(CLAUDE_SONNET_4_6_DISPLAY_NAME);
+    fireEvent.click(modelOption);
+
+    expect(mockOnConfigChange).toHaveBeenCalledWith({
+      model: CLAUDE_SONNET_4_6_MODEL_NAME
+    });
+  });
+
   it('loads saved model from localStorage on mount', async () => {
     // Set up localStorage with a saved model (must be in available models)
     const savedConfig = {
@@ -130,6 +157,7 @@ describe('ModelSelector', () => {
           GPT_5_2_MODEL_NAME,
           GPT_5_5_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
+          CLAUDE_SONNET_4_6_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_1_PRO_MODEL_NAME,
         ]

--- a/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
+++ b/mito-ai/src/tests/AiChat/ModelSelector.test.tsx
@@ -11,6 +11,8 @@ import { DEFAULT_MODEL } from '../../components/ModelSelector';
 import { 
   GPT_4_1_DISPLAY_NAME, 
   GPT_4_1_MODEL_NAME,
+  GPT_5_5_DISPLAY_NAME,
+  GPT_5_5_MODEL_NAME,
   GPT_5_2_MODEL_NAME,
   CLAUDE_HAIKU_MODEL_NAME,
   GEMINI_3_FLASH_MODEL_NAME,
@@ -42,6 +44,7 @@ describe('ModelSelector', () => {
         models: [
           GPT_4_1_MODEL_NAME,
           GPT_5_2_MODEL_NAME,
+          GPT_5_5_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_1_PRO_MODEL_NAME,
@@ -79,6 +82,30 @@ describe('ModelSelector', () => {
     });
   });
 
+  it('calls onConfigChange when GPT 5.5 is selected', async () => {
+    render(<ModelSelector onConfigChange={mockOnConfigChange} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading models...')).not.toBeInTheDocument();
+    });
+
+    const dropdown = screen.getByText(DEFAULT_MODEL).closest('.model-selector-dropdown');
+    if (!dropdown) throw new Error('Dropdown element not found');
+    fireEvent.click(dropdown);
+
+    const modelOptionsContainer = await waitFor(() => {
+      return screen.getByTestId('model-selector').querySelector('.model-options');
+    });
+    if (!modelOptionsContainer) throw new Error('Model options container not found');
+
+    const modelOption = within(modelOptionsContainer as HTMLElement).getByText(GPT_5_5_DISPLAY_NAME);
+    fireEvent.click(modelOption);
+
+    expect(mockOnConfigChange).toHaveBeenCalledWith({
+      model: GPT_5_5_MODEL_NAME
+    });
+  });
+
   it('loads saved model from localStorage on mount', async () => {
     // Set up localStorage with a saved model (must be in available models)
     const savedConfig = {
@@ -101,6 +128,7 @@ describe('ModelSelector', () => {
         models: [
           GPT_4_1_MODEL_NAME,
           GPT_5_2_MODEL_NAME,
+          GPT_5_5_MODEL_NAME,
           CLAUDE_HAIKU_MODEL_NAME,
           GEMINI_3_FLASH_MODEL_NAME,
           GEMINI_3_1_PRO_MODEL_NAME,

--- a/mito-ai/src/utils/models.ts
+++ b/mito-ai/src/utils/models.ts
@@ -47,7 +47,6 @@ export async function getAvailableModels(): Promise<string[]> {
             GPT_5_2_MODEL_NAME,
             GPT_5_5_MODEL_NAME,
             CLAUDE_HAIKU_MODEL_NAME,
-            CLAUDE_SONNET_4_6_MODEL_NAME,
             GEMINI_3_FLASH_MODEL_NAME,
             GEMINI_3_1_PRO_MODEL_NAME,
         ];

--- a/mito-ai/src/utils/models.ts
+++ b/mito-ai/src/utils/models.ts
@@ -15,6 +15,9 @@ export const GPT_4_1_MODEL_NAME = 'gpt-4.1';
 export const GPT_5_2_DISPLAY_NAME = 'GPT 5.2';
 export const GPT_5_2_MODEL_NAME = 'gpt-5.2';
 
+export const GPT_5_5_DISPLAY_NAME = 'GPT 5.5';
+export const GPT_5_5_MODEL_NAME = 'gpt-5.5';
+
 export const GEMINI_3_FLASH_DISPLAY_NAME = 'Gemini 3 Flash';
 export const GEMINI_3_FLASH_MODEL_NAME = 'gemini-3-flash-preview';
 
@@ -40,6 +43,7 @@ export async function getAvailableModels(): Promise<string[]> {
         return [
             GPT_4_1_MODEL_NAME,
             GPT_5_2_MODEL_NAME,
+            GPT_5_5_MODEL_NAME,
             CLAUDE_HAIKU_MODEL_NAME,
             GEMINI_3_FLASH_MODEL_NAME,
             GEMINI_3_1_PRO_MODEL_NAME,

--- a/mito-ai/src/utils/models.ts
+++ b/mito-ai/src/utils/models.ts
@@ -5,6 +5,8 @@
 
 export const CLAUDE_SONNET_DISPLAY_NAME = 'Claude Sonnet 4.5';
 export const CLAUDE_SONNET_MODEL_NAME = 'claude-sonnet-4-5-20250929';
+export const CLAUDE_SONNET_4_6_DISPLAY_NAME = 'Claude Sonnet 4.6';
+export const CLAUDE_SONNET_4_6_MODEL_NAME = 'claude-sonnet-4-6';
 
 export const CLAUDE_HAIKU_DISPLAY_NAME = 'Claude Haiku 4.5';
 export const CLAUDE_HAIKU_MODEL_NAME = 'claude-haiku-4-5-20251001';
@@ -45,6 +47,7 @@ export async function getAvailableModels(): Promise<string[]> {
             GPT_5_2_MODEL_NAME,
             GPT_5_5_MODEL_NAME,
             CLAUDE_HAIKU_MODEL_NAME,
+            CLAUDE_SONNET_4_6_MODEL_NAME,
             GEMINI_3_FLASH_MODEL_NAME,
             GEMINI_3_1_PRO_MODEL_NAME,
         ];


### PR DESCRIPTION
# Description

`gpt 5.5!`

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the default/available model lists and ordering used for model selection across CLI, core utilities, and UI, which could affect which model is chosen in enterprise/router scenarios.
> 
> **Overview**
> Adds `gpt-5.5` as a first-class supported model across the stack: core `STANDARD_MODELS`/`OPENAI_MODEL_ORDER`, CLI name resolution (including aliasing `gpt 5.5` -> `gpt-5.5`), and the frontend model selector (display constants, metadata, and tests).
> 
> Also introduces `get_smartest_model_for_selected_model` in `model_utils` (and a placeholder test suite), and updates UI/test fixtures to include `claude-sonnet-4-6` in the model list (while keeping it commented out of Anthropic ordering/standard models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa111a124adfb6e8ee5c7ea2dab0332a562505f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->