### PR TITLE
[WIP] MCP Server Tool Breakout

### DIFF
--- a/mito-ai-mcp/manifest.json
+++ b/mito-ai-mcp/manifest.json
@@ -27,8 +27,16 @@
   },
   "tools": [
     {
-      "name": "run_data_analyst",
-      "description": "Run one-shot Mito AI analysis for Excel/CSV workflows, EDA, and Jupyter notebook edits."
+      "name": "convert_excel_to_python",
+      "description": "Convert an Excel spreadsheet (.xlsx, .xls) to equivalent Python and pandas code in a Jupyter notebook. Use when the user wants to migrate, automate, or reproduce Excel formulas, sheets, or workbook logic in Python."
+    },
+    {
+      "name": "create_data_visualization",
+      "description": "Create a data visualization from tabular data."
+    },
+    {
+      "name": "run_data_analysis",
+      "description": "Use for data analysis requests in notebook or spreadsheet workflows. Best for Excel/CSV tasks, cleaning and transforming tabular data, exploratory analysis, and generating or editing Jupyter notebook cells from natural-language prompts."
     }
   ],
   "compatibility": {

--- a/mito-ai-mcp/mito_ai_mcp/data_analyst.py
+++ b/mito-ai-mcp/mito_ai_mcp/data_analyst.py
@@ -1,0 +1,199 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+"""One-shot Mito AI data analysis flow for MCP tool handlers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import uuid
+from typing import Any
+
+from mcp.server.fastmcp import Context
+
+from mito_ai_core.agent import ToolResult
+from mito_ai_core.completions.models import AgentResponse
+from mito_ai_mcp.request_agent_execution import (
+    RequestAgentExecutionInput,
+    RequestAgentExecutionManager,
+)
+from mito_ai_mcp.utils.client_capabilities import detect_ask_user_mode
+from mito_ai_mcp.utils.elicitation import build_elicitation_handler
+from mito_ai_mcp.utils.progress import (
+    format_assistant_progress_message,
+    format_tool_progress_message,
+    report_progress,
+)
+from mito_ai_mcp.utils.roots import McpRoot, list_client_roots
+
+logger = logging.getLogger(__name__)
+
+request_agent_execution_manager = RequestAgentExecutionManager()
+
+
+async def run_data_analyst(prompt: str, mcp_context: Context) -> dict[str, Any]:
+    """Run a one-shot Mito AI analysis and return text plus artifact metadata."""
+    progress_step = 0
+    logger.info("Detecting ask-user mode for run_data_analyst request")
+    ask_user_mode = detect_ask_user_mode(mcp_context)
+    logger.info("Resolved ask-user mode: %s", ask_user_mode)
+    roots = await list_client_roots(mcp_context)
+    _log_discovered_roots(roots)
+    prompt_files = _resolve_prompt_files_from_roots(roots)
+    logger.info("Resolved %s files from MCP roots for prompt context", len(prompt_files))
+    notebook_path = _resolve_notebook_output_path(roots)
+    logger.info("Resolved notebook output path: %s", notebook_path)
+    kernel_cwd = _resolve_kernel_cwd_from_roots(roots)
+    logger.info("Resolved kernel cwd from roots: %s", kernel_cwd)
+
+    async def publish_progress(message: str) -> None:
+        nonlocal progress_step
+        progress_step += 1
+        await report_progress(mcp_context, progress=progress_step, message=message)
+
+    await publish_progress("Starting analysis run")
+
+    async def on_assistant_response(response: AgentResponse) -> None:
+        await publish_progress(format_assistant_progress_message(response))
+
+    async def on_tool_result(tool_result: ToolResult) -> None:
+        await publish_progress(format_tool_progress_message(tool_result))
+
+    logger.info("Starting AgentRunner prompt execution")
+    result = await request_agent_execution_manager.run_prompt(
+        prompt,
+        metadata=RequestAgentExecutionInput(
+            notebook_path=notebook_path,
+            kernel_cwd=kernel_cwd,
+            files=prompt_files or None,
+            ask_user_mode=ask_user_mode,
+            ask_user_handler=build_elicitation_handler(mcp_context),
+        ),
+        on_assistant_response=on_assistant_response,
+        on_tool_result=on_tool_result,
+    )
+    logger.info(
+        "AgentRunner prompt execution completed (finished=%s, iterations=%s)",
+        result.finished,
+        result.iterations,
+    )
+    await publish_progress("Analysis run completed")
+    final_text = _append_notebook_path_to_final_text(result.final_text, result.notebook_path)
+    return {
+        "final_text": final_text,
+        "metadata": {
+            "notebook_path": result.notebook_path,
+            "artifact_paths": result.artifact_paths,
+        },
+    }
+
+
+def _resolve_notebook_output_path(roots: list[McpRoot]) -> str:
+    notebook_name = f"mito-{uuid.uuid4().hex}.ipynb"
+    for root in roots:
+        if root.path is None:
+            continue
+        if _is_writable_directory(root.path):
+            return os.path.join(root.path, notebook_name)
+
+    logger.info("No writable MCP roots detected; defaulting notebook path to current directory")
+    candidate = os.path.abspath(notebook_name)
+    parent = os.path.dirname(candidate)
+    if parent and os.path.isdir(parent) and os.access(parent, os.W_OK):
+        return candidate
+    fallback = os.path.join(tempfile.gettempdir(), notebook_name)
+    logger.info("Notebook output directory not writable; using temp path: %s", fallback)
+    return fallback
+
+
+def _resolve_kernel_cwd_from_roots(roots: list[McpRoot]) -> str | None:
+    for root in roots:
+        if root.path is None:
+            continue
+        absolute_path = os.path.abspath(root.path)
+        if _is_writable_directory(absolute_path):
+            return absolute_path
+    return None
+
+
+def _is_writable_directory(path: str) -> bool:
+    return os.path.isdir(path) and os.access(path, os.W_OK | os.X_OK)
+
+
+def _log_discovered_roots(roots: list[McpRoot]) -> None:
+    if not roots:
+        logger.info("MCP roots/list returned no roots")
+        return
+
+    logger.info("MCP roots/list returned %s root(s)", len(roots))
+    for index, root in enumerate(roots):
+        if not root.path:
+            logger.info("MCP root[%s]: uri=%s path=<none>", index, root.uri)
+            continue
+
+        absolute_path = os.path.abspath(root.path)
+        logger.info(
+            "MCP root[%s]: uri=%s path=%s is_dir=%s readable=%s writable=%s",
+            index,
+            root.uri,
+            absolute_path,
+            os.path.isdir(absolute_path),
+            os.access(absolute_path, os.R_OK | os.X_OK),
+            os.access(absolute_path, os.W_OK | os.X_OK),
+        )
+
+
+def _resolve_prompt_files_from_roots(roots: list[McpRoot], *, max_files: int = 200) -> list[str]:
+    files: list[str] = []
+    seen_files: set[str] = set()
+
+    def _add(value: str) -> None:
+        if value in seen_files:
+            return
+        seen_files.add(value)
+        files.append(value)
+
+    for root in roots:
+        if len(files) >= max_files:
+            break
+
+        path = root.path
+        if not path:
+            continue
+
+        absolute_path = os.path.abspath(path)
+        if os.path.isfile(absolute_path):
+            _add(absolute_path)
+            _add(os.path.basename(absolute_path))
+            continue
+
+        if not _is_readable_directory(absolute_path):
+            continue
+
+        try:
+            for name in sorted(os.listdir(absolute_path)):
+                child_path = os.path.join(absolute_path, name)
+                if not os.path.isfile(child_path):
+                    continue
+                _add(os.path.abspath(child_path))
+                _add(name)
+                if len(files) >= max_files:
+                    break
+        except OSError as exc:
+            logger.warning("Failed listing files for MCP root %s: %s", absolute_path, exc)
+
+    return files
+
+
+def _is_readable_directory(path: str) -> bool:
+    return os.path.isdir(path) and os.access(path, os.R_OK | os.X_OK)
+
+
+def _append_notebook_path_to_final_text(final_text: str, notebook_path: str | None) -> str:
+    if not notebook_path:
+        return final_text
+    if notebook_path in final_text:
+        return final_text
+    return f"{final_text}\n\nNotebook saved to: {notebook_path}"

--- a/mito-ai-mcp/mito_ai_mcp/server.py
+++ b/mito-ai-mcp/mito_ai_mcp/server.py
@@ -6,28 +6,12 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
-import tempfile
-import uuid
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 
-from mito_ai_core.agent import ToolResult
-from mito_ai_core.completions.models import AgentResponse
-from mito_ai_mcp.request_agent_execution import (
-    RequestAgentExecutionInput,
-    RequestAgentExecutionManager,
-)
-from mito_ai_mcp.utils.client_capabilities import detect_ask_user_mode
-from mito_ai_mcp.utils.elicitation import build_elicitation_handler
-from mito_ai_mcp.utils.progress import (
-    format_assistant_progress_message,
-    format_tool_progress_message,
-    report_progress,
-)
-from mito_ai_mcp.utils.roots import McpRoot, list_client_roots
+from mito_ai_mcp.data_analyst import run_data_analyst
 
 SERVER_NAME = "mito-ai-mcp"
 SERVER_INSTRUCTIONS = (
@@ -40,24 +24,25 @@ SERVER_INSTRUCTIONS = (
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS)
-request_agent_execution_manager = RequestAgentExecutionManager()
 
 
 @mcp.tool()
 async def convert_excel_to_python(prompt: str, mcp_context: Context) -> dict[str, Any]:
     """
-    Convert an Excel spreadsheet (.xlsx, .xls) to equivalent Python and pandas code in a Jupyter notebook. 
+    Convert an Excel spreadsheet (.xlsx, .xls) to equivalent Python and pandas code in a Jupyter notebook.
     Use when the user wants to migrate, automate, or reproduce Excel formulas, sheets, or workbook logic in Python.
     """
-    return await _run_data_analyst(prompt, mcp_context)
+    return await run_data_analyst(prompt, mcp_context)
 
 
 @mcp.tool()
-async def create_data_visualization(prompt: str, mcp_context: Context) -> dict[str, Any]:
+async def create_data_visualization(
+    prompt: str, mcp_context: Context
+) -> dict[str, Any]:
     """
     Create a data visualization from tabular data.
     """
-    return await _run_data_analyst(prompt, mcp_context)
+    return await run_data_analyst(prompt, mcp_context)
 
 
 @mcp.tool()
@@ -66,173 +51,7 @@ async def run_data_analysis(prompt: str, mcp_context: Context) -> dict[str, Any]
     Use for data analysis requests in notebook or spreadsheet workflows.
     Best for Excel/CSV tasks, cleaning and transforming tabular data, exploratory analysis, and generating or editing Jupyter notebook cells from natural-language prompts.
     """
-    return await _run_data_analyst(prompt, mcp_context)
-
-
-async def _run_data_analyst(prompt: str, mcp_context: Context) -> dict[str, Any]:
-    """Run a one-shot Mito AI analysis and return text plus artifact metadata."""
-    progress_step = 0
-    logger.info("Detecting ask-user mode for run_data_analyst request")
-    ask_user_mode = detect_ask_user_mode(mcp_context)
-    logger.info("Resolved ask-user mode: %s", ask_user_mode)
-    roots = await list_client_roots(mcp_context)
-    _log_discovered_roots(roots)
-    prompt_files = _resolve_prompt_files_from_roots(roots)
-    logger.info("Resolved %s files from MCP roots for prompt context", len(prompt_files))
-    notebook_path = _resolve_notebook_output_path(roots)
-    logger.info("Resolved notebook output path: %s", notebook_path)
-    kernel_cwd = _resolve_kernel_cwd_from_roots(roots)
-    logger.info("Resolved kernel cwd from roots: %s", kernel_cwd)
-
-    async def publish_progress(message: str) -> None:
-        nonlocal progress_step
-        progress_step += 1
-        await report_progress(mcp_context, progress=progress_step, message=message)
-
-    await publish_progress("Starting analysis run")
-
-    async def on_assistant_response(response: AgentResponse) -> None:
-        await publish_progress(format_assistant_progress_message(response))
-
-    async def on_tool_result(tool_result: ToolResult) -> None:
-        await publish_progress(format_tool_progress_message(tool_result))
-
-    logger.info("Starting AgentRunner prompt execution")
-    result = await request_agent_execution_manager.run_prompt(
-        prompt,
-        metadata=RequestAgentExecutionInput(
-            notebook_path=notebook_path,
-            kernel_cwd=kernel_cwd,
-            files=prompt_files or None,
-            ask_user_mode=ask_user_mode,
-            ask_user_handler=build_elicitation_handler(mcp_context),
-        ),
-        on_assistant_response=on_assistant_response,
-        on_tool_result=on_tool_result,
-    )
-    logger.info(
-        "AgentRunner prompt execution completed (finished=%s, iterations=%s)",
-        result.finished,
-        result.iterations,
-    )
-    await publish_progress("Analysis run completed")
-    final_text = _append_notebook_path_to_final_text(result.final_text, result.notebook_path)
-    return {
-        "final_text": final_text,
-        "metadata": {
-            "notebook_path": result.notebook_path,
-            "artifact_paths": result.artifact_paths,
-        },
-    }
-
-
-def _resolve_notebook_output_path(roots: list[McpRoot]) -> str:
-    notebook_name = f"mito-{uuid.uuid4().hex}.ipynb"
-    for root in roots:
-        if root.path is None:
-            continue
-        if _is_writable_directory(root.path):
-            return os.path.join(root.path, notebook_name)
-
-    logger.info("No writable MCP roots detected; defaulting notebook path to current directory")
-    candidate = os.path.abspath(notebook_name)
-    parent = os.path.dirname(candidate)
-    if parent and os.path.isdir(parent) and os.access(parent, os.W_OK):
-        return candidate
-    fallback = os.path.join(tempfile.gettempdir(), notebook_name)
-    logger.info("Notebook output directory not writable; using temp path: %s", fallback)
-    return fallback
-
-
-def _resolve_kernel_cwd_from_roots(roots: list[McpRoot]) -> str | None:
-    for root in roots:
-        if root.path is None:
-            continue
-        absolute_path = os.path.abspath(root.path)
-        if _is_writable_directory(absolute_path):
-            return absolute_path
-    return None
-
-
-def _is_writable_directory(path: str) -> bool:
-    return os.path.isdir(path) and os.access(path, os.W_OK | os.X_OK)
-
-
-def _log_discovered_roots(roots: list[McpRoot]) -> None:
-    if not roots:
-        logger.info("MCP roots/list returned no roots")
-        return
-
-    logger.info("MCP roots/list returned %s root(s)", len(roots))
-    for index, root in enumerate(roots):
-        if not root.path:
-            logger.info("MCP root[%s]: uri=%s path=<none>", index, root.uri)
-            continue
-
-        absolute_path = os.path.abspath(root.path)
-        logger.info(
-            "MCP root[%s]: uri=%s path=%s is_dir=%s readable=%s writable=%s",
-            index,
-            root.uri,
-            absolute_path,
-            os.path.isdir(absolute_path),
-            os.access(absolute_path, os.R_OK | os.X_OK),
-            os.access(absolute_path, os.W_OK | os.X_OK),
-        )
-
-
-def _resolve_prompt_files_from_roots(roots: list[McpRoot], *, max_files: int = 200) -> list[str]:
-    files: list[str] = []
-    seen_files: set[str] = set()
-
-    def _add(value: str) -> None:
-        if value in seen_files:
-            return
-        seen_files.add(value)
-        files.append(value)
-
-    for root in roots:
-        if len(files) >= max_files:
-            break
-
-        path = root.path
-        if not path:
-            continue
-
-        absolute_path = os.path.abspath(path)
-        if os.path.isfile(absolute_path):
-            _add(absolute_path)
-            _add(os.path.basename(absolute_path))
-            continue
-
-        if not _is_readable_directory(absolute_path):
-            continue
-
-        try:
-            for name in sorted(os.listdir(absolute_path)):
-                child_path = os.path.join(absolute_path, name)
-                if not os.path.isfile(child_path):
-                    continue
-                _add(os.path.abspath(child_path))
-                _add(name)
-                if len(files) >= max_files:
-                    break
-        except OSError as exc:
-            logger.warning("Failed listing files for MCP root %s: %s", absolute_path, exc)
-
-    return files
-
-
-def _is_readable_directory(path: str) -> bool:
-    return os.path.isdir(path) and os.access(path, os.R_OK | os.X_OK)
-
-
-def _append_notebook_path_to_final_text(final_text: str, notebook_path: str | None) -> str:
-    if not notebook_path:
-        return final_text
-    if notebook_path in final_text:
-        return final_text
-    return f"{final_text}\n\nNotebook saved to: {notebook_path}"
+    return await run_data_analyst(prompt, mcp_context)
 
 
 def main() -> None:
@@ -249,4 +68,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/mito-ai-mcp/mito_ai_mcp/server.py
+++ b/mito-ai-mcp/mito_ai_mcp/server.py
@@ -43,24 +43,33 @@ mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS)
 request_agent_execution_manager = RequestAgentExecutionManager()
 
 
