### PR TITLE
Fixed duplicate kernel listeners in context manager

### DIFF
--- a/mito-ai/src/Extensions/ContextManager/ContextManagerPlugin.ts
+++ b/mito-ai/src/Extensions/ContextManager/ContextManagerPlugin.ts
@@ -38,6 +38,7 @@ export interface IContextManager {
 export class ContextManager implements IContextManager {
     private notebookContexts: Map<string, NotebookContext> = new Map();
     private notebookTracker: INotebookTracker;
+    private initializedNotebookPanels: WeakSet<NotebookPanel> = new WeakSet();
 
     constructor(app: JupyterFrontEnd, notebookTracker: INotebookTracker) {
         this.notebookTracker = notebookTracker;
@@ -88,6 +89,12 @@ export class ContextManager implements IContextManager {
         // which files are available.
         const updatedFiles = await getFiles(app, notebookPanel);
         this.updateNotebookFiles(notebookPanel.id, updatedFiles);
+
+        // Avoid registering duplicate listeners when the same notebook panel becomes active again.
+        if (this.initializedNotebookPanels.has(notebookPanel)) {
+            return;
+        }
+        this.initializedNotebookPanels.add(notebookPanel);
     
         // Listen for kernel restart or shut down events and clear the variables for this notebook
         notebookPanel.context.sessionContext.statusChanged.connect((sender, status) => {

--- a/mito-ai/src/tests/ContextManager/ContextManagerPlugin.test.tsx
+++ b/mito-ai/src/tests/ContextManager/ContextManagerPlugin.test.tsx
@@ -6,7 +6,8 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { ContextManager } from '../../Extensions/ContextManager/ContextManagerPlugin';
-import { Variable } from '../../Extensions/ContextManager/VariableInspector';
+import { fetchVariablesAndUpdateState, Variable } from '../../Extensions/ContextManager/VariableInspector';
+import { KernelMessage } from '@jupyterlab/services';
 
 // Mock data for testing
 const MOCK_VARIABLES: Variable[] = [
@@ -18,6 +19,10 @@ jest.mock('../../Extensions/ContextManager/FileInspector', () => ({
     getFiles: jest.fn().mockResolvedValue([])
 }));
 
+jest.mock('../../Extensions/ContextManager/VariableInspector', () => ({
+    fetchVariablesAndUpdateState: jest.fn()
+}));
+
 describe('ContextManager', () => {
     let contextManager: ContextManager;
     let mockApp: JupyterFrontEnd;
@@ -25,13 +30,20 @@ describe('ContextManager', () => {
     let mockSessionContext: any;
     let currentChangedCallback: any;
     const mockNotebookId = '/test/notebook.ipynb';
+    const flushPromises = async (): Promise<void> => {
+        await Promise.resolve();
+        await Promise.resolve();
+    };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         // Create mock session context with session ID
         mockSessionContext = {
             statusChanged: {
                 connect: jest.fn()
             },
+            iopubMessage: {
+                connect: jest.fn()
+            }
         };
 
         // Create mock notebook panel
@@ -65,6 +77,11 @@ describe('ContextManager', () => {
 
         // Trigger the currentChanged event to set up the kernel listener
         currentChangedCallback(mockNotebookTracker, mockNotebookPanel);
+        await flushPromises();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     describe('Kernel Refresh', () => {
@@ -126,6 +143,41 @@ describe('ContextManager', () => {
             // Verify that variables were not cleared
             const context = contextManager.getNotebookContext(mockNotebookId);
             expect(context?.variables).toEqual(MOCK_VARIABLES);
+        });
+    });
+
+    describe('Kernel Listener Registration', () => {
+        it('only registers one set of listeners for the same notebook panel', async () => {
+            expect(mockSessionContext.statusChanged.connect).toHaveBeenCalledTimes(1);
+            expect(mockSessionContext.iopubMessage.connect).toHaveBeenCalledTimes(1);
+
+            const mockNotebookPanel = mockNotebookTracker.currentWidget;
+            currentChangedCallback(mockNotebookTracker, mockNotebookPanel);
+            await flushPromises();
+
+            expect(mockSessionContext.statusChanged.connect).toHaveBeenCalledTimes(1);
+            expect(mockSessionContext.iopubMessage.connect).toHaveBeenCalledTimes(1);
+        });
+
+        it('fetches variables once for an execute_input message even after re-activating the same notebook', async () => {
+            const mockNotebookPanel = mockNotebookTracker.currentWidget;
+            currentChangedCallback(mockNotebookTracker, mockNotebookPanel);
+            await flushPromises();
+
+            const iopubMessageCallback = mockSessionContext.iopubMessage.connect.mock.calls[0][0];
+            const executeInputMessage = {
+                header: {
+                    msg_type: 'execute_input'
+                }
+            } as KernelMessage.IMessage;
+
+            iopubMessageCallback({}, executeInputMessage);
+
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledTimes(1);
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledWith(
+                mockNotebookPanel,
+                expect.any(Function)
+            );
         });
     });
 


### PR DESCRIPTION
# Description

Fixes #2135.

This change fixes a duplicate kernel-listener registration bug in the Mito AI context manager. We were registering `iopubMessage` and `statusChanged` listeners more than once for the same `NotebookPanel`, which caused extra silent variable-inspection executions to be triggered during `Run All`.

Before this fix, each real cell execution could trigger multiple context-manager callbacks, which inflated the execution request count and contributed to the kernel appearing stuck after all visible cells had finished.

What changed:
- made context-manager listener registration idempotent per notebook panel
- added regression tests to verify we only register one listener set per notebook
- added regression coverage to verify `execute_input` only triggers one variable refresh callback after re-activating the same notebook

Relevant files:
- `mito-ai/src/Extensions/ContextManager/ContextManagerPlugin.ts`
- `mito-ai/src/tests/ContextManager/ContextManagerPlugin.test.tsx`

Manual verification on the large bitcoin notebook now shows the kernel returning to `Idle` after `Run All`, with the old tripled execution pattern no longer reproducing.

Confirmation screenshot:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e33b4b8d-0c09-4159-8ffa-8437c07d6015" />


# Testing

Automated:
- [x] `npx jest src/tests/ContextManager/ContextManagerPlugin.test.tsx --runInBand`

Manual:
- [x] Opened `large-bitcoin-analysis (1).ipynb` in JupyterLab with Mito AI enabled
- [x] Ran `Run All Cells`
- [x] Confirmed all visible cells completed
- [x] Hovered the kernel status indicator and confirmed the kernel returned to `Idle`
- [x] Confirmed the old `3x` duplicate-listener execution pattern no longer reproduced
- [x] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

Notes:
- Manual verification screenshot shows `Kernel status: Idle` and `Execute 68 cells` after notebook completion.
- `68` is consistent with notebook execution plus silent variable inspection, but the kernel-idle bug from #2135 no longer reproduces.

# Documentation

No documentation changes required for this fix.
