### PR TITLE
Improved agent context compaction

### DIFF
--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_execution_prompt.py
@@ -11,7 +11,7 @@ from mito_ai_core.completions.prompt_builders.prompt_section_registry.base impor
 def create_agent_execution_prompt(context: AgentContext, user_input: str) -> str:
     
     sections: List[PromptSection] = [
-        SG.Generic("Reminder", "Remember to choose the correct tool to respond with."),
+        SG.Reminder("Remember to choose the correct tool to respond with."),
         SG.Rules(context.additional_context),
         SG.StreamlitAppStatus(context.notebook_id, context.notebook_path),
         SG.Files(context.files),

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/__init__.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/__init__.py
@@ -18,6 +18,7 @@ from .rules import RulesSection
 from .task import TaskSection
 from .error_traceback import ErrorTracebackSection
 from .example import ExampleSection
+from .reminder import ReminderSection
 from .generic import GenericSection
 from .base import Prompt, PromptSection
 
@@ -37,6 +38,7 @@ class SectionRegistry:
     Task = TaskSection
     ErrorTraceback = ErrorTracebackSection
     Example = ExampleSection
+    Reminder = ReminderSection
     Generic = GenericSection
 
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/active_cell_id.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/active_cell_id.py
@@ -5,9 +5,9 @@ from .base import PromptSection
 
 
 class ActiveCellIdSection(PromptSection):
-    """Section for the ID of the active code cell."""
+    """Section for the ID of the active code cell in the latest turn."""
 
-    trim_after_messages = None
+    trim_after_messages: int = 1
 
     def __init__(self, active_cell_id: str) -> None:
         self.active_cell_id = active_cell_id

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/base.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/base.py
@@ -11,6 +11,10 @@ class PromptSection(ABC):
     
     # Class variable: trimming threshold (None = never trim)
     trim_after_messages: Optional[int] = 3
+
+    # Class variable: XML tags this section may render as when serialized.
+    # Defaults to the class-derived section name.
+    trim_tag_names: Optional[List[str]] = None
     
     # Class variable: if True, exclude XML tags when content is empty
     exclude_if_empty: bool = False
@@ -18,6 +22,13 @@ class PromptSection(ABC):
     def __init__(self, content: str):
         self.content = content
         self.name = self.__class__.__name__.replace("Section", "")
+
+    @classmethod
+    def get_trim_tag_names(cls) -> List[str]:
+        if cls.trim_tag_names is not None:
+            return cls.trim_tag_names
+
+        return [cls.__name__.replace("Section", "")]
 
     @staticmethod
     def _is_empty_content(content: Any) -> bool:

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/reminder.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/reminder.py
@@ -1,0 +1,8 @@
+from .base import PromptSection
+
+
+class ReminderSection(PromptSection):
+    """Short reminder for the current turn only."""
+
+    trim_after_messages: int = 1
+

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/selected_context.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/selected_context.py
@@ -148,8 +148,8 @@ def get_selected_context_str(additional_context: Optional[List[Dict[str, str]]])
 
 
 class SelectedContextSection(PromptSection):
-    """Section for selected context - never trimmed."""
-    trim_after_messages: Optional[int] = None
+    """Section for selected context from the latest couple of turns."""
+    trim_after_messages: Optional[int] = 2
     exclude_if_empty: bool = True
     
     def __init__(self, additional_context: Optional[List[Dict[str, str]]]):

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/streamlit_app_status.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_section_registry/streamlit_app_status.py
@@ -14,8 +14,8 @@ def get_streamlit_app_status_str(notebook_id: str, notebook_path: str) -> str:
 
 
 class StreamlitAppStatusSection(PromptSection):
-    """Section for Streamlit app status."""
-    trim_after_messages: int = 3
+    """Section for Streamlit app status in the latest turn."""
+    trim_after_messages: int = 1
     
     def __init__(self, notebook_id: str, notebook_path: str):
         self.notebook_id = notebook_id

--- a/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
@@ -272,6 +272,76 @@ After text."""
     assert "threshold" not in result
 
 
+def test_trim_message_content_summarizes_notebook_before_removing_it() -> None:
+    """Test that older Notebook sections keep structure and truncated previews."""
+    notebook_content = """Each cell's "index" is its position from the top of the notebook: 0 = first cell at the top of the notebook, then 1, 2, ... (lower index = earlier in the notebook).
+
+[
+  {
+    "index": 0,
+    "id": "cell-1",
+    "cell_type": "code",
+    "content": "import pandas as pd\\nlong_variable_name = 'This code cell is intentionally long enough that the summarized notebook view should truncate it after a short preview.'"
+  },
+  {
+    "index": 1,
+    "id": "cell-2",
+    "cell_type": "markdown",
+    "content": "  # Report Title  "
+  },
+  {
+    "index": 2,
+    "id": "cell-3",
+    "cell_type": "code",
+    "content": ""
+  }
+]
+"""
+    content = f"""Before text.
+
+<Notebook>
+{notebook_content}</Notebook>
+
+After text."""
+
+    # Fresh messages keep the full notebook payload
+    result = trim_message_content(content, message_age=2)
+    notebook_payload = result.split("<Notebook>", 1)[1].split("</Notebook>", 1)[0].strip()
+    assert "long_variable_name" in notebook_payload
+    assert '"content": "  # Report Title  "' in notebook_payload
+
+    # Older messages summarize bulky cell bodies but keep notebook structure
+    result = trim_message_content(content, message_age=3)
+    assert "<Notebook>" in result
+    notebook_payload = result.split("<Notebook>", 1)[1].split("</Notebook>", 1)[0].strip()
+    notebook_prefix, notebook_json = notebook_payload.split("\n\n", 1)
+    assert notebook_prefix.startswith('Each cell\'s "index" is its position from the top of the notebook:')
+    summarized_cells = json.loads(notebook_json)
+    assert summarized_cells[0]["index"] == 0
+    assert summarized_cells[0]["id"] == "cell-1"
+    assert summarized_cells[0]["cell_type"] == "code"
+    assert summarized_cells[0]["content"].startswith("import pandas as pd\nlong_variable_name =")
+    assert summarized_cells[0]["content"].endswith("...")
+    assert "truncate it after a short preview" not in summarized_cells[0]["content"]
+    assert summarized_cells[1] == {
+        "index": 1,
+        "id": "cell-2",
+        "cell_type": "markdown",
+        "content": "# Report Title",
+    }
+    assert summarized_cells[2] == {
+        "index": 2,
+        "id": "cell-3",
+        "cell_type": "code",
+        "content": "",
+    }
+
+    # Very old messages still drop the Notebook section entirely
+    result = trim_message_content(content, message_age=6)
+    assert "<Notebook>" not in result
+    assert "cell-1" not in result
+
+
 def test_trim_message_content_handles_content_without_sections() -> None:
     """Test that trimming preserves content without XML sections."""
     content = "This is a simple message with no sections to trim."
@@ -443,6 +513,64 @@ def test_trim_old_messages_summarizes_json_variables_before_final_trim() -> None
         {"name": "df", "type": "pd.DataFrame", "value": {"rows": 10}},
         {"name": "threshold", "type": "int", "value": 5},
     ]
+
+
+def test_trim_old_messages_summarizes_notebook_before_final_trim() -> None:
+    """Test the end-to-end history path for summarized Notebook sections."""
+    notebook_content = """<Notebook>
+Each cell's "index" is its position from the top of the notebook: 0 = first cell at the top of the notebook, then 1, 2, ... (lower index = earlier in the notebook).
+
+[
+  {
+    "index": 0,
+    "id": "cell-1",
+    "cell_type": "code",
+    "content": "print('This notebook cell is intentionally long enough to be truncated in old history snapshots while still preserving a short preview.')"
+  },
+  {
+    "index": 1,
+    "id": "cell-2",
+    "cell_type": "markdown",
+    "content": "# Summary"
+  }
+]
+</Notebook>"""
+
+    messages: List[ChatCompletionMessageParam] = [
+        {"role": "user", "content": notebook_content},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": notebook_content},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "most recent"},
+    ]
+
+    result = trim_old_messages(messages)
+
+    # Index 0 has age 4, so Notebook should be summarized, not removed.
+    oldest_content = result[0].get("content")
+    assert isinstance(oldest_content, str)
+    assert "<Notebook>" in oldest_content
+    oldest_payload = oldest_content.split("<Notebook>", 1)[1].split("</Notebook>", 1)[0].strip()
+    notebook_prefix, notebook_json = oldest_payload.split("\n\n", 1)
+    assert notebook_prefix.startswith('Each cell\'s "index" is its position from the top of the notebook:')
+    summarized_cells = json.loads(notebook_json)
+    assert summarized_cells[0]["index"] == 0
+    assert summarized_cells[0]["id"] == "cell-1"
+    assert summarized_cells[0]["cell_type"] == "code"
+    assert summarized_cells[0]["content"].startswith("print('This notebook cell is intentionally long enough")
+    assert summarized_cells[0]["content"].endswith("...")
+    assert "short preview.')" not in summarized_cells[0]["content"]
+    assert summarized_cells[1] == {
+        "index": 1,
+        "id": "cell-2",
+        "cell_type": "markdown",
+        "content": "# Summary",
+    }
+
+    # Index 2 has age 2, so Notebook should remain untouched.
+    newer_content = result[2].get("content")
+    assert isinstance(newer_content, str)
+    assert "preserving a short preview." in newer_content
 
 
 def test_trim_old_messages_handles_mixed_content_messages() -> None:

--- a/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
@@ -8,6 +8,7 @@ from mito_ai_core.utils.trim_message_history import trim_message_content, trim_o
 from unittest.mock import Mock, patch
 from mito_ai_core.completions.message_history import GlobalMessageHistory, ChatThread
 from mito_ai_core.completions.models import ThreadID
+from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
 
 
 # Tests for trim_message_content function
@@ -160,6 +161,31 @@ def test_trim_message_content_handles_empty_content() -> None:
     content = ""
     result = trim_message_content(content, message_age=5)
     assert result == ""
+
+
+def test_trim_message_content_uses_declared_trim_tag_names() -> None:
+    """Test that trimming uses the section's rendered tag name, not its class name."""
+
+    class RuntimeNamedSection(PromptSection):
+        trim_after_messages = 3
+        trim_tag_names = ["Reminder"]
+
+    content = """Before text.
+
+<Reminder>Remember to choose the correct tool to respond with.</Reminder>
+
+After text."""
+
+    with patch(
+        "mito_ai_core.utils.trim_message_history.get_all_section_classes",
+        return_value=[RuntimeNamedSection],
+    ):
+        result = trim_message_content(content, message_age=3)
+
+    assert "<Reminder>" not in result
+    assert "Remember to choose the correct tool" not in result
+    assert "Before text." in result
+    assert "After text." in result
 
 
 def test_trim_message_content_handles_content_without_sections() -> None:

--- a/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
@@ -129,14 +129,14 @@ Text after."""
 
 def test_trim_message_content_preserves_sections_with_none_threshold() -> None:
     """Test that sections with trim_after_messages = None are never trimmed."""
-    # ActiveCellIdSection has trim_after_messages = None
     # TaskSection has trim_after_messages = None
+    # RulesSection has trim_after_messages = None
     
     content = """Some text.
 
-<ActiveCellId>cell1</ActiveCellId>
-
 <Task>Your task: Do something</Task>
+
+<Rules>Always be concise.</Rules>
 
 <Files>file1.csv</Files>
 
@@ -145,11 +145,11 @@ More text."""
     # Test with very high message_age
     result = trim_message_content(content, message_age=100)
     
-    # ActiveCellId and Task should remain (threshold = None)
-    assert "<ActiveCellId>" in result
-    assert "cell1" in result
+    # Task and Rules should remain (threshold = None)
     assert "<Task>" in result
     assert "Your task: Do something" in result
+    assert "<Rules>" in result
+    assert "Always be concise." in result
     
     # Files should be removed (threshold = 3)
     assert "<Files>" not in result
@@ -166,9 +166,14 @@ def test_trim_message_content_handles_empty_content() -> None:
 def test_trim_message_content_uses_declared_trim_tag_names() -> None:
     """Test that trimming uses the section's rendered tag name, not its class name."""
 
-    class RuntimeNamedSection(PromptSection):
-        trim_after_messages = 3
-        trim_tag_names = ["Reminder"]
+    RuntimeNamedSection = type(
+        "RuntimeNamedSection",
+        (),
+        {
+            "trim_after_messages": 3,
+            "get_trim_tag_names": classmethod(lambda cls: ["Reminder"]),
+        },
+    )
 
     content = """Before text.
 
@@ -185,6 +190,41 @@ After text."""
     assert "<Reminder>" not in result
     assert "Remember to choose the correct tool" not in result
     assert "Before text." in result
+    assert "After text." in result
+
+
+def test_trim_message_content_trims_ephemeral_sections_aggressively() -> None:
+    """Test that short-lived execution context is trimmed quickly."""
+
+    content = """Before text.
+
+<Reminder>Remember to choose the correct tool to respond with.</Reminder>
+
+<StreamlitAppStatus>The notebook does not have an existing Streamlit app.</StreamlitAppStatus>
+
+<ActiveCellId>active-cell-123</ActiveCellId>
+
+<SelectedContext>The user selected rows 1-5.</SelectedContext>
+
+<Task>Continue working on the user's task until you have finished</Task>
+
+After text."""
+
+    # At age 1, turn-local reminders/state should be trimmed, but selected context survives
+    result = trim_message_content(content, message_age=1)
+    assert "<Reminder>" not in result
+    assert "<StreamlitAppStatus>" not in result
+    assert "<ActiveCellId>" not in result
+    assert "<SelectedContext>" in result
+    assert "<Task>" in result
+
+    # At age 2, selected context should also be trimmed
+    result = trim_message_content(content, message_age=2)
+    assert "<Reminder>" not in result
+    assert "<StreamlitAppStatus>" not in result
+    assert "<ActiveCellId>" not in result
+    assert "<SelectedContext>" not in result
+    assert "<Task>" in result
     assert "After text." in result
 
 

--- a/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/message_history/test_message_history_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import json
 import pytest
 from typing import List, cast
 from openai.types.chat import ChatCompletionMessageParam
@@ -228,6 +229,49 @@ After text."""
     assert "After text." in result
 
 
+def test_trim_message_content_summarizes_variables_before_removing_them() -> None:
+    """Test that older Variables sections keep names/types and cheap scalar values."""
+    content = """Before text.
+
+<Variables>
+[
+  {"name": "df", "type": "pd.DataFrame", "value": {"rows": 10}},
+  {"name": "threshold", "type": "int", "value": 5},
+  {"name": "flag", "type": "bool", "value": true},
+  {"name": "optional", "type": "NoneType", "value": null},
+  {"name": "label", "type": "str", "value": "short label"},
+  {"name": "module", "type": "module", "value": "<module 'pandas' from '/tmp/pandas.py'>"},
+  {"name": "long_text", "type": "str", "value": "This string is intentionally long enough to be dropped from the summarized variables payload."}
+]
+</Variables>
+
+After text."""
+
+    # Fresh messages keep the full variables payload
+    result = trim_message_content(content, message_age=2)
+    variables_payload = result.split("<Variables>", 1)[1].split("</Variables>", 1)[0].strip()
+    assert json.loads(variables_payload)[0]["value"] == {"rows": 10}
+
+    # Older messages summarize bulky values but preserve cheap scalars
+    result = trim_message_content(content, message_age=3)
+    assert "<Variables>" in result
+    variables_payload = result.split("<Variables>", 1)[1].split("</Variables>", 1)[0].strip()
+    assert json.loads(variables_payload) == [
+        {"name": "df", "type": "pd.DataFrame"},
+        {"name": "threshold", "type": "int", "value": 5},
+        {"name": "flag", "type": "bool", "value": True},
+        {"name": "optional", "type": "NoneType", "value": None},
+        {"name": "label", "type": "str", "value": "short label"},
+        {"name": "module", "type": "module"},
+        {"name": "long_text", "type": "str"},
+    ]
+
+    # Very old messages still drop the Variables section entirely
+    result = trim_message_content(content, message_age=6)
+    assert "<Variables>" not in result
+    assert "threshold" not in result
+
+
 def test_trim_message_content_handles_content_without_sections() -> None:
     """Test that trimming preserves content without XML sections."""
     content = "This is a simple message with no sections to trim."
@@ -360,6 +404,45 @@ file2.txt</Files>
     assert isinstance(assistant_content, str)
     assert assistant_content == assistant_message_with_sections
     assert "<Files>" in assistant_content
+
+
+def test_trim_old_messages_summarizes_json_variables_before_final_trim() -> None:
+    """Test the end-to-end history path for summarized Variables sections."""
+    variables_content = """<Variables>
+[
+  {"name": "df", "type": "pd.DataFrame", "value": {"rows": 10}},
+  {"name": "threshold", "type": "int", "value": 5}
+]
+</Variables>"""
+
+    messages: List[ChatCompletionMessageParam] = [
+        {"role": "user", "content": variables_content},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": variables_content},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "most recent"},
+    ]
+
+    result = trim_old_messages(messages)
+
+    # Index 0 has age 4, so Variables should be summarized, not removed.
+    oldest_content = result[0].get("content")
+    assert isinstance(oldest_content, str)
+    assert "<Variables>" in oldest_content
+    oldest_payload = oldest_content.split("<Variables>", 1)[1].split("</Variables>", 1)[0].strip()
+    assert json.loads(oldest_payload) == [
+        {"name": "df", "type": "pd.DataFrame"},
+        {"name": "threshold", "type": "int", "value": 5},
+    ]
+
+    # Index 2 has age 2, so Variables should remain untouched.
+    newer_content = result[2].get("content")
+    assert isinstance(newer_content, str)
+    newer_payload = newer_content.split("<Variables>", 1)[1].split("</Variables>", 1)[0].strip()
+    assert json.loads(newer_payload) == [
+        {"name": "df", "type": "pd.DataFrame", "value": {"rows": 10}},
+        {"name": "threshold", "type": "int", "value": 5},
+    ]
 
 
 def test_trim_old_messages_handles_mixed_content_messages() -> None:

--- a/mito-ai-core/mito_ai_core/utils/trim_message_history.py
+++ b/mito-ai-core/mito_ai_core/utils/trim_message_history.py
@@ -21,6 +21,9 @@ from mito_ai_core.completions.prompt_builders.prompt_section_registry import (
 
 VARIABLES_SUMMARY_AFTER_MESSAGES = 3
 VARIABLES_SHORT_STRING_LIMIT = 80
+NOTEBOOK_SUMMARY_AFTER_MESSAGES = 3
+NOTEBOOK_CONTENT_PREVIEW_LIMIT = 120
+NOTEBOOK_PREFIX_SEPARATOR = "\n\n"
 
 
 def build_section_to_trim_message_index_mapping() -> Dict[str, Optional[int]]:
@@ -108,6 +111,92 @@ def _summarize_variables_sections(
     return content
 
 
+def _summarize_notebook_cell_content(cell_content: Any) -> Any:
+    """Return a compact preview of cell content for older notebook snapshots."""
+    if not isinstance(cell_content, str):
+        return cell_content
+
+    stripped_content = cell_content.strip()
+    if stripped_content == "":
+        return stripped_content
+
+    if len(stripped_content) <= NOTEBOOK_CONTENT_PREVIEW_LIMIT:
+        return stripped_content
+
+    return stripped_content[:NOTEBOOK_CONTENT_PREVIEW_LIMIT] + "..."
+
+
+def _summarize_notebook_payload(notebook_payload: str) -> Optional[str]:
+    """Summarize a serialized Notebook payload while preserving structure."""
+    notebook_prefix = ""
+    notebook_json_payload = notebook_payload.strip()
+
+    if NOTEBOOK_PREFIX_SEPARATOR in notebook_payload:
+        notebook_prefix, notebook_json_payload = notebook_payload.split(
+            NOTEBOOK_PREFIX_SEPARATOR,
+            1,
+        )
+        notebook_prefix = notebook_prefix.strip()
+        notebook_json_payload = notebook_json_payload.strip()
+
+    try:
+        parsed_payload = json.loads(notebook_json_payload)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed_payload, list):
+        return None
+
+    summarized_cells = []
+    for cell in parsed_payload:
+        if not isinstance(cell, dict):
+            return None
+
+        summarized_cells.append(
+            {
+                "index": cell.get("index"),
+                "id": cell.get("id"),
+                "cell_type": cell.get("cell_type"),
+                "content": _summarize_notebook_cell_content(cell.get("content", "")),
+            }
+        )
+
+    summarized_json = json.dumps(summarized_cells, indent=2)
+    if notebook_prefix == "":
+        return summarized_json
+
+    return f"{notebook_prefix}{NOTEBOOK_PREFIX_SEPARATOR}{summarized_json}"
+
+
+def _summarize_notebook_sections(
+    content: str,
+    message_age: int,
+    notebook_threshold: Optional[int],
+) -> str:
+    """Rewrite older Notebook sections into a lightweight summary."""
+    if notebook_threshold is None:
+        return content
+
+    if (
+        message_age < NOTEBOOK_SUMMARY_AFTER_MESSAGES
+        or message_age >= notebook_threshold
+    ):
+        return content
+
+    pattern = r"<Notebook>(.*?)</Notebook>"
+    matches = list(re.finditer(pattern, content, flags=re.DOTALL))
+
+    for match in reversed(matches):
+        summarized_payload = _summarize_notebook_payload(match.group(1).strip())
+        if summarized_payload is None:
+            continue
+
+        replacement = f"<Notebook>\n{summarized_payload}\n</Notebook>"
+        content = content[:match.start()] + replacement + content[match.end():]
+
+    return content
+
+
 def trim_message_content(content: str, message_age: int) -> str:
     """
     Trims sections from XML string based on age and thresholds.
@@ -136,6 +225,11 @@ def trim_message_content(content: str, message_age: int) -> str:
         content,
         message_age,
         section_mapping.get("Variables"),
+    )
+    content = _summarize_notebook_sections(
+        content,
+        message_age,
+        section_mapping.get("Notebook"),
     )
 
     # For other sections, parse and trim based on section_mapping

