### PR TITLE
Improve ipywidget style

### DIFF
--- a/mito-ai/style/theme/IpywidgetsOutput.css
+++ b/mito-ai/style/theme/IpywidgetsOutput.css
@@ -12,7 +12,7 @@
 .jp-OutputArea {
   /* Tune ipywidgets' own CSS variables for this subtree only */
   --mito-widgets-control-radius: 6px;
-  --jp-widgets-label-color: var(--jp-content-font-color2);
+  --jp-widgets-label-color: var(--jp-content-font-color1);
   --jp-widgets-readout-color: var(--jp-content-font-color1);
   --jp-widgets-color: var(--jp-content-font-color1);
   --jp-widgets-input-focus-border-color: var(--jp-brand-color1);
@@ -42,7 +42,7 @@
   gap: var(--jp-widgets-inline-margin);
 }
 
-/* Labels: slightly softer than body (ipywidgets horizontal labels stay right-aligned) */
+/* Labels: primary text color so they read as real captions, not disabled chrome */
 .jp-OutputArea :is(.widget-label, .jupyter-widget-label) {
   font-weight: 500;
 }

--- a/mito-ai/style/theme/IpywidgetsOutput.css
+++ b/mito-ai/style/theme/IpywidgetsOutput.css
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+/*
+ * Mito-themed ipywidgets inside notebook outputs only (Mito Light/Dark theme bundle).
+ * Selectors align with @jupyter-widgets/controls ~5.x / ipywidgets 8.x (widgets-base.css,
+ * nouislider.css): .jupyter-widgets, .jupyter-widget-* , .noUi-*.
+ */
+
+.jp-OutputArea {
+  /* Tune ipywidgets' own CSS variables for this subtree only */
+  --mito-widgets-control-radius: 6px;
+  --jp-widgets-label-color: var(--jp-content-font-color2);
+  --jp-widgets-readout-color: var(--jp-content-font-color1);
+  --jp-widgets-color: var(--jp-content-font-color1);
+  --jp-widgets-input-focus-border-color: var(--jp-brand-color1);
+  --jp-widgets-input-color: var(--jp-content-font-color1);
+  --jp-widgets-input-background-color: var(--jp-input-background);
+  --jp-widgets-input-border-color: var(--jp-input-border-color);
+  --jp-widgets-slider-active-handle-color: var(--jp-brand-color1);
+  --jp-widgets-slider-handle-border-color: var(--jp-border-color1);
+  --jp-widgets-slider-handle-background-color: var(--jp-layout-color0);
+  --jp-widgets-margin: 4px;
+  --jp-widgets-inline-height: 30px;
+  --jp-widgets-inline-margin: 6px;
+}
+
+/* Layout rhythm */
+.jp-OutputArea .jupyter-widgets {
+  font-family: var(--jp-ui-font-family);
+}
+
+.jp-OutputArea :is(.widget-inline-hbox, .jupyter-widget-inline-hbox) {
+  align-items: center;
+  gap: var(--jp-widgets-inline-margin);
+}
+
+.jp-OutputArea
+  :is(.widget-hbox, .jupyter-widget-hbox, .widget-vbox, .jupyter-widget-vbox) {
+  gap: var(--jp-widgets-inline-margin);
+}
+
+/* Labels: slightly softer than body (ipywidgets horizontal labels stay right-aligned) */
+.jp-OutputArea :is(.widget-label, .jupyter-widget-label) {
+  font-weight: 500;
+}
+
+/* Shared field chrome */
+.jp-OutputArea
+  :is(
+    .widget-text input[type='text'],
+    .widget-text input[type='number'],
+    .widget-text input[type='password'],
+    .widget-textarea textarea,
+    .widget-datepicker input[type='date'],
+    .widget-dropdown > select,
+    .widget-select > select,
+    .jupyter-widget-text input[type='text'],
+    .jupyter-widget-text input[type='number'],
+    .jupyter-widget-text input[type='password'],
+    .jupyter-widget-textarea textarea,
+    .jupyter-widget-datepicker input[type='date'],
+    .jupyter-widget-dropdown > select,
+    .jupyter-widget-select > select
+  ) {
+  border-radius: var(--mito-widgets-control-radius);
+  box-shadow: none;
+}
+
+.jp-OutputArea
+  :is(
+    .widget-text input[type='text']:focus,
+    .widget-text input[type='number']:focus,
+    .widget-text input[type='password']:focus,
+    .widget-textarea textarea:focus,
+    .widget-datepicker input[type='date']:focus,
+    .widget-dropdown > select:focus,
+    .widget-select > select:focus,
+    .jupyter-widget-text input[type='text']:focus,
+    .jupyter-widget-text input[type='number']:focus,
+    .jupyter-widget-text input[type='password']:focus,
+    .jupyter-widget-textarea textarea:focus,
+    .jupyter-widget-datepicker input[type='date']:focus,
+    .jupyter-widget-dropdown > select:focus,
+    .jupyter-widget-select > select:focus
+  ) {
+  /* ipywidgets sets outline: none !important on these controls */
+  outline: 2px solid var(--jp-brand-color1) !important;
+  outline-offset: 1px;
+}
+
+/* Native checkboxes / radios: brand tint (supported in Chromium, Safari, Firefox) */
+.jp-OutputArea
+  :is(
+    .widget-checkbox input[type='checkbox'],
+    .jupyter-widget-checkbox input[type='checkbox'],
+    .jupyter-widget-radio-box input[type='radio']
+  ) {
+  accent-color: var(--jp-brand-color1);
+  min-width: 16px;
+  min-height: 16px;
+}
+
+/* noUi slider (IntSlider / FloatSlider): replace default teal #3FB8AF */
+.jp-OutputArea :is(.jupyter-widget-slider, .widget-slider) .noUi-connect {
+  background: var(--jp-brand-color1);
+}
+
+.jp-OutputArea :is(.jupyter-widget-slider, .widget-slider) .noUi-target {
+  background: var(--jp-layout-color2);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  border-radius: 999px;
+  box-shadow: none;
+}
+
+.jp-OutputArea :is(.jupyter-widget-slider, .widget-slider) .noUi-handle {
+  border: var(--jp-border-width) solid var(--jp-brand-color2);
+  border-radius: 50%;
+  background: var(--jp-layout-color0);
+  box-shadow: var(--jp-elevation-z1);
+}
+
+.jp-OutputArea :is(.jupyter-widget-slider, .widget-slider) .noUi-handle::before,
+.jp-OutputArea :is(.jupyter-widget-slider, .widget-slider) .noUi-handle::after {
+  display: none;
+}