-@mcp.tool(
-    name="run_data_analyst",
-    description=(
-        "Use for data analysis requests in notebook or spreadsheet workflows. "
-        "Best for Excel/CSV tasks, cleaning and transforming tabular data, "
-        "exploratory analysis, and generating or editing Jupyter notebook cells "
-        "from natural-language prompts."
-    ),
-    # As a workaround to file system access issues, we tried to get claude to pass the absolute path
-    # to the files to the server, but we then got permission errors.
-#   description=(
-#         """Run data analysis in a Jupyter notebook. Use for Excel/CSV tasks, cleaning tabular data, exploratory analysis, and generating notebook cells from natural language.
-# CRITICAL: If the user references a file that the data analysis is supposed to use
-# you must pass its absolute path to the file on the user's computer in the prompt. Do not use relative paths, or mnt paths. The run_data_analysis function won't have access to those.
-# If you don't have an absolute path, elicit the user for the full path(s) before calling this function. """
-#     ),
-)
-async def run_data_analyst(prompt: str, mcp_context: Context) -> dict[str, Any]:
+@mcp.tool()
+async def convert_excel_to_python(prompt: str, mcp_context: Context) -> dict[str, Any]:
+    """
+    Convert an Excel spreadsheet (.xlsx, .xls) to equivalent Python and pandas code in a Jupyter notebook. 
+    Use when the user wants to migrate, automate, or reproduce Excel formulas, sheets, or workbook logic in Python.
+    """
+    return await _run_data_analyst(prompt, mcp_context)
+
+
+@mcp.tool()
+async def create_data_visualization(prompt: str, mcp_context: Context) -> dict[str, Any]:
+    """
+    Create a data visualization from tabular data.
+    """
+    return await _run_data_analyst(prompt, mcp_context)
+
+
+@mcp.tool()
+async def run_data_analysis(prompt: str, mcp_context: Context) -> dict[str, Any]:
+    """
+    Use for data analysis requests in notebook or spreadsheet workflows.
+    Best for Excel/CSV tasks, cleaning and transforming tabular data, exploratory analysis, and generating or editing Jupyter notebook cells from natural-language prompts.
+    """
+    return await _run_data_analyst(prompt, mcp_context)
+
+
+async def _run_data_analyst(prompt: str, mcp_context: Context) -> dict[str, Any]:
     """Run a one-shot Mito AI analysis and return text plus artifact metadata."""
     progress_step = 0
     logger.info("Detecting ask-user mode for run_data_analyst request")

