### PR TITLE
Drop Support for Python 3.9

### DIFF
--- a/.github/workflows/lint-mito-ai-typescript.yml
+++ b/.github/workflows/lint-mito-ai-typescript.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install JupyterLab
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-mito-ai-backend.yml
+++ b/.github/workflows/test-mito-ai-backend.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/mito-ai/CLAUDE.md
+++ b/mito-ai/CLAUDE.md
@@ -118,7 +118,7 @@ The system consists of multiple JupyterLab plugins that work together:
 - React JSX support with ES2018 target
 
 ### Python Configuration  
-- Python 3.9+ required
+- Python 3.10+ required
 - pytest 8.3.4 for testing with asyncio support
 - mypy for static type checking with strict settings
 - SQLAlchemy for database operations

--- a/mito-ai/pyproject.toml
+++ b/mito-ai/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 name = "mito_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -24,7 +24,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
# Description

Resolved https://github.com/mito-ds/mito/issues/2306

# Testing

No real testing required. Just clone, and send a message. Make sure things are working. 

# Documentation

Yes, update 3.9 to 3.10 anywhere they are mentioned in the docs. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code risk but moderate release/compatibility risk: CI and packaging now require Python >=3.10, which will break installs and tests for any remaining 3.9 users.
> 
> **Overview**
> Drops Python 3.9 support for `mito-ai` by raising the package minimum to `requires-python = ">=3.10"` and removing the `3.9` Trove classifier in `pyproject.toml`.
> 
> Updates CI to align: the TypeScript lint workflow now sets up Python `3.10`, and backend tests no longer run against Python `3.9` (matrix is `3.10`–`3.13`). Documentation in `CLAUDE.md` is updated to state Python `3.10+`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73459a77261ccd266da350d585dcc6b2430a5ed6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->