--- a/mito-ai/style/theme/theme.css
+++ b/mito-ai/style/theme/theme.css
@@ -12,7 +12,7 @@
 @import './componentStyling.css';
 @import './icons.css';
 @import './CellNumbering.css';
-
+@import url('./IpywidgetsOutput.css');
 
 /* Set the default typography for monospace elements */
 .jp-ThemedContainer tt,
@@ -102,5 +102,3 @@
 .jp-Editor .cm-gutters {
   background: transparent !important;
 }
-
-


### PR DESCRIPTION
# Description

Improve formatting of the ipywidgets to match Mito theme 

<img width="1151" height="181" alt="Screenshot 2026-05-12 at 3 07 04 PM" src="https://github.com/user-attachments/assets/d6d81b15-32d5-4356-97d2-572e59814696" />
<img width="1154" height="196" alt="Screenshot 2026-05-12 at 3 07 13 PM" src="https://github.com/user-attachments/assets/066fa3fc-bc18-4357-b1fb-022ff525444d" />


# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only changes scoped to `.jp-OutputArea`, but may alter notebook output widget appearance across themes/browsers.
> 
> **Overview**
> Adds a new `IpywidgetsOutput.css` stylesheet that rethemes ipywidgets *only within* `.jp-OutputArea` by overriding widget CSS variables and normalizing spacing, fonts, label weight, focus outlines, checkbox/radio accent colors, and noUiSlider colors/handles.
> 
> Updates `theme.css` to import this new stylesheet so the widget output styling ships with the Mito theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f454d4f1c1fbf5e1565dc2736de91a2d42490d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->