--- a/mito-ai-core/mito_ai_core/utils/trim_message_history.py
+++ b/mito-ai-core/mito_ai_core/utils/trim_message_history.py
@@ -23,8 +23,8 @@ def build_section_to_trim_message_index_mapping() -> Dict[str, Optional[int]]:
     """Build mapping from section names to trim_after_messages thresholds."""
     mapping = {}
     for section_class in get_all_section_classes():
-        section_name = section_class.__name__.replace("Section", "")
-        mapping[section_name] = section_class.trim_after_messages
+        for section_name in section_class.get_trim_tag_names():
+            mapping[section_name] = section_class.trim_after_messages
     return mapping
 
 

--- a/mito-ai-core/mito_ai_core/utils/trim_message_history.py
+++ b/mito-ai-core/mito_ai_core/utils/trim_message_history.py
@@ -9,14 +9,18 @@ import these helpers without a circular import (the utils module imports
 ``GlobalMessageHistory`` for ``append_agent_system_message``).
 """
 
+import json
 import re
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from openai.types.chat import ChatCompletionMessageParam
 
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import (
     get_all_section_classes,
 )
+
+VARIABLES_SUMMARY_AFTER_MESSAGES = 3
+VARIABLES_SHORT_STRING_LIMIT = 80
 
 
 def build_section_to_trim_message_index_mapping() -> Dict[str, Optional[int]]:
@@ -26,6 +30,82 @@ def build_section_to_trim_message_index_mapping() -> Dict[str, Optional[int]]:
         for section_name in section_class.get_trim_tag_names():
             mapping[section_name] = section_class.trim_after_messages
     return mapping
+
+
+def _should_keep_variable_value(value: Any) -> bool:
+    """Keep only cheap, high-signal variable values in summarized history."""
+    if value is None:
+        return True
+
+    if isinstance(value, (bool, int, float)):
+        return True
+
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        return (
+            len(stripped_value) <= VARIABLES_SHORT_STRING_LIMIT
+            and not stripped_value.startswith("<module ")
+        )
+
+    return False
+
+
+def _summarize_variables_payload(variables_payload: str) -> Optional[str]:
+    """Summarize a serialized Variables payload while preserving useful scalars."""
+    try:
+        parsed_payload = json.loads(variables_payload)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed_payload, list):
+        return None
+
+    summarized_variables = []
+    for variable in parsed_payload:
+        if not isinstance(variable, dict):
+            return None
+
+        summarized_variable = {
+            "name": variable.get("name"),
+            "type": variable.get("type"),
+        }
+
+        value = variable.get("value")
+        if _should_keep_variable_value(value):
+            summarized_variable["value"] = value
+
+        summarized_variables.append(summarized_variable)
+
+    return json.dumps(summarized_variables, indent=2)
+
+
+def _summarize_variables_sections(
+    content: str,
+    message_age: int,
+    variables_threshold: Optional[int],
+) -> str:
+    """Rewrite older Variables sections into a lightweight summary."""
+    if variables_threshold is None:
+        return content
+
+    if (
+        message_age < VARIABLES_SUMMARY_AFTER_MESSAGES
+        or message_age >= variables_threshold
+    ):
+        return content
+
+    pattern = r"<Variables>(.*?)</Variables>"
+    matches = list(re.finditer(pattern, content, flags=re.DOTALL))
+
+    for match in reversed(matches):
+        summarized_payload = _summarize_variables_payload(match.group(1).strip())
+        if summarized_payload is None:
+            continue
+
+        replacement = f"<Variables>\n{summarized_payload}\n</Variables>"
+        content = content[:match.start()] + replacement + content[match.end():]
+
+    return content
 
 
 def trim_message_content(content: str, message_age: int) -> str:
@@ -51,6 +131,12 @@ def trim_message_content(content: str, message_age: int) -> str:
         if example_threshold is not None and message_age >= example_threshold:
             # Remove the entire Example block
             content = content[:match.start()] + content[match.end():]
+
+    content = _summarize_variables_sections(
+        content,
+        message_age,
+        section_mapping.get("Variables"),
+    )
 
     # For other sections, parse and trim based on section_mapping
     # Match XML tags like <SectionName>...</SectionName>


### PR DESCRIPTION
# Description

- Made history compaction tag-name aware instead of relying only on section class names, so trimming can target the actual serialized XML tags in stored messages.
- `Reminder` now trims after 1 message.
- `ActiveCellId` now trims after 1 message
- `StreamlitAppStatus` now trims after 1 message
- `SelectedContext` now trims after 2 messages

- Added a staged compaction tier for `Variables` in message history:
  - ages 0-2: keep full payload
  - ages 3-5: summarize to name, type, and only cheap/high-signal scalar values
  - ages 6+: remove the Variables section entirely

- Added a staged compaction tier for `Notebook` in message history:
  - ages 0-2: keep full notebook snapshot
  - ages 3-5: summarize each cell to index, id, cell_type, and a short truncated content preview
  - ages 6+: remove the Notebook section entirely

# Testing

Create a notebook and open a dataset with lots of columns, this is the easiest way to trigger the variable compaction. Send a few messages, and use the Streamlit _Chat History Viewer_ app to inspect the user messages. 

Smaller notebooks, and variables below the minimum threshold should be unaffected. Only users working with very large datasets should be affected. 

# Documentation

N/A -- Behind the scenes change. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what the model sees in long conversations (trim thresholds and summarized Variables/Notebook), which can affect multi-turn agent behavior even though logic is well-tested.
> 
> **Overview**
> Improves **agent chat history compaction** so long threads keep useful context with fewer tokens.
> 
> **Turn-local context** drops from history sooner: new `ReminderSection` (via `SG.Reminder`), and tighter `trim_after_messages` on `ActiveCellId`, `StreamlitAppStatus`, and `SelectedContext` (selected UI context now lasts ~2 turns instead of never trimming).
> 
> **Trimming by XML tag name**: `PromptSection.get_trim_tag_names()` drives the section→threshold map so history trimming matches rendered tags (e.g. `Reminder`), not only class names.
> 
> **Gradual compaction** for heavy sections before full removal: older `Variables` payloads keep names, types, and small scalars while dropping large values; older `Notebook` sections keep cell structure with truncated cell bodies. Full section removal still happens at the existing thresholds.
> 
> Tests cover tag-based trimming, ephemeral sections, summarization, and end-to-end `trim_old_messages` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a7ba9c49a58fe49a5c50803c959e04868fce8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->