### PR TITLE
Table of contents for document mode

### DIFF
--- a/mito-ai/package.json
+++ b/mito-ai/package.json
@@ -74,6 +74,7 @@
     "@jupyterlab/services": "^7.1.0",
     "@jupyterlab/settingregistry": "^4.1.0",
     "@jupyterlab/statusbar": "^4.1.0",
+    "@jupyterlab/toc": "^6.1.0",
     "@jupyterlab/ui-components": "^4.1.0",
     "@lumino/commands": "^2.0.0",
     "@lumino/coreutils": "^2.0.0",

--- a/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContents.tsx
+++ b/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContents.tsx
@@ -5,22 +5,55 @@
 
 import React, { useEffect, useState } from 'react';
 import { TableOfContents } from '@jupyterlab/toc';
+import { INotebookHeading } from '@jupyterlab/notebook';
+import { NotebookPanel } from '@jupyterlab/notebook';
 import { INotebookViewMode, NotebookViewMode } from '../NotebookViewMode/NotebookViewModePlugin';
 
 interface IDocumentTableOfContentsProps {
   model: TableOfContents.Model;
   viewMode: INotebookViewMode;
+  panel: NotebookPanel;
 }
+
+// The active heading is the last heading whose cell top has scrolled
+// past this offset from the top of the notebook scroll container.
+const ACTIVE_HEADING_OFFSET_PX = 100;
+
+const computeActiveHeadingFromScroll = (
+  headings: TableOfContents.IHeading[],
+  scrollContainer: HTMLElement
+): TableOfContents.IHeading | null => {
+  if (headings.length === 0) {
+    return null;
+  }
+  const threshold =
+    scrollContainer.getBoundingClientRect().top + ACTIVE_HEADING_OFFSET_PX;
+
+  let active: TableOfContents.IHeading | null = null;
+  for (const heading of headings) {
+    const cell = (heading as INotebookHeading).cellRef;
+    const cellNode = cell?.node;
+    if (!cellNode || !document.body.contains(cellNode)) {
+      continue;
+    }
+    const rect = cellNode.getBoundingClientRect();
+    if (rect.top <= threshold) {
+      active = heading;
+    }
+  }
+  return active ?? headings[0] ?? null;
+};
 
 const DocumentTableOfContents: React.FC<IDocumentTableOfContentsProps> = ({
   model,
-  viewMode
+  viewMode,
+  panel
 }) => {
   const [headings, setHeadings] = useState<TableOfContents.IHeading[]>(
     model.headings
   );
   const [activeHeading, setActiveHeading] =
-    useState<TableOfContents.IHeading | null>(model.activeHeading);
+    useState<TableOfContents.IHeading | null>(null);
   const [mode, setMode] = useState<NotebookViewMode>(viewMode.getMode());
   const [isHovered, setIsHovered] = useState(false);
 
@@ -28,26 +61,51 @@ const DocumentTableOfContents: React.FC<IDocumentTableOfContentsProps> = ({
     const onHeadingsChanged = (): void => {
       setHeadings([...model.headings]);
     };
-    const onActiveHeadingChanged = (
-      _: TableOfContents.Model,
-      h: TableOfContents.IHeading | null
-    ): void => {
-      setActiveHeading(h);
-    };
     const onModeChanged = (_: INotebookViewMode, m: NotebookViewMode): void => {
       setMode(m);
     };
 
     model.headingsChanged.connect(onHeadingsChanged);
-    model.activeHeadingChanged.connect(onActiveHeadingChanged);
     viewMode.modeChanged.connect(onModeChanged);
 
     return () => {
       model.headingsChanged.disconnect(onHeadingsChanged);
-      model.activeHeadingChanged.disconnect(onActiveHeadingChanged);
       viewMode.modeChanged.disconnect(onModeChanged);
     };
   }, [model, viewMode]);
+
+  useEffect(() => {
+    const scrollContainer = panel.content.outerNode;
+    let rafId: number | null = null;
+
+    const recompute = (): void => {
+      rafId = null;
+      setActiveHeading(
+        computeActiveHeadingFromScroll(model.headings, scrollContainer)
+      );
+    };
+
+    const onScroll = (): void => {
+      if (rafId !== null) {
+        return;
+      }
+      rafId = requestAnimationFrame(recompute);
+    };
+
+    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+    scrollContainer.addEventListener('scrollend', onScroll, { passive: true });
+    model.headingsChanged.connect(recompute);
+    recompute();
+
+    return () => {
+      scrollContainer.removeEventListener('scroll', onScroll);
+      scrollContainer.removeEventListener('scrollend', onScroll);
+      model.headingsChanged.disconnect(recompute);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, [panel, model]);
 
   if (mode !== 'Document' || headings.length === 0) {
     return null;
@@ -58,13 +116,7 @@ const DocumentTableOfContents: React.FC<IDocumentTableOfContentsProps> = ({
   };
 
   const isActive = (heading: TableOfContents.IHeading): boolean => {
-    if (!activeHeading) {
-      return false;
-    }
-    return (
-      activeHeading.text === heading.text &&
-      activeHeading.level === heading.level
-    );
+    return activeHeading === heading;
   };
 
   return (

--- a/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContents.tsx
+++ b/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContents.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { TableOfContents } from '@jupyterlab/toc';
+import { INotebookViewMode, NotebookViewMode } from '../NotebookViewMode/NotebookViewModePlugin';
+
+interface IDocumentTableOfContentsProps {
+  model: TableOfContents.Model;
+  viewMode: INotebookViewMode;
+}
+
+const DocumentTableOfContents: React.FC<IDocumentTableOfContentsProps> = ({
+  model,
+  viewMode
+}) => {
+  const [headings, setHeadings] = useState<TableOfContents.IHeading[]>(
+    model.headings
+  );
+  const [activeHeading, setActiveHeading] =
+    useState<TableOfContents.IHeading | null>(model.activeHeading);
+  const [mode, setMode] = useState<NotebookViewMode>(viewMode.getMode());
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    const onHeadingsChanged = (): void => {
+      setHeadings([...model.headings]);
+    };
+    const onActiveHeadingChanged = (
+      _: TableOfContents.Model,
+      h: TableOfContents.IHeading | null
+    ): void => {
+      setActiveHeading(h);
+    };
+    const onModeChanged = (_: INotebookViewMode, m: NotebookViewMode): void => {
+      setMode(m);
+    };
+
+    model.headingsChanged.connect(onHeadingsChanged);
+    model.activeHeadingChanged.connect(onActiveHeadingChanged);
+    viewMode.modeChanged.connect(onModeChanged);
+
+    return () => {
+      model.headingsChanged.disconnect(onHeadingsChanged);
+      model.activeHeadingChanged.disconnect(onActiveHeadingChanged);
+      viewMode.modeChanged.disconnect(onModeChanged);
+    };
+  }, [model, viewMode]);
+
+  if (mode !== 'Document' || headings.length === 0) {
+    return null;
+  }
+
+  const onItemClick = (heading: TableOfContents.IHeading): void => {
+    model.setActiveHeading(heading);
+  };
+
+  const isActive = (heading: TableOfContents.IHeading): boolean => {
+    if (!activeHeading) {
+      return false;
+    }
+    return (
+      activeHeading.text === heading.text &&
+      activeHeading.level === heading.level
+    );
+  };
+
+  return (
+    <div
+      className={`mito-toc-container${isHovered ? ' mito-toc-hovered' : ''}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="mito-toc-indicator" aria-hidden="true">
+        {headings.map((heading, idx) => (
+          <div
+            key={`line-${idx}`}
+            className={`mito-toc-line mito-toc-line-h${heading.level}${
+              isActive(heading) ? ' mito-toc-line-active' : ''
+            }`}
+            data-level={heading.level}
+          />
+        ))}
+      </div>
+      <div className="mito-toc-panel" role="navigation" aria-label="Table of contents">
+        {headings.map((heading, idx) => (
+          <button
+            key={`item-${idx}`}
+            type="button"
+            className={`mito-toc-item${
+              isActive(heading) ? ' mito-toc-item-active' : ''
+            }`}
+            data-level={heading.level}
+            onClick={() => onItemClick(heading)}
+            title={heading.text}
+          >
+            {heading.text}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DocumentTableOfContents;

--- a/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
+++ b/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
@@ -45,7 +45,11 @@ const mountForPanel = (
 
     const root: Root = createRoot(host);
     root.render(
-      <DocumentTableOfContents model={model} viewMode={viewMode} />
+      <DocumentTableOfContents
+        model={model}
+        viewMode={viewMode}
+        panel={panel}
+      />
     );
 
     panel.disposed.connect(() => {

--- a/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
+++ b/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
@@ -26,7 +26,9 @@ const mountForPanel = (
       return;
     }
 
-    const model = tocRegistry.getModel(panel) as TableOfContents.Model | undefined;
+    const model = tocRegistry.getModel(
+      panel as unknown as Parameters<ITableOfContentsRegistry['getModel']>[0]
+    ) as TableOfContents.Model | undefined;
     if (!model) {
       return;
     }
@@ -63,7 +65,11 @@ const DocumentTableOfContentsPlugin: JupyterFrontEndPlugin<void> = {
   id: 'mito-ai:document-table-of-contents',
   description: 'Notion-style table of contents overlay for document mode',
   autoStart: true,
-  requires: [INotebookTracker, ITableOfContentsRegistry, INotebookViewMode],
+  requires: [
+    INotebookTracker,
+    ITableOfContentsRegistry,
+    INotebookViewMode
+  ] as JupyterFrontEndPlugin<void>['requires'],
   activate: (
     _app: JupyterFrontEnd,
     notebookTracker: INotebookTracker,

--- a/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
+++ b/mito-ai/src/Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+import { ITableOfContentsRegistry, TableOfContents } from '@jupyterlab/toc';
+import { INotebookViewMode } from '../NotebookViewMode/NotebookViewModePlugin';
+import DocumentTableOfContents from './DocumentTableOfContents';
+
+import '../../../style/DocumentTableOfContents.css';
+
+const HOST_CLASS = 'mito-toc-host';
+
+const mountForPanel = (
+  panel: NotebookPanel,
+  tocRegistry: ITableOfContentsRegistry,
+  viewMode: INotebookViewMode
+): void => {
+  // Wait for the panel to be ready so the TOC model can be created.
+  void panel.context.ready.then(() => {
+    if (panel.isDisposed) {
+      return;
+    }
+
+    const model = tocRegistry.getModel(panel) as TableOfContents.Model | undefined;
+    if (!model) {
+      return;
+    }
+
+    // Keep the model active even when the JupyterLab TOC panel is hidden,
+    // so headings stay populated and active-heading tracking continues.
+    model.isActive = true;
+
+    if (panel.node.querySelector(`.${HOST_CLASS}`)) {
+      return;
+    }
+
+    const host = document.createElement('div');
+    host.className = HOST_CLASS;
+    panel.node.appendChild(host);
+
+    const root: Root = createRoot(host);
+    root.render(
+      <DocumentTableOfContents model={model} viewMode={viewMode} />
+    );
+
+    panel.disposed.connect(() => {
+      root.unmount();
+      host.remove();
+    });
+  });
+};
+
+const DocumentTableOfContentsPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'mito-ai:document-table-of-contents',
+  description: 'Notion-style table of contents overlay for document mode',
+  autoStart: true,
+  requires: [INotebookTracker, ITableOfContentsRegistry, INotebookViewMode],
+  activate: (
+    _app: JupyterFrontEnd,
+    notebookTracker: INotebookTracker,
+    tocRegistry: ITableOfContentsRegistry,
+    viewMode: INotebookViewMode
+  ): void => {
+    notebookTracker.forEach(panel => {
+      mountForPanel(panel, tocRegistry, viewMode);
+    });
+    notebookTracker.widgetAdded.connect((_, panel) => {
+      mountForPanel(panel, tocRegistry, viewMode);
+    });
+  }
+};
+
+export default DocumentTableOfContentsPlugin;

--- a/mito-ai/src/index.ts
+++ b/mito-ai/src/index.ts
@@ -19,6 +19,7 @@ import mitoThemesPlugin from './Extensions/MitoThemes';
 import ManageAppsPlugin from "./Extensions/AppManager/ManageAppsPlugin"
 import ChartWizardPlugin from './Extensions/ChartWizard/ChartWizardPlugin';
 import NotebookViewModePlugin from './Extensions/NotebookViewMode/NotebookViewModePlugin';
+import DocumentTableOfContentsPlugin from './Extensions/DocumentTableOfContents/DocumentTableOfContentsPlugin';
 import CommentsPlugin from './Extensions/Comments/CommentsPlugin';
 
 // This is the main entry point to the mito-ai extension. It must export all of the top level
@@ -40,5 +41,6 @@ export default [
   mitoThemesPlugin,
   ChartWizardPlugin,
   NotebookViewModePlugin,
+  DocumentTableOfContentsPlugin,
   CommentsPlugin
 ];

--- a/mito-ai/style/DocumentTableOfContents.css
+++ b/mito-ai/style/DocumentTableOfContents.css
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ *
+ * Notion-style table of contents overlay shown in document mode.
+ * The host is mounted on every NotebookPanel but the inner container
+ * only renders content when the notebook is in document mode.
+ */
+
+.mito-toc-host {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.mito-toc-container {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.mito-toc-indicator {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 6px;
+  align-items: flex-end;
+  cursor: pointer;
+  transition: opacity 120ms ease-in-out;
+}
+
+.mito-toc-container.mito-toc-hovered .mito-toc-indicator {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mito-toc-line {
+  height: 2px;
+  border-radius: 2px;
+  background-color: var(--jp-border-color2);
+  transition: background-color 120ms ease-in-out;
+}
+
+.mito-toc-line-h1 {
+  width: 28px;
+  background-color: var(--jp-ui-font-color2);
+}
+
+.mito-toc-line-h2 {
+  width: 22px;
+}
+
+.mito-toc-line-h3 {
+  width: 18px;
+}
+
+.mito-toc-line-h4 {
+  width: 14px;
+}
+
+.mito-toc-line-h5 {
+  width: 12px;
+}
+
+.mito-toc-line-h6 {
+  width: 10px;
+}
+
+.mito-toc-line-active {
+  background-color: var(--jp-ui-font-color1);
+  height: 3px;
+}
+
+.mito-toc-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  min-width: 220px;
+  max-width: 320px;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 12px 8px;
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 12%);
+  display: none;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mito-toc-container.mito-toc-hovered .mito-toc-panel {
+  display: flex;
+}
+
+.mito-toc-item {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font: inherit;
+  color: var(--jp-ui-font-color1);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mito-toc-item[data-level='1'] {
+  padding-left: 8px;
+}
+
+.mito-toc-item[data-level='2'] {
+  padding-left: 24px;
+}
+
+.mito-toc-item[data-level='3'] {
+  padding-left: 40px;
+}
+
+.mito-toc-item[data-level='4'] {
+  padding-left: 56px;
+}
+
+.mito-toc-item[data-level='5'] {
+  padding-left: 72px;
+}
+
+.mito-toc-item[data-level='6'] {
+  padding-left: 88px;
+}
+
+.mito-toc-item:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.mito-toc-item-active {
+  color: var(--jp-brand-color1);
+  font-weight: 600;
+}

--- a/mito-ai/yarn.lock
+++ b/mito-ai/yarn.lock
@@ -3307,6 +3307,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/apputils@npm:^4.6.7":
+  version: 4.6.7
+  resolution: "@jupyterlab/apputils@npm:4.6.7"
+  dependencies:
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/services": ^7.5.7
+    "@jupyterlab/settingregistry": ^4.5.7
+    "@jupyterlab/statedb": ^4.5.7
+    "@jupyterlab/statusbar": ^4.5.7
+    "@jupyterlab/translation": ^4.5.7
+    "@jupyterlab/ui-components": ^4.5.7
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/domutils": ^2.0.4
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/virtualdom": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    "@types/react": ^18.0.26
+    react: ^18.2.0
+    sanitize-html: ~2.12.1
+  checksum: decd766d608f10ef64556f9320acf7d31b851e964e21b6b190c5d78dcd3e8a8ca52414a341f9d4512848e5dceaf17617cae80097b992246ad9d87efbe3360f2c
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/attachments@npm:^4.4.2":
   version: 4.4.2
   resolution: "@jupyterlab/attachments@npm:4.4.2"
@@ -3443,6 +3472,30 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
   checksum: b74ba6c6b24924f2fd63d35e25ebbc7ddbfa32e8ae77763b01b3dea647d141ff796b8639b9e1b1221c8dd0646ea9837e0d32f3936e41918213173fb613f887aa
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/codeeditor@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/codeeditor@npm:4.5.7"
+  dependencies:
+    "@codemirror/state": ^6.5.4
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/apputils": ^4.6.7
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/nbformat": ^4.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/statusbar": ^4.5.7
+    "@jupyterlab/translation": ^4.5.7
+    "@jupyterlab/ui-components": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/dragdrop": ^2.1.8
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 4f15f95e08caa9296203eb7971f17c0b515907ab66411b3882f05c4da8fa9ff03a156a34bf49ebf9e5775dcec3ebd08b75331bffc08ffd4a983eb05f0060b4c4
   languageName: node
   linkType: hard
 
@@ -3586,6 +3639,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/coreutils@npm:^6.5.7":
+  version: 6.5.7
+  resolution: "@jupyterlab/coreutils@npm:6.5.7"
+  dependencies:
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    minimist: ~1.2.0
+    path-browserify: ^1.0.0
+    url-parse: ~1.5.4
+  checksum: cf77491e064dfc8d4b0e3eb8bac80d755adf23de5f43e5a839294ba730be521ef81bfe884f995b366914750d99ed0d59bbed063980ae4f44886167045d7fcbe2
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/docmanager@npm:^4.1.0":
   version: 4.5.5
   resolution: "@jupyterlab/docmanager@npm:4.5.5"
@@ -3686,6 +3753,32 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
   checksum: fc07e1dbaabdea83638e1d737b1f33d77c016b07cb1bb6c7358d5eb83e0ec9cae7ab44057d9ec391ebfc5590e37807f4ff94e62524cf06f23b798578ac4c0194
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/docregistry@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/docregistry@npm:4.5.7"
+  dependencies:
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/apputils": ^4.6.7
+    "@jupyterlab/codeeditor": ^4.5.7
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/rendermime": ^4.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/services": ^7.5.7
+    "@jupyterlab/translation": ^4.5.7
+    "@jupyterlab/ui-components": ^4.5.7
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: e72eb4c02383ac5be8486db5c7a5c90eda2b70c66d4b014b132d5d9e19f3a472389b0083b98570424534cf1163cadc2e1b11d86f513a470ef61f284162301a0f
   languageName: node
   linkType: hard
 
@@ -3846,6 +3939,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/nbformat@npm:4.5.7"
+  dependencies:
+    "@lumino/coreutils": ^2.2.2
+  checksum: 7b75969953654c490b19b7ca5b2218169f39012e1136f9ee943defe8e8b11202cb00fc65e5e3ba3fceee8781b8fec4bda978f8f39d31ced75cf9d954b2060048
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/notebook@npm:^4.1.0, @jupyterlab/notebook@npm:^4.4.2":
   version: 4.4.2
   resolution: "@jupyterlab/notebook@npm:4.4.2"
@@ -3910,6 +4012,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/observables@npm:^5.5.7":
+  version: 5.5.7
+  resolution: "@jupyterlab/observables@npm:5.5.7"
+  dependencies:
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+  checksum: 2693f75edc23c7f9e1cd30c21611af9c3678c079b1cfa0c2da9b9286c4631c8559f02cc8fc02036ab8d66dd39df33b9347a8f2761c3f34b74d1db03f57a5aaa7
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/outputarea@npm:^4.4.2":
   version: 4.4.2
   resolution: "@jupyterlab/outputarea@npm:4.4.2"
@@ -3949,6 +4064,16 @@ __metadata:
     "@lumino/coreutils": ^1.11.0 || ^2.2.2
     "@lumino/widgets": ^1.37.2 || ^2.7.5
   checksum: b128c5babd0728383f8e35af16aa76cd63e8a4e922f74643298baf647419885f1c7cacf1f7bcd6f6094ba5e7d7d0b20900d1a127c297c1c8df7d6a78f9ee6463
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/rendermime-interfaces@npm:^3.13.7":
+  version: 3.13.7
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.13.7"
+  dependencies:
+    "@lumino/coreutils": ^1.11.0 || ^2.2.2
+    "@lumino/widgets": ^1.37.2 || ^2.7.5
+  checksum: 0dd31f82b3a8f2eac62fe7a0a5fd406793b518c4e040b17e695bf311c328a9692cfb00e0b630c0af6b3642c9039ee15ccfe3858065cdf59143cb69f2b715bd6e
   languageName: node
   linkType: hard
 
@@ -3992,6 +4117,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/rendermime@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/rendermime@npm:4.5.7"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.7
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/nbformat": ^4.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/services": ^7.5.7
+    "@jupyterlab/translation": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    lodash.escape: ^4.0.1
+  checksum: a37a75a623a1825a3189488f347a2d3ed83127c1d79b7119ce957e4bc93edbdb4a0f2ed7b05c1e2a831a7dc5ab26414ad0b704556efa4349e1c670f176e181e7
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/services@npm:^7.1.0, @jupyterlab/services@npm:^7.4.2":
   version: 7.4.2
   resolution: "@jupyterlab/services@npm:7.4.2"
@@ -4027,6 +4172,25 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     ws: ^8.11.0
   checksum: 54b0483c72835367085dc03f2066f8a4458f234d94b8ff16921f05821d06a742148d8977c38e0c73224dbecf6eb42b8519853884afd2a7003a515a4c1ba7fc1a
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/services@npm:^7.5.7":
+  version: 7.5.7
+  resolution: "@jupyterlab/services@npm:7.5.7"
+  dependencies:
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/nbformat": ^4.5.7
+    "@jupyterlab/settingregistry": ^4.5.7
+    "@jupyterlab/statedb": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/polling": ^2.1.5
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    ws: ^8.11.0
+  checksum: a1d7ea7d90856d0edd3c207885cad04b55fee3c6261e9bd16a1499e0ce574e3753c88a34be9e13ee5f6f826995d14e264615874f2cdb8ddd5e2ec3f8fe66a4a5
   languageName: node
   linkType: hard
 
@@ -4068,6 +4232,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/settingregistry@npm:4.5.7"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.5.7
+    "@jupyterlab/statedb": ^4.5.7
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: 4114ea3a0f95645bf1dd189a6d807d3c1185fee9f3ef7458cb297840d9cdd969157ff3139e087e6055eacfa962088c218c47f07b8c4e6e49d595941c39fa19e5
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.4.2":
   version: 4.4.2
   resolution: "@jupyterlab/statedb@npm:4.4.2"
@@ -4091,6 +4274,19 @@ __metadata:
     "@lumino/properties": ^2.0.4
     "@lumino/signaling": ^2.1.5
   checksum: a3bd24f190420aa631af6311ff2cb91bcd23aeebd041f3a211c30d39be4593af48795f2d9c9efd25f004310547ba001f3b1509a1b0992fba43208082ac322efe
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/statedb@npm:4.5.7"
+  dependencies:
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+  checksum: 0560e22f83c526b237551cd520deecc608ce16b04eca6a7cf87e5c41738e9513b3ff9eb0c1a678062c1d3824e0c6fef50608ea5e53bd5970421acc322384c751
   languageName: node
   linkType: hard
 
@@ -4123,6 +4319,22 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
   checksum: dfe4da0b2c373e8e2c3458c720b1940e574cf2e26869319cb6018b8eddebfa4bf21b7022ba65fe1cd33049c9c139045052bbadf61a1ae749fec7490d115cec9f
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statusbar@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/statusbar@npm:4.5.7"
+  dependencies:
+    "@jupyterlab/ui-components": ^4.5.7
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 3a3bffb3c1f6b7ab6bf5b70f287ac8439b083a71caeed35439dffa28d54b998cb75c6e19ce9fd06de40bee469c79627f114fb6e30be54af8660a546a562936ba
   languageName: node
   linkType: hard
 
@@ -4159,6 +4371,29 @@ __metadata:
     "@jupyterlab/rendermime": ^4.4.2
     "@jupyterlab/testing": ^4.4.2
   checksum: 92ecec520cbfcf073c15b108d3df623fe3fc928ab79b47d971e45817cf69bab043cf4fdc7173c636de2716eab82afe1f7a7e45d6e77c7e2ff53306e8448aa7dd
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/toc@npm:^6.1.0":
+  version: 6.5.7
+  resolution: "@jupyterlab/toc@npm:6.5.7"
+  dependencies:
+    "@jupyter/react-components": ^0.16.6
+    "@jupyterlab/apputils": ^4.6.7
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/docregistry": ^4.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/rendermime": ^4.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/translation": ^4.5.7
+    "@jupyterlab/ui-components": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: df7332cff3f7978175496a2a03ec58af0aa88ce8a56221d7fdb4d06d452a50e52a80bbbd11d1e011ca73d3fe0f706255680d905f8acf16be7ac8581e95d10fcf
   languageName: node
   linkType: hard
 
@@ -4234,6 +4469,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/translation@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/translation@npm:4.5.7"
+  dependencies:
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/services": ^7.5.7
+    "@jupyterlab/statedb": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+  checksum: 8eeb51d36de3012c7d6a3beb2676e544520b8dbfa9fb8efb09572fad5a61d0c92bf59f0d710d03e4fb101fc236a8e797ebcbd8c212484a938c830fd425054872
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/ui-components@npm:^4.1.0, @jupyterlab/ui-components@npm:^4.4.2":
   version: 4.4.2
   resolution: "@jupyterlab/ui-components@npm:4.4.2"
@@ -4293,6 +4541,37 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 51dd8aecaf5ced1e82418daf13e9c1f8196146bad95f4e7b59bc9810544fbecffc31354a70d15a2344eaa686a981db35f6c5e5ba341084700c57fa86b7c8ae8b
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/ui-components@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@jupyterlab/ui-components@npm:4.5.7"
+  dependencies:
+    "@jupyter/react-components": ^0.16.6
+    "@jupyter/web-components": ^0.16.6
+    "@jupyterlab/coreutils": ^6.5.7
+    "@jupyterlab/observables": ^5.5.7
+    "@jupyterlab/rendermime-interfaces": ^3.13.7
+    "@jupyterlab/translation": ^4.5.7
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/virtualdom": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    "@rjsf/core": ^5.13.4
+    "@rjsf/utils": ^5.13.4
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    typestyle: ^2.0.4
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 675ae0f415de19abd1376a4be696dc20024d17dfad9c09ed7d903cb26a6ea55c688f188a9d034c0f566c053e9c70321180c01304153a498eb8b665af38531fbd
   languageName: node
   linkType: hard
 
@@ -11392,6 +11671,7 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.1.0
     "@jupyterlab/statusbar": ^4.1.0
     "@jupyterlab/testutils": ^4.1.0
+    "@jupyterlab/toc": ^6.1.0
     "@jupyterlab/ui-components": ^4.1.0
     "@lumino/commands": ^2.0.0
     "@lumino/coreutils": ^2.0.0


### PR DESCRIPTION
A sticky overlay shown in the top-left of the notebook content area while in Document mode. At rest it shows as a stack of thin bars sized by heading level; on hover it expands into a card listing all headings. Clicking a heading scrolls the notebook to that cell. The currently visible section is highlighted automatically.

Reuses JupyterLab's ITableOfContentsRegistry for heading parsing and active-heading tracking, so all the model work is delegated to the existing toc extension.

Resolves https://github.com/mito-ds/mito/issues/2319

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new always-mounted notebook overlay with scroll listeners and TOC model activation; risk is mainly UI regressions/performance impact in notebooks and potential compatibility issues with JupyterLab versions/dependencies.
> 
> **Overview**
> Adds a **document-mode table of contents overlay** to notebooks, rendering a compact indicator that expands on hover and lets users click headings to scroll to sections while auto-highlighting the currently visible heading.
> 
> Introduces a new JupyterLab plugin that mounts the overlay for each `NotebookPanel`, wires it to `@jupyterlab/toc` models (kept active even when the built-in TOC panel is hidden), and styles the overlay via new `DocumentTableOfContents.css`. Also registers the plugin in `src/index.ts` and adds the `@jupyterlab/toc` dependency (with corresponding `yarn.lock` updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d694bf2e930cac778b08cc56c7358baae9343293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->