### PR TITLE
Filter warnings in document mode

### DIFF
--- a/mito-ai/style/DocumentMode.css
+++ b/mito-ai/style/DocumentMode.css
@@ -77,3 +77,18 @@
 .jp-Notebook.jp-mod-mito-document-mode .jp-OutputArea-promptOverlay {
   display: none !important;
 }
+
+/*
+ * Document mode: hide warning / stderr streams so the page reads like a clean
+ * report. Python warnings use stderr; Mito wraps many in .mito-warning-block.
+ * Keep outputs that include the augmented error UI (.error-mime-renderer-container)
+ * so tracebacks and "Fix Error in AI Chat" still show.
+ */
+.jp-Notebook.jp-mod-mito-document-mode
+  .lm-Widget.jp-OutputArea-output:has(.mito-warning-block),
+.jp-Notebook.jp-mod-mito-document-mode
+  .lm-Widget.jp-OutputArea-output:has(
+    [data-mime-type='application/vnd.jupyter.stderr']
+  ):not(:has(.error-mime-renderer-container)) {
+  display: none !important;
+}


### PR DESCRIPTION
# Description

Filter warnings in document mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change, though it relies on the `:has()` selector which could behave differently across browser/embedded environments and may hide some stderr content unexpectedly.
> 
> **Overview**
> Document mode now filters noisy outputs by **hiding warning blocks and `stderr` stream outputs** (including `.mito-warning-block` and Jupyter `application/vnd.jupyter.stderr`).
> 
> Outputs that contain the augmented error UI (`.error-mime-renderer-container`) are explicitly *not* hidden so tracebacks and the “Fix Error in AI Chat” experience remain visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ff1987615bf8b07bd2be2234fd711a03f67066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->