### PR TITLE
Fix/output buttons

### DIFF
--- a/mito-ai/src/Extensions/ChartWizard/ChartWizardPlugin.tsx
+++ b/mito-ai/src/Extensions/ChartWizard/ChartWizardPlugin.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { createRoot, Root } from 'react-dom/client';
+import { mountOutputAction, unmountOutputAction } from '../OutputActions/outputActionsToolbar';
 import { JupyterFrontEnd, JupyterFrontEndPlugin, ILayoutRestorer } from '@jupyterlab/application';
 import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
 import { INotebookTracker } from '@jupyterlab/notebook';
@@ -147,7 +147,7 @@ class AugmentedImageRenderer extends Widget implements IRenderMime.IRenderer {
     private notebookTracker: INotebookTracker;
     private app: JupyterFrontEnd;
     private openChartWizard: (chartData?: ChartWizardData) => void;
-    private reactRoot: Root | null = null;
+    private _outputWrapper: HTMLElement | null = null;
 
     constructor(
         app: JupyterFrontEnd,
@@ -166,37 +166,35 @@ class AugmentedImageRenderer extends Widget implements IRenderMime.IRenderer {
      * Render the original image and append the Chart Wizard button.
      */
     async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-        // Clean up any existing React root before creating a new one
-        if (this.reactRoot) {
-            this.reactRoot.unmount();
-            this.reactRoot = null;
-        }
+        this._unmountChartWizardAction();
 
-        const chartWizardDiv = document.createElement('div');
-        chartWizardDiv.className = 'chart-wizard-button-container';
         const originalNode = this.originalRenderer.node;
-
-        // Store the root reference so we can unmount it later
-        this.reactRoot = createRoot(chartWizardDiv);
-        this.reactRoot.render(
-            <ChartWizardButton onButtonClick={() => this.handleButtonClick(model)} />
-        );
-
-        this.node.style.position = 'relative';
-        this.node.classList.add('chart-wizard-output-container');
-        this.node.appendChild(chartWizardDiv);
         await this.originalRenderer.renderModel(model);
+        this.node.classList.add('chart-wizard-output-container');
         this.node.appendChild(originalNode);
+
+        this._outputWrapper = this.node.closest('.jp-Cell-outputWrapper') as HTMLElement | null;
+        if (this._outputWrapper) {
+            mountOutputAction(
+                this._outputWrapper,
+                'chartWizard',
+                <ChartWizardButton onButtonClick={() => this.handleButtonClick(model)} />
+            );
+        }
+    }
+
+    private _unmountChartWizardAction(): void {
+        if (this._outputWrapper) {
+            unmountOutputAction(this._outputWrapper, 'chartWizard');
+        }
+        this._outputWrapper = null;
     }
 
     /**
      * Dispose of the widget and clean up the React root.
      */
     dispose(): void {
-        if (this.reactRoot) {
-            this.reactRoot.unmount();
-            this.reactRoot = null;
-        }
+        this._unmountChartWizardAction();
         super.dispose();
     }
 

--- a/mito-ai/src/Extensions/ChartWizard/ChartWizardPlugin.tsx
+++ b/mito-ai/src/Extensions/ChartWizard/ChartWizardPlugin.tsx
@@ -11,6 +11,7 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import { CodeCell } from '@jupyterlab/cells';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { ChartWizardWidget } from './ChartWizardWidget';
 import { COMMAND_MITO_AI_OPEN_CHART_WIZARD } from '../../commands';
@@ -148,6 +149,7 @@ class AugmentedImageRenderer extends Widget implements IRenderMime.IRenderer {
     private app: JupyterFrontEnd;
     private openChartWizard: (chartData?: ChartWizardData) => void;
     private _outputWrapper: HTMLElement | null = null;
+    private _renderedModel: IRenderMime.IMimeModel | null = null;
 
     constructor(
         app: JupyterFrontEnd,
@@ -167,20 +169,48 @@ class AugmentedImageRenderer extends Widget implements IRenderMime.IRenderer {
      */
     async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
         this._unmountChartWizardAction();
+        this._renderedModel = null;
 
         const originalNode = this.originalRenderer.node;
         await this.originalRenderer.renderModel(model);
         this.node.classList.add('chart-wizard-output-container');
         this.node.appendChild(originalNode);
 
-        this._outputWrapper = this.node.closest('.jp-Cell-outputWrapper') as HTMLElement | null;
-        if (this._outputWrapper) {
-            mountOutputAction(
-                this._outputWrapper,
-                'chartWizard',
-                <ChartWizardButton onButtonClick={() => this.handleButtonClick(model)} />
-            );
+        this._renderedModel = model;
+        // OutputArea calls renderModel before insertWidget, so the wrapper may not
+        // be an ancestor yet. Mount after attach (see onAfterAttach).
+        this._syncChartWizardAction();
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this._syncChartWizardAction();
+    }
+
+    private _findOutputWrapper(): HTMLElement | null {
+        return (
+            (this.node.closest('.jp-Cell-outputWrapper') as HTMLElement | null) ??
+            (this.node.closest('.jp-CodeCell')?.querySelector('.jp-Cell-outputWrapper') as HTMLElement | null)
+        );
+    }
+
+    private _syncChartWizardAction(): void {
+        if (this.isDisposed || !this._renderedModel || !this.node.isConnected) {
+            return;
         }
+
+        const wrapper = this._findOutputWrapper();
+        if (!wrapper) {
+            return;
+        }
+
+        this._outputWrapper = wrapper;
+        const model = this._renderedModel;
+        mountOutputAction(
+            wrapper,
+            'chartWizard',
+            <ChartWizardButton onButtonClick={() => this.handleButtonClick(model)} />
+        );
     }
 
     private _unmountChartWizardAction(): void {
@@ -195,6 +225,7 @@ class AugmentedImageRenderer extends Widget implements IRenderMime.IRenderer {
      */
     dispose(): void {
         this._unmountChartWizardAction();
+        this._renderedModel = null;
         super.dispose();
     }
 

--- a/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
+++ b/mito-ai/src/Extensions/Comments/CommentsPlugin.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { createRoot, type Root } from 'react-dom/client';
+import { type Root } from 'react-dom/client';
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 import { CodeCell, MarkdownCell } from '@jupyterlab/cells';
@@ -21,6 +21,11 @@ import {
 import { getCellNumberById } from '../../utils/cellReferences';
 import TextAndIconButton from '../../components/TextAndIconButton';
 import CommentIcon from '../../icons/CommentIcon';
+import {
+    hasOutputActionSlot,
+    mountOutputAction,
+    unmountOutputAction,
+} from '../OutputActions/outputActionsToolbar';
 
 import '../../../style/Comments.css';
 
@@ -206,21 +211,25 @@ const OutputCommentButton: React.FC<OutputCommentButtonProps> = ({ onClick }) =>
     );
 };
 
+export function shouldMountOutputCommentButton(
+    isDocumentMode: boolean,
+    isMitosheetOutput: boolean,
+): boolean {
+    if (isMitosheetOutput && !isDocumentMode) {
+        return false;
+    }
+    return true;
+}
+
 export function mountOutputCommentButtonOnHost(
     host: HTMLElement,
     cellId: string,
     app: JupyterFrontEnd,
     notebookTracker: INotebookTracker,
 ): Root | null {
-    if (host.querySelector('.output-comment-button-container')) {
+    if (hasOutputActionSlot(host, 'comment')) {
         return null;
     }
-
-    host.style.position = 'relative';
-    host.classList.add('output-comment-output-container');
-
-    const commentBtnDiv = document.createElement('div');
-    commentBtnDiv.className = 'output-comment-button-container';
 
     const handleClick = (): void => {
         const notebookPanel = notebookTracker.currentWidget;
@@ -229,7 +238,8 @@ export function mountOutputCommentButtonOnHost(
         }
 
         const cellNumber = getCellNumberById(cellId, notebookPanel) || 0;
-        const btnRect = commentBtnDiv.getBoundingClientRect();
+        const commentSlot = host.querySelector('.mito-output-action-slot-comment') as HTMLElement | null;
+        const btnRect = (commentSlot ?? host).getBoundingClientRect();
 
         showCommentPopover(
             btnRect,
@@ -252,11 +262,7 @@ export function mountOutputCommentButtonOnHost(
         );
     };
 
-    const root = createRoot(commentBtnDiv);
-    root.render(<OutputCommentButton onClick={handleClick} />);
-
-    host.appendChild(commentBtnDiv);
-    return root;
+    return mountOutputAction(host, 'comment', <OutputCommentButton onClick={handleClick} />);
 }
 
 /**
@@ -283,8 +289,8 @@ function injectOutputCommentButton(
         !!outputWrapper.querySelector('.mito-container, .mito-viewer, .mito-mime-renderer') ||
         cell.model.sharedModel.getSource().toLowerCase().includes('mitosheet');
 
-    if (isMitosheetOutput && !isDocumentMode) {
-        outputWrapper.querySelector('.output-comment-button-container')?.remove();
+    if (!shouldMountOutputCommentButton(isDocumentMode, isMitosheetOutput)) {
+        unmountOutputAction(outputWrapper, 'comment');
         return;
     }
 
@@ -308,7 +314,10 @@ function setupOutputCommentButtons(
         }
 
         // Ignore mutations produced by our own injection.
-        if (node.classList.contains('output-comment-button-container') || node.closest('.output-comment-button-container')) {
+        if (
+            node.classList.contains('mito-output-actions-toolbar') ||
+            node.closest('.mito-output-actions-toolbar')
+        ) {
             return false;
         }
 

--- a/mito-ai/src/Extensions/NotebookViewMode/documentModeViewCodeButtons.tsx
+++ b/mito-ai/src/Extensions/NotebookViewMode/documentModeViewCodeButtons.tsx
@@ -6,22 +6,24 @@
 /**
  * In Document mode, adds hover "View code" (and output-style "Comment" for markdown)
  * on code outputs and rendered markdown so users can jump to Notebook mode or comment
- * for the AI. Not injected in Notebook mode — output comments for code cells are
- * hidden outside Document mode via Comments.css.
+ * for the AI.
  */
 
 import React from 'react';
-import { createRoot, type Root } from 'react-dom/client';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { CodeCell, MarkdownCell } from '@jupyterlab/cells';
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 import { IDisposable } from '@lumino/disposable';
 import { mountOutputCommentButtonOnHost } from '../Comments/CommentsPlugin';
+import {
+  hasOutputActionSlot,
+  mountOutputAction,
+  OUTPUT_ACTIONS_TOOLBAR_CLASS,
+  unmountOutputAction,
+} from '../OutputActions/outputActionsToolbar';
 import TextAndIconButton from '../../components/TextAndIconButton';
 import CodeIcon from '../../icons/CodeIcon';
 
-const VIEW_CODE_BUTTON_CLASS = 'document-mode-view-code-button-container';
-const VIEW_CODE_OUTPUT_HOVER_CLASS = 'document-mode-view-code-output-container';
 const OUTPUT_MUTATION_SELECTOR =
   '.jp-Cell-outputWrapper, .jp-Cell-outputArea, .jp-OutputArea-output, .jp-MarkdownOutput, .jp-MarkdownCell';
 
@@ -49,10 +51,8 @@ function isRelevantOutputMutationNode(node: Node): boolean {
   }
 
   if (
-    node.classList.contains(VIEW_CODE_BUTTON_CLASS) ||
-    node.closest(`.${VIEW_CODE_BUTTON_CLASS}`) ||
-    node.classList.contains('output-comment-button-container') ||
-    node.closest('.output-comment-button-container')
+    node.classList.contains(OUTPUT_ACTIONS_TOOLBAR_CLASS) ||
+    node.closest(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`)
   ) {
     return false;
   }
@@ -69,8 +69,8 @@ export class DocumentModeViewCodeButtons implements IDisposable {
   private readonly _app: JupyterFrontEnd;
   private readonly _notebookTracker: INotebookTracker;
   private readonly _onViewCodeForCell: (cellId: string) => void;
-  private readonly _roots = new Map<HTMLElement, Root>();
-  private readonly _markdownCommentRoots = new Map<HTMLElement, Root>();
+  private readonly _viewCodeHosts = new Set<HTMLElement>();
+  private readonly _markdownCommentHosts = new Set<HTMLElement>();
   private _observer: MutationObserver | null = null;
   private _disposePanelHook: (() => void) | null = null;
   private _injectScheduled = false;
@@ -125,28 +125,15 @@ export class DocumentModeViewCodeButtons implements IDisposable {
       this._disposePanelHook = null;
     }
 
-    const wrappersToClean = new Set<HTMLElement>();
-    const entries = [...this._roots.entries()];
-    entries.forEach(([container, root]) => {
-      const parent = container.parentElement;
-      if (parent) {
-        wrappersToClean.add(parent);
-      }
-      root.unmount();
-      container.remove();
-    });
-    this._roots.clear();
+    for (const host of this._viewCodeHosts) {
+      unmountOutputAction(host, 'viewCode');
+    }
+    this._viewCodeHosts.clear();
 
-    this._markdownCommentRoots.forEach((root, host) => {
-      root.unmount();
-      host.querySelector('.output-comment-button-container')?.remove();
-      host.classList.remove('output-comment-output-container');
-    });
-    this._markdownCommentRoots.clear();
-
-    wrappersToClean.forEach((w) => {
-      w.classList.remove(VIEW_CODE_OUTPUT_HOVER_CLASS);
-    });
+    for (const host of this._markdownCommentHosts) {
+      unmountOutputAction(host, 'comment');
+    }
+    this._markdownCommentHosts.clear();
   }
 
   get isDisposed(): boolean {
@@ -154,27 +141,20 @@ export class DocumentModeViewCodeButtons implements IDisposable {
   }
 
   private _injectViewCodeButtonOnHost(host: HTMLElement, cellId: string): void {
-    if (host.querySelector(`.${VIEW_CODE_BUTTON_CLASS}`)) {
+    if (hasOutputActionSlot(host, 'viewCode')) {
       return;
     }
 
-    host.style.position = 'relative';
-    host.classList.add(VIEW_CODE_OUTPUT_HOVER_CLASS);
-
-    const container = document.createElement('div');
-    container.className = VIEW_CODE_BUTTON_CLASS;
-
-    const root = createRoot(container);
-    this._roots.set(container, root);
-    root.render(
+    mountOutputAction(
+      host,
+      'viewCode',
       <DocumentViewCodeButton
         onClick={() => {
           this._onViewCodeForCell(cellId);
         }}
       />
     );
-
-    host.appendChild(container);
+    this._viewCodeHosts.add(host);
   }
 
   private _injectCodeCellViewCode(cell: CodeCell): void {
@@ -200,28 +180,22 @@ export class DocumentModeViewCodeButtons implements IDisposable {
       this._notebookTracker
     );
     if (commentRoot) {
-      this._markdownCommentRoots.set(host, commentRoot);
+      this._markdownCommentHosts.add(host);
     }
   }
 
-  private _pruneStaleRoots(): void {
-    for (const [container, root] of [...this._roots.entries()]) {
-      if (!this._panel.content.node.contains(container)) {
-        const parent = container.parentElement;
-        root.unmount();
-        this._roots.delete(container);
-        if (parent) {
-          parent.classList.remove(VIEW_CODE_OUTPUT_HOVER_CLASS);
-        }
+  private _pruneStaleHosts(): void {
+    for (const host of [...this._viewCodeHosts]) {
+      if (!this._panel.content.node.contains(host)) {
+        unmountOutputAction(host, 'viewCode');
+        this._viewCodeHosts.delete(host);
       }
     }
 
-    for (const [host, root] of [...this._markdownCommentRoots.entries()]) {
+    for (const host of [...this._markdownCommentHosts]) {
       if (!this._panel.content.node.contains(host)) {
-        root.unmount();
-        host.querySelector('.output-comment-button-container')?.remove();
-        host.classList.remove('output-comment-output-container');
-        this._markdownCommentRoots.delete(host);
+        unmountOutputAction(host, 'comment');
+        this._markdownCommentHosts.delete(host);
       }
     }
   }
@@ -230,7 +204,7 @@ export class DocumentModeViewCodeButtons implements IDisposable {
     if (this._isDisposed) {
       return;
     }
-    this._pruneStaleRoots();
+    this._pruneStaleHosts();
     for (const cell of this._panel.content.widgets) {
       if (cell instanceof CodeCell && cell.outputArea?.model.length) {
         this._injectCodeCellViewCode(cell);

--- a/mito-ai/src/Extensions/OutputActions/outputActionsToolbar.tsx
+++ b/mito-ai/src/Extensions/OutputActions/outputActionsToolbar.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import '../../../style/OutputActionsToolbar.css';
+
+export const OUTPUT_ACTIONS_HOST_CLASS = 'mito-output-actions-host';
+export const OUTPUT_ACTIONS_TOOLBAR_CLASS = 'mito-output-actions-toolbar';
+
+export type OutputActionSlot = 'viewCode' | 'chartWizard' | 'comment';
+
+const SLOT_ORDER: OutputActionSlot[] = ['viewCode', 'chartWizard', 'comment'];
+
+const slotRoots = new WeakMap<HTMLElement, Map<OutputActionSlot, Root>>();
+
+function slotClassName(slot: OutputActionSlot): string {
+  return `mito-output-action-slot mito-output-action-slot-${slot}`;
+}
+
+function getSlotRoots(toolbar: HTMLElement): Map<OutputActionSlot, Root> {
+  let roots = slotRoots.get(toolbar);
+  if (!roots) {
+    roots = new Map();
+    slotRoots.set(toolbar, roots);
+  }
+  return roots;
+}
+
+function ensureSlotOrder(toolbar: HTMLElement): void {
+  for (const slot of SLOT_ORDER) {
+    const slotEl = toolbar.querySelector(`.mito-output-action-slot-${slot}`);
+    if (slotEl) {
+      toolbar.appendChild(slotEl);
+    }
+  }
+}
+
+export function getOrCreateOutputActionsToolbar(host: HTMLElement): HTMLElement {
+  host.style.position = 'relative';
+  host.classList.add(OUTPUT_ACTIONS_HOST_CLASS);
+
+  let toolbar = host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement | null;
+  if (!toolbar) {
+    toolbar = document.createElement('div');
+    toolbar.className = OUTPUT_ACTIONS_TOOLBAR_CLASS;
+    host.appendChild(toolbar);
+  }
+  return toolbar;
+}
+
+export function hasOutputActionSlot(host: HTMLElement, slot: OutputActionSlot): boolean {
+  return !!host.querySelector(`.mito-output-action-slot-${slot}`);
+}
+
+export function mountOutputAction(
+  host: HTMLElement,
+  slot: OutputActionSlot,
+  element: React.ReactElement
+): Root {
+  unmountOutputAction(host, slot);
+  const toolbar = getOrCreateOutputActionsToolbar(host);
+
+  const slotEl = document.createElement('div');
+  slotEl.className = slotClassName(slot);
+  toolbar.appendChild(slotEl);
+  ensureSlotOrder(toolbar);
+
+  const root = createRoot(slotEl);
+  getSlotRoots(toolbar).set(slot, root);
+  root.render(element);
+  return root;
+}
+
+export function unmountOutputAction(host: HTMLElement, slot: OutputActionSlot): void {
+  const toolbar = host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement | null;
+  if (!toolbar) {
+    return;
+  }
+
+  const slotEl = toolbar.querySelector(`.mito-output-action-slot-${slot}`);
+  if (!slotEl) {
+    return;
+  }
+
+  const roots = slotRoots.get(toolbar);
+  const existingRoot = roots?.get(slot);
+  if (existingRoot) {
+    existingRoot.unmount();
+    roots?.delete(slot);
+  }
+
+  slotEl.remove();
+
+  if (toolbar.childElementCount === 0) {
+    toolbar.remove();
+    host.classList.remove(OUTPUT_ACTIONS_HOST_CLASS);
+  }
+}

--- a/mito-ai/src/tests/OutputButtons/outputActionsToolbar.test.tsx
+++ b/mito-ai/src/tests/OutputButtons/outputActionsToolbar.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+import { flushSync } from 'react-dom';
+import {
+  hasOutputActionSlot,
+  mountOutputAction,
+} from '../../Extensions/OutputActions/outputActionsToolbar';
+
+describe('outputActionsToolbar', () => {
+  it('mounts a slot on the host', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    flushSync(() => {
+      mountOutputAction(host, 'viewCode', <button type="button">View code</button>);
+    });
+
+    expect(hasOutputActionSlot(host, 'viewCode')).toBe(true);
+    host.remove();
+  });
+});

--- a/mito-ai/src/tests/OutputButtons/outputButtonLayout.test.tsx
+++ b/mito-ai/src/tests/OutputButtons/outputButtonLayout.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import {
+  applyScenarioInjection,
+  buildOutputHostFixture,
+  cleanupFixture,
+  OUTPUT_ACTIONS_TOOLBAR_CLASS,
+} from './outputButtonTestUtils';
+
+const TOOLBAR_TOP_OFFSET_PX = 8;
+const TOOLBAR_RIGHT_OFFSET_PX = 8;
+
+describe('output overlay button layout', () => {
+  it('L1: single toolbar on wrapper; buttons not under chart node', () => {
+    const fixture = buildOutputHostFixture({
+      isDocumentMode: true,
+      hostType: 'codeOutput',
+      hasGraph: true,
+    });
+
+    applyScenarioInjection(fixture, {
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: true,
+      isMitosheet: false,
+      isDocumentMode: true,
+    });
+
+    const toolbars = fixture.host.querySelectorAll(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`);
+    expect(toolbars).toHaveLength(1);
+
+    const chartMarker = fixture.host.querySelector('.chart-wizard-output-container');
+    expect(chartMarker?.querySelector('.mito-output-action-slot-chartWizard')).toBeNull();
+
+    for (const slot of ['viewCode', 'chartWizard', 'comment']) {
+      const el = fixture.host.querySelector(`.mito-output-action-slot-${slot}`);
+      expect(el?.closest(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`)).toBe(toolbars[0]);
+    }
+
+    cleanupFixture(fixture);
+  });
+
+  it('L2: toolbar anchored to wrapper top-right', () => {
+    const fixture = buildOutputHostFixture({
+      isDocumentMode: true,
+      hostType: 'codeOutput',
+      hasGraph: true,
+    });
+
+    applyScenarioInjection(fixture, {
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: true,
+      isMitosheet: false,
+      isDocumentMode: true,
+    });
+
+    const toolbar = fixture.host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement;
+    const toolbarStyle = window.getComputedStyle(toolbar);
+
+    expect(toolbarStyle.position).toBe('absolute');
+    expect(toolbarStyle.top).toBe(`${TOOLBAR_TOP_OFFSET_PX}px`);
+    expect(toolbarStyle.right).toBe(`${TOOLBAR_RIGHT_OFFSET_PX}px`);
+
+    cleanupFixture(fixture);
+  });
+
+  it('L3: equal flex gap between adjacent toolbar buttons', () => {
+    const fixture = buildOutputHostFixture({
+      isDocumentMode: true,
+      hostType: 'codeOutput',
+      hasGraph: true,
+    });
+
+    applyScenarioInjection(fixture, {
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: true,
+      isMitosheet: false,
+      isDocumentMode: true,
+    });
+
+    const toolbar = fixture.host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement;
+    expect(window.getComputedStyle(toolbar).gap).toBe('8px');
+
+    const slots = toolbar.querySelectorAll('.mito-output-action-slot');
+    expect(slots.length).toBe(3);
+
+    cleanupFixture(fixture);
+  });
+
+  it('L4: notebook graph — toolbar at wrapper top-right', () => {
+    const fixture = buildOutputHostFixture({
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: true,
+    });
+
+    applyScenarioInjection(fixture, {
+      injectViewCode: false,
+      injectComment: true,
+      injectChartWizard: true,
+      isMitosheet: false,
+      isDocumentMode: false,
+    });
+
+    const toolbar = fixture.host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement;
+    const toolbarStyle = window.getComputedStyle(toolbar);
+
+    expect(toolbarStyle.right).toBe(`${TOOLBAR_RIGHT_OFFSET_PX}px`);
+    expect(toolbarStyle.top).toBe(`${TOOLBAR_TOP_OFFSET_PX}px`);
+
+    cleanupFixture(fixture);
+  });
+
+  it('L5: text above chart — toolbar stays on wrapper not chart node', () => {
+    const fixture = buildOutputHostFixture({
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: true,
+    });
+
+    applyScenarioInjection(fixture, {
+      injectViewCode: false,
+      injectComment: true,
+      injectChartWizard: true,
+      isMitosheet: false,
+      isDocumentMode: false,
+    });
+
+    const chartMarker = fixture.host.querySelector('.chart-wizard-output-container') as HTMLElement;
+    const toolbar = fixture.host.querySelector(`.${OUTPUT_ACTIONS_TOOLBAR_CLASS}`) as HTMLElement;
+
+    expect(fixture.host.contains(toolbar)).toBe(true);
+    expect(chartMarker.contains(toolbar)).toBe(false);
+    expect(fixture.host.firstElementChild?.classList.contains('jp-OutputArea-output')).toBe(true);
+
+    cleanupFixture(fixture);
+  });
+});

--- a/mito-ai/src/tests/OutputButtons/outputButtonTestUtils.tsx
+++ b/mito-ai/src/tests/OutputButtons/outputButtonTestUtils.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+import { flushSync } from 'react-dom';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import CodeIcon from '../../icons/CodeIcon';
+import MagicWand from '../../icons/MagicWand';
+import {
+  hasOutputActionSlot,
+  mountOutputAction,
+  OUTPUT_ACTIONS_TOOLBAR_CLASS,
+} from '../../Extensions/OutputActions/outputActionsToolbar';
+
+export { hasOutputActionSlot, OUTPUT_ACTIONS_TOOLBAR_CLASS };
+import {
+  mountOutputCommentButtonOnHost,
+  shouldMountOutputCommentButton,
+} from '../../Extensions/Comments/CommentsPlugin';
+import TextAndIconButton from '../../components/TextAndIconButton';
+
+import '../../../style/OutputActionsToolbar.css';
+
+export const DOCUMENT_MODE_CLASS = 'jp-mod-mito-document-mode';
+export const FORCE_HOVER_CLASS = 'mito-output-actions-host--test-hover';
+
+const testHoverStyle = document.createElement('style');
+testHoverStyle.textContent = `
+  .mito-output-actions-host {
+    position: relative;
+  }
+  .mito-output-actions-toolbar {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 10;
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    justify-content: flex-end;
+    opacity: 0;
+  }
+  .mito-output-actions-host.${FORCE_HOVER_CLASS} .mito-output-actions-toolbar {
+    opacity: 1 !important;
+  }
+`;
+if (!document.head.querySelector('[data-mito-output-actions-test-hover]')) {
+  testHoverStyle.setAttribute('data-mito-output-actions-test-hover', 'true');
+  document.head.appendChild(testHoverStyle);
+}
+
+export type HostType = 'markdown' | 'codeOutput';
+
+export interface OutputHostFixture {
+  notebookRoot: HTMLElement;
+  host: HTMLElement;
+}
+
+export interface ExpectedButtons {
+  viewCode: boolean;
+  comment: boolean;
+  chartWizard: boolean;
+}
+
+export function buildOutputHostFixture(options: {
+  isDocumentMode: boolean;
+  hostType: HostType;
+  hasGraph?: boolean;
+  isMitosheet?: boolean;
+}): OutputHostFixture {
+  const notebookRoot = document.createElement('div');
+  notebookRoot.className = 'jp-Notebook';
+  if (options.isDocumentMode) {
+    notebookRoot.classList.add(DOCUMENT_MODE_CLASS);
+  }
+
+  let host: HTMLElement;
+  if (options.hostType === 'markdown') {
+    host = document.createElement('div');
+    host.className = 'jp-MarkdownOutput';
+  } else {
+    host = document.createElement('div');
+    host.className = 'jp-Cell-outputWrapper';
+    if (options.isMitosheet) {
+      const mito = document.createElement('div');
+      mito.className = 'mito-container';
+      host.appendChild(mito);
+    }
+    if (options.hasGraph) {
+      const textOut = document.createElement('div');
+      textOut.className = 'jp-OutputArea-output';
+      textOut.textContent = 'Hello World';
+      host.appendChild(textOut);
+
+      const chartMarker = document.createElement('div');
+      chartMarker.className = 'chart-wizard-output-container';
+      host.appendChild(chartMarker);
+    }
+  }
+
+  notebookRoot.appendChild(host);
+  document.body.appendChild(notebookRoot);
+  return { notebookRoot, host };
+}
+
+export function cleanupFixture(fixture: OutputHostFixture): void {
+  fixture.notebookRoot.remove();
+}
+
+export function createMockAppAndTracker(): {
+  app: JupyterFrontEnd;
+  notebookTracker: INotebookTracker;
+} {
+  return {
+    app: { commands: { execute: jest.fn() } } as unknown as JupyterFrontEnd,
+    notebookTracker: { currentWidget: null } as unknown as INotebookTracker,
+  };
+}
+
+export function mountViewCodeOnHost(host: HTMLElement): void {
+  mountOutputAction(
+    host,
+    'viewCode',
+    <TextAndIconButton
+      icon={CodeIcon}
+      text="View code"
+      title="View code"
+      onClick={() => undefined}
+      variant="purple"
+      width="fit-contents"
+      iconPosition="left"
+    />
+  );
+}
+
+export function mountChartWizardOnHost(host: HTMLElement): void {
+  mountOutputAction(
+    host,
+    'chartWizard',
+    <TextAndIconButton
+      icon={MagicWand}
+      text="Chart Wizard"
+      title="Chart Wizard"
+      onClick={() => undefined}
+      variant="purple"
+      width="fit-contents"
+      iconPosition="left"
+    />
+  );
+}
+
+export function applyScenarioInjection(
+  fixture: OutputHostFixture,
+  options: {
+    injectViewCode: boolean;
+    injectComment: boolean;
+    injectChartWizard: boolean;
+    isMitosheet: boolean;
+    isDocumentMode: boolean;
+    cellId?: string;
+  }
+): void {
+  const { app, notebookTracker } = createMockAppAndTracker();
+  const cellId = options.cellId ?? 'test-cell-id';
+
+  flushSync(() => {
+    if (options.injectViewCode) {
+      mountViewCodeOnHost(fixture.host);
+    }
+
+    if (
+      options.injectComment &&
+      shouldMountOutputCommentButton(options.isDocumentMode, options.isMitosheet)
+    ) {
+      mountOutputCommentButtonOnHost(fixture.host, cellId, app, notebookTracker);
+    }
+
+    if (options.injectChartWizard) {
+      mountChartWizardOnHost(fixture.host);
+    }
+  });
+}
+
+export function assertOutputButtons(
+  host: HTMLElement,
+  expected: ExpectedButtons
+): void {
+  expect(hasOutputActionSlot(host, 'viewCode')).toBe(expected.viewCode);
+  expect(hasOutputActionSlot(host, 'comment')).toBe(expected.comment);
+  expect(hasOutputActionSlot(host, 'chartWizard')).toBe(expected.chartWizard);
+}

--- a/mito-ai/src/tests/OutputButtons/outputButtonTestUtils.tsx
+++ b/mito-ai/src/tests/OutputButtons/outputButtonTestUtils.tsx
@@ -22,35 +22,7 @@ import {
 } from '../../Extensions/Comments/CommentsPlugin';
 import TextAndIconButton from '../../components/TextAndIconButton';
 
-import '../../../style/OutputActionsToolbar.css';
-
 export const DOCUMENT_MODE_CLASS = 'jp-mod-mito-document-mode';
-export const FORCE_HOVER_CLASS = 'mito-output-actions-host--test-hover';
-
-const testHoverStyle = document.createElement('style');
-testHoverStyle.textContent = `
-  .mito-output-actions-host {
-    position: relative;
-  }
-  .mito-output-actions-toolbar {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    z-index: 10;
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    justify-content: flex-end;
-    opacity: 0;
-  }
-  .mito-output-actions-host.${FORCE_HOVER_CLASS} .mito-output-actions-toolbar {
-    opacity: 1 !important;
-  }
-`;
-if (!document.head.querySelector('[data-mito-output-actions-test-hover]')) {
-  testHoverStyle.setAttribute('data-mito-output-actions-test-hover', 'true');
-  document.head.appendChild(testHoverStyle);
-}
 
 export type HostType = 'markdown' | 'codeOutput';
 

--- a/mito-ai/src/tests/OutputButtons/outputButtonVisibility.test.tsx
+++ b/mito-ai/src/tests/OutputButtons/outputButtonVisibility.test.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import {
+  applyScenarioInjection,
+  assertOutputButtons,
+  buildOutputHostFixture,
+  cleanupFixture,
+  ExpectedButtons,
+} from './outputButtonTestUtils';
+
+describe('output overlay button visibility', () => {
+  const cases: Array<{
+    id: string;
+    isDocumentMode: boolean;
+    hostType: 'markdown' | 'codeOutput';
+    hasGraph: boolean;
+    isMitosheet: boolean;
+    injectViewCode: boolean;
+    injectComment: boolean;
+    injectChartWizard: boolean;
+    expected: ExpectedButtons;
+  }> = [
+    {
+      id: 'D1',
+      isDocumentMode: true,
+      hostType: 'markdown',
+      hasGraph: false,
+      isMitosheet: false,
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: false,
+      expected: { viewCode: true, comment: true, chartWizard: false },
+    },
+    {
+      id: 'D2',
+      isDocumentMode: true,
+      hostType: 'codeOutput',
+      hasGraph: false,
+      isMitosheet: false,
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: false,
+      expected: { viewCode: true, comment: true, chartWizard: false },
+    },
+    {
+      id: 'D3',
+      isDocumentMode: true,
+      hostType: 'codeOutput',
+      hasGraph: true,
+      isMitosheet: false,
+      injectViewCode: true,
+      injectComment: true,
+      injectChartWizard: true,
+      expected: { viewCode: true, comment: true, chartWizard: true },
+    },
+    {
+      id: 'N1',
+      isDocumentMode: false,
+      hostType: 'markdown',
+      hasGraph: false,
+      isMitosheet: false,
+      injectViewCode: false,
+      injectComment: false,
+      injectChartWizard: false,
+      expected: { viewCode: false, comment: false, chartWizard: false },
+    },
+    {
+      id: 'N2',
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: false,
+      isMitosheet: false,
+      injectViewCode: false,
+      injectComment: false,
+      injectChartWizard: false,
+      expected: { viewCode: false, comment: false, chartWizard: false },
+    },
+    {
+      id: 'N3',
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: false,
+      isMitosheet: true,
+      injectViewCode: false,
+      injectComment: true,
+      injectChartWizard: false,
+      expected: { viewCode: false, comment: false, chartWizard: false },
+    },
+    {
+      id: 'N4',
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: true,
+      isMitosheet: false,
+      injectViewCode: false,
+      injectComment: true,
+      injectChartWizard: true,
+      expected: { viewCode: false, comment: true, chartWizard: true },
+    },
+    {
+      id: 'N5',
+      isDocumentMode: false,
+      hostType: 'codeOutput',
+      hasGraph: false,
+      isMitosheet: false,
+      injectViewCode: false,
+      injectComment: true,
+      injectChartWizard: false,
+      expected: { viewCode: false, comment: true, chartWizard: false },
+    },
+  ];
+
+  it.each(cases)(
+    '$id',
+    ({
+      isDocumentMode,
+      hostType,
+      hasGraph,
+      isMitosheet,
+      injectViewCode,
+      injectComment,
+      injectChartWizard,
+      expected,
+    }) => {
+      const fixture = buildOutputHostFixture({
+        isDocumentMode,
+        hostType,
+        hasGraph,
+        isMitosheet,
+      });
+
+      applyScenarioInjection(fixture, {
+        injectViewCode,
+        injectComment,
+        injectChartWizard,
+        isMitosheet,
+        isDocumentMode,
+      });
+
+      assertOutputButtons(fixture.host, expected);
+      cleanupFixture(fixture);
+    }
+  );
+});

--- a/mito-ai/style/ChartWizardPlugin.css
+++ b/mito-ai/style/ChartWizardPlugin.css
@@ -1,18 +1,7 @@
 /*
  * Copyright (c) Saga Inc.
  * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ *
+ * Chart Wizard actions mount on .mito-output-actions-toolbar (see OutputActionsToolbar.css).
+ * .chart-wizard-output-container marks PNG chart outputs in a cell.
  */
-
-/* Position the button container in the upper right, offset to leave room for the comment button */
-.chart-wizard-button-container {
-    position: absolute;
-    top: 8px;
-    right: 118px;
-    z-index: 10;
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
-}
-
-.chart-wizard-output-container:hover .chart-wizard-button-container {
-    opacity: 1;
-}

--- a/mito-ai/style/Comments.css
+++ b/mito-ai/style/Comments.css
@@ -114,32 +114,9 @@
     color: white;
 }
 
-/* Output comment button - positioned at top right of output area */
-.output-comment-button-container {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    z-index: 10;
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
-}
-
-/* Show the comment button when hovering over the output container */
-.output-comment-output-container:hover .output-comment-button-container {
-    opacity: 1;
-}
-
 /* Output comment indicator - purple left border when a comment is active */
 .jp-Cell-outputWrapper.comment-indicator-active,
 .jp-MarkdownOutput.comment-indicator-active {
     border-left: 3px solid var(--purple-500);
     cursor: pointer;
-}
-
-/*
- * Output "Comment" affordance is for Document-style reading; hide in full Notebook mode.
- * (View code controls are injected only in Document mode from NotebookViewMode.)
- */
-.jp-Notebook:not(.jp-mod-mito-document-mode) .output-comment-button-container {
-    display: none !important;
 }

--- a/mito-ai/style/DocumentMode.css
+++ b/mito-ai/style/DocumentMode.css
@@ -125,28 +125,3 @@
   ):not(:has(.error-mime-renderer-container)) {
   display: none !important;
 }
-
-/*
- * Document mode: "View code" on output hover (same pattern as output comment button;
- * right offset matches Chart Wizard so it sits left of Comment).
- */
-.document-mode-view-code-button-container {
-  position: absolute;
-  top: 8px;
-  right: 118px;
-  z-index: 10;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out;
-}
-
-.document-mode-view-code-output-container:hover .document-mode-view-code-button-container {
-  opacity: 1;
-}
-
-/*
- * When Chart Wizard is present in the same output wrapper, shift further left so the
- * two controls do not overlap (Chart Wizard is positioned from the chart widget).
- */
-.jp-Cell-outputWrapper:has(.chart-wizard-button-container) .document-mode-view-code-button-container {
-  right: 240px;
-}

--- a/mito-ai/style/OutputActionsToolbar.css
+++ b/mito-ai/style/OutputActionsToolbar.css
@@ -27,3 +27,21 @@
 .mito-output-action-slot {
   display: flex;
 }
+
+/* Lock output overlay buttons to a consistent size regardless of host. */
+.mito-output-actions-toolbar .text-and-icon-button {
+  font-size: 14px;
+  line-height: 1;
+  padding: 5px 10px;
+}
+
+.mito-output-actions-toolbar .text-and-icon-button__icon {
+  height: 14px;
+  display: flex;
+  align-items: center;
+}
+
+.mito-output-actions-toolbar .text-and-icon-button__icon > svg {
+  height: 14px;
+  width: auto;
+}

--- a/mito-ai/style/OutputActionsToolbar.css
+++ b/mito-ai/style/OutputActionsToolbar.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+.mito-output-actions-host {
+  position: relative;
+}
+
+.mito-output-actions-toolbar {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  justify-content: flex-end;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.mito-output-actions-host:hover .mito-output-actions-toolbar {
+  opacity: 1;
+}
+
+.mito-output-action-slot {
+  display: flex;
+}

--- a/tests/mitoai_ui_tests/chartWizard.spec.ts
+++ b/tests/mitoai_ui_tests/chartWizard.spec.ts
@@ -42,11 +42,10 @@ test.describe.parallel('Chart Wizard', () => {
         const chartOutputContainer = page.locator('.chart-wizard-output-container').first();
         await expect(chartOutputContainer).toBeVisible({ timeout: 10000 });
 
-        // Hover over the chart output to make the button visible
-        await chartOutputContainer.hover();
+        const outputWrapper = chartOutputContainer.locator('xpath=ancestor::div[contains(@class,"jp-Cell-outputWrapper")]');
+        await outputWrapper.hover();
 
-        // Wait for the Chart Wizard button to become visible (opacity changes on hover)
-        const chartWizardButton = page.locator('.chart-wizard-button-container').getByRole('button', { name: 'Chart Wizard' });
+        const chartWizardButton = outputWrapper.locator('.mito-output-action-slot-chartWizard').getByRole('button', { name: 'Chart Wizard' });
         await expect(chartWizardButton).toBeVisible();
 
         // Click the Chart Wizard button

--- a/tests/mitoai_ui_tests/documentModeOutputButtons.smoke.spec.ts
+++ b/tests/mitoai_ui_tests/documentModeOutputButtons.smoke.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { test, expect } from '../fixtures';
+import {
+    createAndRunNotebookWithCells,
+    runCell,
+    waitForIdle,
+} from '../jupyter_utils/jupyterlab_utils';
+
+const CHART_CODE = `!pip install matplotlib --quiet
+import pandas as pd
+df = pd.DataFrame({'x': [1, 2, 3, 4, 5], 'y': [2, 4, 1, 5, 3]})
+ax = df.plot(x='x', y='y', kind='line', title='Smoke test chart')
+ax.set_xlabel('X')
+ax.set_ylabel('Y')`;
+
+test.describe('Document mode output buttons smoke', () => {
+    test('chart output shows View code, Chart Wizard, and Comment in one toolbar', async ({ page }) => {
+        await createAndRunNotebookWithCells(page, []);
+        await waitForIdle(page);
+
+        await page.notebook.setCell(0, 'code', CHART_CODE);
+        await runCell(page, 0);
+        await waitForIdle(page);
+
+        const chartMarker = page.locator('.chart-wizard-output-container').first();
+        await expect(chartMarker).toBeVisible({ timeout: 10000 });
+
+        const documentTab = page.locator('.mode-switcher-segment').filter({ hasText: 'Document' });
+        await documentTab.click();
+        await waitForIdle(page);
+
+        const outputWrapper = chartMarker.locator('xpath=ancestor::div[contains(@class,"jp-Cell-outputWrapper")]');
+        await outputWrapper.hover();
+
+        const toolbar = outputWrapper.locator('.mito-output-actions-toolbar');
+        await expect(toolbar).toBeVisible();
+
+        await expect(toolbar.locator('.mito-output-action-slot-viewCode').getByRole('button', { name: 'View code' })).toBeVisible();
+        await expect(toolbar.locator('.mito-output-action-slot-chartWizard').getByRole('button', { name: 'Chart Wizard' })).toBeVisible();
+        await expect(toolbar.locator('.mito-output-action-slot-comment').getByRole('button', { name: 'Comment' })).toBeVisible();
+    });
+});


### PR DESCRIPTION
# Description

Fix the output buttons:
- Align Chart Wizard Button with Top of Cell Output instead of in the chart itself
- In notebook mode the Chart Wizard button is no longer aligned right, there is a gap
- The Chart Wizard Button is attached to the View Code button

Resolves https://github.com/mito-ds/mito/issues/2325

# Testing

I aimed for the following setup: 


### Document Mode, A Markdown Cell
1. View Code
2. Comment

### Document Mode, Code Cell Output Area W/O graph in it
1. View Code
2. Comment

### Document Mode, Code Cell Output Area WITH graph in it
1. Chart Wizard
2. View Code
3. Comment Button 

### Notebook Mode, Markdown Cell
1. No buttons

### Notebook Mode, Code Cell
1. No buttons

### Notebook Mode, Output Area With Mito Default Dataframe Output 
1. No buttons

### Notebook Mode, Output Area With Graph
1. Chart Wizard
2. Comment Button

### Notebook Mode, Output Area W/O Graph and W/O Mito Deafualt Datamfra Output
1. Comment Button
# Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/DOM-injection refactor across multiple JupyterLab renderers/observers; risk is mainly regressions in when/where output actions mount/unmount and hover/positioning across notebook vs document mode.
> 
> **Overview**
> **Unifies output overlay buttons into one toolbar.** Introduces `outputActionsToolbar` to mount/unmount `viewCode`, `chartWizard`, and `comment` actions into a single, ordered, hover-revealed overlay anchored to the output host.
> 
> **Migrates existing button injections to the new system.** Chart Wizard now mounts its action on the enclosing `.jp-Cell-outputWrapper` (handling attach timing), Comments uses toolbar slots (including mitosheet/document-mode gating via `shouldMountOutputCommentButton`), and Document Mode “View code”/markdown “Comment” switch from per-host React roots to toolbar slots with proper cleanup.
> 
> **Updates styling and tests.** Removes per-feature hover/position CSS in favor of `OutputActionsToolbar.css`, adds unit tests for visibility/layout scenarios, and updates/extends Playwright UI tests to target the new toolbar/slot DOM structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df521423acf51c91cc9fef9ec3568014fa9ef1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->