### PR TITLE
Defer ContextManager variable refresh until kernel is idle

### DIFF
--- a/mito-ai/src/Extensions/ContextManager/ContextManagerPlugin.ts
+++ b/mito-ai/src/Extensions/ContextManager/ContextManagerPlugin.ts
@@ -39,6 +39,7 @@ export class ContextManager implements IContextManager {
     private notebookContexts: Map<string, NotebookContext> = new Map();
     private notebookTracker: INotebookTracker;
     private initializedNotebookPanels: WeakSet<NotebookPanel> = new WeakSet();
+    private dirtyNotebooks: Set<string> = new Set();
 
     constructor(app: JupyterFrontEnd, notebookTracker: INotebookTracker) {
         this.notebookTracker = notebookTracker;
@@ -96,31 +97,44 @@ export class ContextManager implements IContextManager {
         }
         this.initializedNotebookPanels.add(notebookPanel);
     
-        // Listen for kernel restart or shut down events and clear the variables for this notebook
-        notebookPanel.context.sessionContext.statusChanged.connect((sender, status) => {
+        // Listen for kernel status changes:
+        //  - On restart/terminate/unknown: clear variables for this notebook
+        //  - On idle: if the notebook has been marked dirty by a recent execute_input,
+        //    refresh variables and files once and clear the dirty flag. This batches
+        //    context refreshes so that "Run All" produces a single refresh after the
+        //    execution queue drains, rather than one refresh per executed cell.
+        notebookPanel.context.sessionContext.statusChanged.connect(async (sender, status) => {
             if (status === 'restarting' || status === 'terminating' || status === 'unknown') {
-                // Clear the variables for this specific notebook, but don't clear the files 
+                // Clear the variables for this specific notebook, but don't clear the files
                 // as they have not changed.
                 this.updateNotebookVariables(notebookPanel.id, []); // Clear variables for this specific notebook
+                this.dirtyNotebooks.delete(notebookPanel.id);
+                return;
             }
-        });
-    
-        // Listen to kernel messages
-        notebookPanel.context.sessionContext.iopubMessage.connect(async (sender, msg: KernelMessage.IMessage) => {
-    
-            // Watch for execute_input messages, which indicate is a request to execute code. 
-            // Previosuly, we watched for 'execute_result' messages, but these are only returned
-            // from the kernel when a code cell prints a value to the output cell, which is not what we want.
-            // TODO: Check if there is a race condition where we might end up fetching variables before the 
-            // code is executed. I don't think this is the case because the kernel runs in one thread I believe.
-            // TODO: Eventually we should create a document manager listener so if the user uploads a new file
-            // to jupyter, we can update the available files even if they have not executed a kernel message.
-            if (msg.header.msg_type === 'execute_input') {
+
+            if (status === 'idle' && this.dirtyNotebooks.has(notebookPanel.id)) {
+                // Clear the flag before fetching so concurrent execute_inputs that arrive
+                // during the fetch will re-mark the notebook dirty and trigger another
+                // refresh on the next idle.
+                this.dirtyNotebooks.delete(notebookPanel.id);
 
                 void fetchVariablesAndUpdateState(notebookPanel, this.updateNotebookVariables.bind(this, notebookPanel.id));
 
                 const updatedFiles = await getFiles(app, notebookPanel);
                 this.updateNotebookFiles(notebookPanel.id, updatedFiles);
+            }
+        });
+
+        // Listen to kernel messages
+        notebookPanel.context.sessionContext.iopubMessage.connect((sender, msg: KernelMessage.IMessage) => {
+            // Watch for execute_input messages, which indicate a request to execute code.
+            // Previously we fetched variables synchronously here, but that issued an extra
+            // kernel.requestExecute per executed cell, inflating the kernel queue (e.g. "Run All"
+            // on a 37-cell notebook produced ~74 executions). Instead, mark the notebook
+            // context as dirty and defer the actual refresh until the kernel returns to idle
+            // (handled in the statusChanged listener above).
+            if (msg.header.msg_type === 'execute_input') {
+                this.dirtyNotebooks.add(notebookPanel.id);
             }
         });
     }

--- a/mito-ai/src/tests/ContextManager/ContextManagerPlugin.test.tsx
+++ b/mito-ai/src/tests/ContextManager/ContextManagerPlugin.test.tsx
@@ -137,12 +137,75 @@ describe('ContextManager', () => {
             // Get the callback that was registered for status changes
             const statusChangedCallback = mockSessionContext.statusChanged.connect.mock.calls[0][0];
 
-            // Simulate a different kernel status change
+            // Simulate a different kernel status change. The notebook has not been marked
+            // dirty by an execute_input, so 'idle' should not trigger a refresh either.
             statusChangedCallback({}, 'idle');
 
             // Verify that variables were not cleared
             const context = contextManager.getNotebookContext(mockNotebookId);
             expect(context?.variables).toEqual(MOCK_VARIABLES);
+        });
+    });
+
+    describe('Deferred variable fetching', () => {
+        it('does not fetch variables on execute_input — defers until kernel idle', () => {
+            const iopubMessageCallback = mockSessionContext.iopubMessage.connect.mock.calls[0][0];
+            const executeInputMessage = {
+                header: { msg_type: 'execute_input' }
+            } as KernelMessage.IMessage;
+
+            iopubMessageCallback({}, executeInputMessage);
+
+            expect(fetchVariablesAndUpdateState).not.toHaveBeenCalled();
+        });
+
+        it('fetches variables once when the kernel returns to idle after one or more execute_inputs', () => {
+            const iopubMessageCallback = mockSessionContext.iopubMessage.connect.mock.calls[0][0];
+            const statusChangedCallback = mockSessionContext.statusChanged.connect.mock.calls[0][0];
+            const executeInputMessage = {
+                header: { msg_type: 'execute_input' }
+            } as KernelMessage.IMessage;
+
+            // Simulate "Run All": multiple execute_inputs arrive before the kernel goes idle.
+            iopubMessageCallback({}, executeInputMessage);
+            iopubMessageCallback({}, executeInputMessage);
+            iopubMessageCallback({}, executeInputMessage);
+
+            expect(fetchVariablesAndUpdateState).not.toHaveBeenCalled();
+
+            // Once the kernel goes idle, exactly one fetch should fire for the batch.
+            statusChangedCallback({}, 'idle');
+
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledTimes(1);
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledWith(
+                mockNotebookTracker.currentWidget,
+                expect.any(Function)
+            );
+        });
+
+        it('does not fetch on idle when the notebook is not dirty', () => {
+            const statusChangedCallback = mockSessionContext.statusChanged.connect.mock.calls[0][0];
+
+            // No execute_input has marked the notebook dirty, so idle alone is a no-op.
+            statusChangedCallback({}, 'idle');
+
+            expect(fetchVariablesAndUpdateState).not.toHaveBeenCalled();
+        });
+
+        it('clears the dirty flag after fetching, so a subsequent idle without new execute_input does nothing', () => {
+            const iopubMessageCallback = mockSessionContext.iopubMessage.connect.mock.calls[0][0];
+            const statusChangedCallback = mockSessionContext.statusChanged.connect.mock.calls[0][0];
+            const executeInputMessage = {
+                header: { msg_type: 'execute_input' }
+            } as KernelMessage.IMessage;
+
+            iopubMessageCallback({}, executeInputMessage);
+            statusChangedCallback({}, 'idle');
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledTimes(1);
+
+            // A second idle with no intervening execute_input should not trigger a second fetch.
+            statusChangedCallback({}, 'idle');
+            expect(fetchVariablesAndUpdateState).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -159,12 +222,15 @@ describe('ContextManager', () => {
             expect(mockSessionContext.iopubMessage.connect).toHaveBeenCalledTimes(1);
         });
 
-        it('fetches variables once for an execute_input message even after re-activating the same notebook', async () => {
+        it('fetches variables once per execute_input/idle cycle even after re-activating the same notebook', async () => {
             const mockNotebookPanel = mockNotebookTracker.currentWidget;
             currentChangedCallback(mockNotebookTracker, mockNotebookPanel);
             await flushPromises();
 
+            // Only one set of listeners should be registered, so there is still only one
+            // iopub callback and one statusChanged callback to drive.
             const iopubMessageCallback = mockSessionContext.iopubMessage.connect.mock.calls[0][0];
+            const statusChangedCallback = mockSessionContext.statusChanged.connect.mock.calls[0][0];
             const executeInputMessage = {
                 header: {
                     msg_type: 'execute_input'
@@ -172,6 +238,7 @@ describe('ContextManager', () => {
             } as KernelMessage.IMessage;
 
             iopubMessageCallback({}, executeInputMessage);
+            statusChangedCallback({}, 'idle');
 
             expect(fetchVariablesAndUpdateState).toHaveBeenCalledTimes(1);
             expect(fetchVariablesAndUpdateState).toHaveBeenCalledWith(


### PR DESCRIPTION
# Description

The `ContextManager` previously called `fetchVariablesAndUpdateState` on every `execute_input` iopub message, which issued a separate `kernel.requestExecute` per executed cell. On large notebooks, Run All produced roughly 2× the expected kernel executions (e.g. ~74 for a 37-cell notebook), inflated the Jupyter status indicator, and could leave the kernel appearing stuck while it drained queued inspection requests.

This change marks the notebook context dirty on `execute_input` and defers the variable + file refresh until the kernel `statusChanged` event fires `'idle'`, so a Run All produces a single batched context refresh instead of one per cell. The duplicate-listener `WeakSet` guard from #2299 is preserved.

Fixes https://github.com/mito-ds/mito/issues/2301

# Testing

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

Unit coverage in `ContextManagerPlugin.test.tsx` exercises the new flow: `execute_input` alone does not fetch; multiple `execute_input`s followed by one `idle` produce exactly one fetch; `idle` without dirty is a no-op; the dirty flag clears after fetching so a second idle does not re-fetch.

# Documentation

No new documentation needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing and batching of kernel-driven context refreshes, which could affect how quickly variables/files appear updated and may introduce edge cases around kernel status transitions.
> 
> **Overview**
> **Defers ContextManager refresh work to batch kernel executions.** Instead of fetching variables (and files) on every `execute_input` iopub message, the notebook is marked *dirty* and a single refresh is triggered when the kernel transitions back to `idle`.
> 
> Adds per-notebook dirty tracking (cleared on restart/terminate/unknown) and updates unit tests to cover the new deferred/one-per-idle-cycle behavior while preserving the duplicate-listener guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5811166cfe1e611386068aea401f80d7f908c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->