--- a/mito-ai-mcp/tests/test_server_e2e.py
+++ b/mito-ai-mcp/tests/test_server_e2e.py
@@ -13,9 +13,9 @@ import pytest
 
 from mito_ai_core.agent import AgentRunResult, ToolResult
 from mito_ai_core.completions.models import AgentResponse
+from mito_ai_mcp import data_analyst
 from mito_ai_mcp import request_agent_execution
-from mito_ai_mcp import server as mcp_server
-from mito_ai_mcp.server import run_data_analyst
+from mito_ai_mcp.data_analyst import run_data_analyst
 from mito_ai_mcp.utils.client_capabilities import detect_ask_user_mode
 
 class FakeMcpContext:
@@ -154,7 +154,7 @@ async def test_run_data_analyst_wires_callbacks_progress_and_final_text(monkeypa
     monkeypatch.setattr(request_agent_execution, "save_notebook", lambda nb, path: None)
     monkeypatch.setattr(request_agent_execution, "cells_to_notebook", lambda cells: {"cells": cells})
     monkeypatch.setattr(
-        mcp_server,
+        data_analyst,
         "_resolve_notebook_output_path",
         lambda _roots: "/tmp/test-mcp-notebook.ipynb",
     )
@@ -208,7 +208,7 @@ async def test_run_data_analyst_uses_first_writable_root_for_notebook_path(
             artifact_paths=[metadata.notebook_path],
         )
 
-    monkeypatch.setattr(mcp_server.request_agent_execution_manager, "run_prompt", fake_run_prompt)
+    monkeypatch.setattr(data_analyst.request_agent_execution_manager, "run_prompt", fake_run_prompt)
     ctx = FakeMcpContextWithRoots(tmp_path)
 
     response = await run_data_analyst("Use the notebook root", mcp_context=ctx)
@@ -251,7 +251,7 @@ async def test_run_data_analyst_leaves_kernel_cwd_unset_without_writable_roots(
             artifact_paths=[metadata.notebook_path],
         )
 
-    monkeypatch.setattr(mcp_server.request_agent_execution_manager, "run_prompt", fake_run_prompt)
+    monkeypatch.setattr(data_analyst.request_agent_execution_manager, "run_prompt", fake_run_prompt)
     ctx = FakeMcpContext()
 
     await run_data_analyst("Use defaults", mcp_context=ctx)


### PR DESCRIPTION
# Description

Breaking up the MCP server into specific tool calls. This should (hopefully) create more specific use cases for the client to understand when the Mito Agent should be used. 

To start, I've broken out:

- convert_excel_to_python
- create_data_visualization
- run_data_analysis

# Testing

Use the MCP server.

# Documentation

Maybe update some docs? I have to look into this. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the MCP tool surface area (new tool names and removal of the old `run_data_analyst` tool), which can break client integrations even though core execution logic is largely refactored without behavioral changes.
> 
> **Overview**
> Extracts the one-shot agent execution flow (roots discovery, notebook path selection, progress reporting, and prompt execution) from `server.py` into a new `data_analyst.py` module exposing `run_data_analyst()`.
> 
> Replaces the single MCP tool with three more specific MCP tools—`convert_excel_to_python`, `create_data_visualization`, and `run_data_analysis`—all delegating to the shared `run_data_analyst()` implementation.
> 
> Updates end-to-end tests to patch and import from `data_analyst` (including its `request_agent_execution_manager`) instead of `server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ba0e23ca28b687be5f2f9a34554ced44aad1db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->