### PR TITLE
Removed Comment Button For Mitosheet

### DIFF
--- a/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
+++ b/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
@@ -189,6 +189,11 @@ interface OutputCommentButtonProps {
     onClick: () => void;
 }
 
+const MITOSHEET_OUTPUT_MIME_TYPES = new Set([
+    'application/x.mito+json',
+    'application/x-mitosheet',
+]);
+
 const OutputCommentButton: React.FC<OutputCommentButtonProps> = ({ onClick }) => {
     return (
         <TextAndIconButton
@@ -266,6 +271,44 @@ function injectOutputCommentButton(
     outputWrapper.appendChild(commentBtnDiv);
 }
 
+function removeOutputCommentButton(cell: CodeCell): void {
+    const outputWrapper = cell.node.querySelector('.jp-Cell-outputWrapper') as HTMLElement | null;
+    if (!outputWrapper) {
+        return;
+    }
+
+    const existingButton = outputWrapper.querySelector('.output-comment-button-container');
+    if (existingButton) {
+        existingButton.remove();
+    }
+}
+
+function isMitosheetOutputCell(cell: CodeCell): boolean {
+    const outputs = cell.outputArea?.model?.toJSON?.() ?? [];
+    for (const output of outputs) {
+        if (output.output_type === 'display_data' || output.output_type === 'execute_result') {
+            const outputData = output.data as Record<string, unknown> | undefined;
+            if (!outputData) {
+                continue;
+            }
+            for (const mimeType of Object.keys(outputData)) {
+                if (MITOSHEET_OUTPUT_MIME_TYPES.has(mimeType) || mimeType.includes('mito')) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Fallback for already-rendered Mitosheet outputs in the DOM.
+    if (cell.node.querySelector('.mito-mime-renderer, .mito-container, .mito-viewer')) {
+        return true;
+    }
+
+    // Source fallback for classic mitosheet output cells rendered via JS/HTML.
+    const sourceText = (cell.model.sharedModel.getSource() || '').toLowerCase();
+    return sourceText.includes('mitosheet.sheet(') || sourceText.includes('from mitosheet import sheet');
+}
+
 /**
  * Inject comment buttons into all code cells that have output,
  * and observe for new outputs being rendered.
@@ -298,6 +341,10 @@ function setupOutputCommentButtons(
     const injectAllForPanel = (notebookPanel: NotebookPanel): void => {
         for (const cell of notebookPanel.content.widgets) {
             if (cell instanceof CodeCell && cell.outputArea?.model.length > 0) {
+                if (isMitosheetOutputCell(cell)) {
+                    removeOutputCommentButton(cell);
+                    continue;
+                }
                 injectOutputCommentButton(cell, app, notebookTracker);
             }
         }

--- a/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
+++ b/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
@@ -189,11 +189,6 @@ interface OutputCommentButtonProps {
     onClick: () => void;
 }
 
-const MITOSHEET_OUTPUT_MIME_TYPES = new Set([
-    'application/x.mito+json',
-    'application/x-mitosheet',
-]);
-
 const OutputCommentButton: React.FC<OutputCommentButtonProps> = ({ onClick }) => {
     return (
         <TextAndIconButton
@@ -219,6 +214,15 @@ function injectOutputCommentButton(
 ): void {
     const outputWrapper = cell.node.querySelector('.jp-Cell-outputWrapper') as HTMLElement | null;
     if (!outputWrapper) {
+        return;
+    }
+
+    const isMitosheetOutput =
+        !!outputWrapper.querySelector('.mito-container, .mito-viewer, .mito-mime-renderer') ||
+        cell.model.sharedModel.getSource().toLowerCase().includes('mitosheet');
+
+    if (isMitosheetOutput) {
+        outputWrapper.querySelector('.output-comment-button-container')?.remove();
         return;
     }
 
@@ -271,44 +275,6 @@ function injectOutputCommentButton(
     outputWrapper.appendChild(commentBtnDiv);
 }
 
-function removeOutputCommentButton(cell: CodeCell): void {
-    const outputWrapper = cell.node.querySelector('.jp-Cell-outputWrapper') as HTMLElement | null;
-    if (!outputWrapper) {
-        return;
-    }
-
-    const existingButton = outputWrapper.querySelector('.output-comment-button-container');
-    if (existingButton) {
-        existingButton.remove();
-    }
-}
-
-function isMitosheetOutputCell(cell: CodeCell): boolean {
-    const outputs = cell.outputArea?.model?.toJSON?.() ?? [];
-    for (const output of outputs) {
-        if (output.output_type === 'display_data' || output.output_type === 'execute_result') {
-            const outputData = output.data as Record<string, unknown> | undefined;
-            if (!outputData) {
-                continue;
-            }
-            for (const mimeType of Object.keys(outputData)) {
-                if (MITOSHEET_OUTPUT_MIME_TYPES.has(mimeType) || mimeType.includes('mito')) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    // Fallback for already-rendered Mitosheet outputs in the DOM.
-    if (cell.node.querySelector('.mito-mime-renderer, .mito-container, .mito-viewer')) {
-        return true;
-    }
-
-    // Source fallback for classic mitosheet output cells rendered via JS/HTML.
-    const sourceText = (cell.model.sharedModel.getSource() || '').toLowerCase();
-    return sourceText.includes('mitosheet.sheet(') || sourceText.includes('from mitosheet import sheet');
-}
-
 /**
  * Inject comment buttons into all code cells that have output,
  * and observe for new outputs being rendered.
@@ -341,10 +307,6 @@ function setupOutputCommentButtons(
     const injectAllForPanel = (notebookPanel: NotebookPanel): void => {
         for (const cell of notebookPanel.content.widgets) {
             if (cell instanceof CodeCell && cell.outputArea?.model.length > 0) {
-                if (isMitosheetOutputCell(cell)) {
-                    removeOutputCommentButton(cell);
-                    continue;
-                }
                 injectOutputCommentButton(cell, app, notebookTracker);
             }
         }


### PR DESCRIPTION
# Description

Not showing the comment button on Mitosheet or dataframe outputs. This button used to block most of the top bar in Mitosheet, and would obfuscated the search bar for the dataframe output. 

# Testing

Render a Mitosheet, make sure the comment is not there. Try a few other output types, make sure the comment button is still there.

# Documentation

N/A - Small bug fix. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to suppressing the injected output comment button for Mitosheet-related outputs; main risk is mis-detecting outputs and hiding the button in unintended cases.
> 
> **Overview**
> Prevents the output hover *Comment* button from being injected on Mitosheet/dataframe-style outputs.
> 
> `injectOutputCommentButton` now detects Mitosheet renders via `.mito-*` DOM markers or `mitosheet` in the cell source, and removes any previously injected `.output-comment-button-container` instead of showing it, avoiding UI overlap with Mitosheet’s top bar/search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901dec1b9018feab6a3dda228c36e7b61614469d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->