### PR TITLE
Cleaner document mode

### DIFF
--- a/mito-ai/src/Extensions/NotebookViewMode/NotebookViewModePlugin.ts
+++ b/mito-ai/src/Extensions/NotebookViewMode/NotebookViewModePlugin.ts
@@ -295,6 +295,9 @@ export class NotebookViewModeManager implements INotebookViewMode {
     this._killActiveProcess();
     // Dispose iframe/placeholder
     this._disposeTransientWidgets();
+    // Expand any collapsed outputs so Document mode always opens with
+    // fully visible output content.
+    this._expandCollapsedOutputs(panel);
     // Hide native toolbar (Run Cell, cell type, etc. are not relevant in Document mode)
     panel.toolbar.hide();
     // Show custom mode toolbar (mode switcher only, no app buttons since mode is Document)
@@ -306,6 +309,20 @@ export class NotebookViewModeManager implements INotebookViewMode {
     // Attach dblclick listener
     this._attachOrDetachDblclickListener(panel, true);
   }
+
+  /**
+   * Expand collapsed code-cell outputs before entering document mode.
+   */
+  private _expandCollapsedOutputs(panel: NotebookPanel): void {
+    const collapsedOutputToggles = panel.content.node.querySelectorAll<HTMLElement>(
+      '.jp-OutputArea .jp-OutputArea-promptOverlay[title*="Expand"], .jp-OutputArea .jp-mod-collapsed'
+    );
+
+    collapsedOutputToggles.forEach((toggle) => {
+      toggle.click();
+    });
+  }
+
 
   /**
    * Apply the App mode UI: hide native toolbar, show app toolbar,

--- a/mito-ai/style/DocumentMode.css
+++ b/mito-ai/style/DocumentMode.css
@@ -24,3 +24,31 @@
   content: "" !important;
   display: none !important;
 }
+
+/*
+ * Hide cell toolbar buttons in document mode, except the AI agent's
+ * Accept/Reject buttons. Mirrors the existing carve-out in base.css for
+ * `.jp-toolbar-overlap` so the agent flow keeps working from document mode.
+ */
+.jp-Notebook.jp-mod-mito-document-mode .jp-cell-toolbar {
+  display: flex !important;
+}
+
+.jp-Notebook.jp-mod-mito-document-mode
+  .jp-cell-toolbar
+  > *:not([data-jp-item-name='accept-code']):not(
+    [data-jp-item-name='reject-code']
+  ) {
+  display: none !important;
+}
+
+/*
+ * Hide the `Out[N]:` execution-number text on code-cell outputs in
+ * document mode. Use `visibility: hidden` (not `display: none`) so the
+ * 64px prompt column is preserved and outputs keep their existing left
+ * edge — which is also where rendered markdown sits, so alignment between
+ * markdown content and code outputs is preserved automatically.
+ */
+.jp-Notebook.jp-mod-mito-document-mode .jp-OutputPrompt {
+  visibility: hidden;
+}

--- a/mito-ai/style/DocumentMode.css
+++ b/mito-ai/style/DocumentMode.css
@@ -52,3 +52,13 @@
 .jp-Notebook.jp-mod-mito-document-mode .jp-OutputPrompt {
   visibility: hidden;
 }
+
+/*
+ * In document mode, don't show the active markdown-cell border treatment.
+ * This keeps selected markdown cells looking like part of a continuous doc.
+ */
+.jp-Notebook.jp-mod-mito-document-mode
+  .jp-MarkdownCell.jp-mod-active
+  .jp-MarkdownOutput {
+  border-color: transparent;
+}

--- a/mito-ai/style/DocumentMode.css
+++ b/mito-ai/style/DocumentMode.css
@@ -62,3 +62,18 @@
   .jp-MarkdownOutput {
   border-color: transparent;
 }
+
+/*
+ * Hide markdown heading collapse buttons in document mode so the notebook
+ * reads like a clean document without collapser affordances.
+ */
+.jp-Notebook.jp-mod-mito-document-mode .jp-collapseHeadingButton {
+  display: none !important;
+}
+
+/*
+ * Hide output gutter collapser overlay in document mode.
+ */
+.jp-Notebook.jp-mod-mito-document-mode .jp-OutputArea-promptOverlay {
+  display: none !important;
+}

--- a/mito-ai/style/NotebookMarkdown.css
+++ b/mito-ai/style/NotebookMarkdown.css
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ *
+ * Notion-style restyle of rendered markdown cells.
+ * Scoped to `.jp-MarkdownCell .jp-RenderedHTMLCommon` so DataFrame outputs,
+ * IPython.display.HTML/Markdown outputs in code cells, and the chat panel
+ * are all left at their existing styling.
+ */
+
+/* Headings: bump weights and add breathing room above sections.
+   Sizes are intentionally untouched. */
+.jp-MarkdownCell .jp-RenderedHTMLCommon h1 {
+    font-weight: 700;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon h2,
+.jp-MarkdownCell .jp-RenderedHTMLCommon h3,
+.jp-MarkdownCell .jp-RenderedHTMLCommon h4,
+.jp-MarkdownCell .jp-RenderedHTMLCommon h5,
+.jp-MarkdownCell .jp-RenderedHTMLCommon h6 {
+    font-weight: 600;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon h2 {
+    margin-top: 2em;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon h3 {
+    margin-top: 1.5em;
+}
+
+/* Inline code: Mito-purple pill. Mirrors the chat-panel pattern in
+   MarkdownMessage.css so light and dark themes inherit a working palette. */
+.jp-MarkdownCell .jp-RenderedHTMLCommon :not(pre) > code {
+    background-color: var(--purple-300);
+    color: var(--purple-700);
+    border-radius: 3px;
+    padding: 1px 4px;
+}
+
+/* Lists: tighter indent and per-item breathing room.
+   Glyph stack only applies to <ul>; <ol> uses default numbering. */
+.jp-MarkdownCell .jp-RenderedHTMLCommon ul,
+.jp-MarkdownCell .jp-RenderedHTMLCommon ol {
+    padding-left: 28px;
+    margin-block: 0.75em;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon ul {
+    list-style-type: disc;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon ul ul {
+    list-style-type: circle;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon ul ul ul {
+    list-style-type: square;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon li {
+    margin-block: 4px;
+}
+
+/* Tables: clean borders, padded cells, zebra rows. */
+.jp-MarkdownCell .jp-RenderedHTMLCommon table {
+    border-collapse: collapse;
+    border: none;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon th,
+.jp-MarkdownCell .jp-RenderedHTMLCommon td {
+    padding: 8px 12px;
+    text-align: left;
+    border: none;
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon th {
+    font-weight: 600;
+    border-bottom: 1px solid var(--jp-border-color2);
+}
+
+.jp-MarkdownCell .jp-RenderedHTMLCommon tbody tr:nth-child(even) {
+    background-color: var(--jp-rendermime-table-row-background);
+}
+
+/* Blockquotes: purple left rule with softer body text. */
+.jp-MarkdownCell .jp-RenderedHTMLCommon blockquote {
+    border-left: 3px solid var(--purple-300);
+    color: var(--jp-content-font-color2);
+    padding-left: 16px;
+    margin-left: 0;
+}
+
+/* Hide the collapser caret on rendered markdown cells so the document
+   feels chrome-less. Add equivalent left padding so rendered content
+   stays horizontally aligned with where the cell input/output begins. */
+.jp-MarkdownCell.jp-mod-rendered .jp-Collapser {
+    display: none;
+}
+
+.jp-MarkdownCell.jp-mod-rendered .jp-RenderedHTMLCommon {
+    padding-left: var(--jp-cell-collapser-width);
+}

--- a/mito-ai/style/base.css
+++ b/mito-ai/style/base.css
@@ -11,6 +11,7 @@
 
 @import url('icons.css');
 @import url('statusItem.css');
+@import url('NotebookMarkdown.css');
 
 :root {
   /* Margins */


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI/CSS changes, but it relies on DOM querying/clicking to expand outputs and changes JupyterLab notebook chrome, which could be brittle across JupyterLab versions or themes.
> 
> **Overview**
> Improves *Document mode* to read more like a clean document: entering Document mode now auto-expands any collapsed cell outputs, and additional styling hides most cell chrome (toolbars except AI accept/reject, output execution prompts, markdown selection borders, heading/output collapse affordances).
> 
> Adds a new `NotebookMarkdown.css` (imported from `base.css`) to restyle rendered markdown cells (headings, inline code, lists, tables, blockquotes) while scoping changes to markdown-cell rendered HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eb63085b7e70da39028ca4357e97f35b51f387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->