### PR TITLE
Added Skills - Excel to Python 

### DIFF
--- a/mito-ai-core/mito_ai_core/agent/agent_runner.py
+++ b/mito-ai-core/mito_ai_core/agent/agent_runner.py
@@ -60,6 +60,7 @@ class AgentRunner:
             "create_streamlit_app",
             "edit_streamlit_app",
             "mcp_tool_call",
+            "read_skill",
         }
     )
 
@@ -226,6 +227,7 @@ class AgentRunner:
                 scratchpad_code=None,
                 scratchpad_summary=None,
                 mcp_tool_call=None,
+                skill_name=None,
             )
         return AgentRunResult(
             final_response=last_response,
@@ -362,6 +364,19 @@ class AgentRunner:
                 response.mcp_tool_call.mcp_server_id,
                 response.mcp_tool_call.tool_name,
                 loaded,
+                response.message,
+            )
+
+        if rtype == "read_skill":
+            if response.skill_name is None or not response.skill_name.strip():
+                return ToolResult(
+                    success=False,
+                    tool_name=rtype,
+                    error_message="Agent returned read_skill but skill_name is null or empty.",
+                )
+            return await self._tool_executor.read_skill(
+                ctx,
+                response.skill_name.strip(),
                 response.message,
             )
 

--- a/mito-ai-core/mito_ai_core/agent/tool_executor.py
+++ b/mito-ai-core/mito_ai_core/agent/tool_executor.py
@@ -201,7 +201,7 @@ class ToolExecutor(Protocol):
         ctx:
             Current agent context.
         skill_name:
-            Skill identifier (matches a ``.md`` file in bundled or user skills).
+            Skill identifier (matches a ``.py`` skill module in package or user skills).
         message:
             Agent's reasoning for loading this skill.
         """

--- a/mito-ai-core/mito_ai_core/agent/tool_executor.py
+++ b/mito-ai-core/mito_ai_core/agent/tool_executor.py
@@ -188,6 +188,25 @@ class ToolExecutor(Protocol):
         """
         ...
 
+    async def read_skill(
+        self,
+        ctx: AgentContext,
+        skill_name: str,
+        message: str,
+    ) -> ToolResult:
+        """Load a skill document by name.
+
+        Parameters
+        ----------
+        ctx:
+            Current agent context.
+        skill_name:
+            Skill identifier (matches a ``.md`` file in bundled or user skills).
+        message:
+            Agent's reasoning for loading this skill.
+        """
+        ...
+
     async def execute_mcp_tool(
         self,
         ctx: AgentContext,

--- a/mito-ai-core/mito_ai_core/agent/tool_executor.py
+++ b/mito-ai-core/mito_ai_core/agent/tool_executor.py
@@ -201,7 +201,7 @@ class ToolExecutor(Protocol):
         ctx:
             Current agent context.
         skill_name:
-            Skill identifier (matches a ``.py`` skill module in package or user skills).
+            Skill identifier for a registered skill (see Available Skills in the system prompt).
         message:
             Agent's reasoning for loading this skill.
         """

--- a/mito-ai-core/mito_ai_core/agent/utils.py
+++ b/mito-ai-core/mito_ai_core/agent/utils.py
@@ -27,6 +27,7 @@ _OPTIONAL_RESPONSE_FIELDS = (
     "scratchpad_code",
     "scratchpad_summary",
     "mcp_tool_call",
+    "skill_name",
 )
 
 

--- a/mito-ai-core/mito_ai_core/completions/models.py
+++ b/mito-ai-core/mito_ai_core/completions/models.py
@@ -63,6 +63,7 @@ class AgentResponse(BaseModel):
         'ask_user_question', 
         'scratchpad',
         'mcp_tool_call',
+        'read_skill',
     ]
     message: str
     cell_update: Optional[CellUpdate]
@@ -75,6 +76,7 @@ class AgentResponse(BaseModel):
     scratchpad_code: Optional[str]
     scratchpad_summary: Optional[str]
     mcp_tool_call: Optional[MCPToolCall]
+    skill_name: Optional[str]
     
     
 @dataclass(frozen=True)

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -10,7 +10,6 @@ from mito_ai_core.completions.prompt_builders.prompt_constants import (
     CHART_CONFIG_RULES,
     CITATION_RULES,
     CELL_REFERENCE_RULES,
-    EXCEL_TO_PYTHON_RULES,
     MARKDOWN_RULES,
     get_database_rules
 )
@@ -110,7 +109,6 @@ You will not always know every key driver up front. Treat the configuration cell
 """))
 
     sections.append(SG.Generic("Chart Config Rules", CHART_CONFIG_RULES))
-    sections.append(SG.Generic("Excel to Python Rules", EXCEL_TO_PYTHON_RULES))
 
     sections.append(SG.Generic("TOOL: CELL_UPDATE", """
 
@@ -403,7 +401,8 @@ Important information:
 1. Only request skills listed in the "Available Skills" section.
 2. The skill_name must exactly match one of the listed skill names.
 3. After reading a skill, follow its instructions for the rest of the task.
-4. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
+4. Call read_skill with skill_name `excel_to_python` when the user asks you to convert, translate, or replicate Excel workbook logic in Python.
+5. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
 """))
 
     # MCP_TOOL_CALL tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -385,8 +385,6 @@ Important information:
 
 """))
 
-    sections.append(SG.Generic("Available Skills", format_available_skills()))
-
     sections.append(SG.Generic("TOOL: READ_SKILL", """
 Load detailed instructions for a specialized task on demand. Use this before work that needs guidance not included in the base prompt (e.g. Excel formula translation, database connections).
 
@@ -403,6 +401,8 @@ Important information:
 3. After reading a skill, follow its instructions for the rest of the task.
 4. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
 """))
+
+    sections.append(SG.Generic("Available Skills", format_available_skills()))
 
     # MCP_TOOL_CALL tool
     sections.append(

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -401,8 +401,7 @@ Important information:
 1. Only request skills listed in the "Available Skills" section.
 2. The skill_name must exactly match one of the listed skill names.
 3. After reading a skill, follow its instructions for the rest of the task.
-4. Call read_skill with skill_name `excel_to_python` when the user asks you to convert, translate, or replicate Excel workbook logic in Python.
-5. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
+4. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
 """))
 
     # MCP_TOOL_CALL tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -4,6 +4,7 @@
 from typing import Any, Dict, List, Optional
 from mito_ai_core.completions.prompt_builders.prompt_section_registry import SG, Prompt
 from mito_ai_core.completions.prompt_builders.mcp_tools import format_available_mcp_tools
+from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 from mito_ai_core.completions.prompt_builders.prompt_constants import (
     ABOUT_MITO,
     CHART_CONFIG_RULES,
@@ -384,6 +385,25 @@ Important information:
     }}
     </Example>
 
+"""))
+
+    sections.append(SG.Generic("Available Skills", format_available_skills()))
+
+    sections.append(SG.Generic("TOOL: READ_SKILL", """
+Load detailed instructions for a specialized task on demand. Use this before work that needs guidance not included in the base prompt (e.g. Excel formula translation, database connections).
+
+Format:
+{{
+    "type": "read_skill",
+    "message": "<string>",
+    "skill_name": "<string>"
+}}
+
+Important information:
+1. Only request skills listed in the "Available Skills" section.
+2. The skill_name must exactly match one of the listed skill names.
+3. After reading a skill, follow its instructions for the rest of the task.
+4. Do not call read_skill for the same skill more than once in a conversation unless the user asks you to reload it.
 """))
 
     # MCP_TOOL_CALL tool

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
@@ -10,7 +10,6 @@ import os
 import json
 from typing import Final
 
-from mito_ai_core.completions.prompt_builders.excel_to_python_rules import EXCEL_TO_PYTHON_RULES
 from mito_ai_core.utils.schema import MITO_FOLDER
 
 CHART_CONFIG_RULES = """

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
@@ -1,13 +1,12 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import List
-
-from mito_ai_core.skills.utils import list_available_skills
+from mito_ai_core.skills.utils import SKILLS
 
 
 def format_available_skills() -> str:
-    skills: List[str] = list_available_skills()
-    if not skills:
+    if not SKILLS:
         return "No skills are currently available."
-    return "\n".join(f"- {name}" for name in skills)
+    return "\n".join(
+        f"- {skill.name}: {skill.description}" for skill in sorted(SKILLS.values(), key=lambda s: s.name)
+    )

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
@@ -1,0 +1,13 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from typing import List
+
+from mito_ai_core.skills.utils import list_available_skills
+
+
+def format_available_skills() -> str:
+    skills: List[str] = list_available_skills()
+    if not skills:
+        return "No skills are currently available."
+    return "\n".join(f"- {name}" for name in skills)

--- a/mito-ai-core/mito_ai_core/skills/__init__.py
+++ b/mito-ai-core/mito_ai_core/skills/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+"""Agent skills — on-demand instruction documents loaded via the read_skill tool."""
+
+from mito_ai_core.skills.utils import (
+    get_skill,
+    list_available_skills,
+    read_skill,
+)
+
+__all__ = [
+    "get_skill",
+    "list_available_skills",
+    "read_skill",
+]

--- a/mito-ai-core/mito_ai_core/skills/__init__.py
+++ b/mito-ai-core/mito_ai_core/skills/__init__.py
@@ -1,15 +1,14 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-"""Agent skills — on-demand instruction documents loaded via the read_skill tool."""
+"""Agent skills — on-demand instructions loaded via the read_skill tool."""
 
-from mito_ai_core.skills.utils import (
-    get_skill,
-    list_available_skills,
-    read_skill,
-)
+from mito_ai_core.skills.types import Skill
+from mito_ai_core.skills.utils import SKILLS, get_skill, list_available_skills, read_skill
 
 __all__ = [
+    "Skill",
+    "SKILLS",
     "get_skill",
     "list_available_skills",
     "read_skill",

--- a/mito-ai-core/mito_ai_core/skills/bundled/excel_to_python.md
+++ b/mito-ai-core/mito_ai_core/skills/bundled/excel_to_python.md
@@ -1,12 +1,5 @@
-# Copyright (c) Saga Inc.
-# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+# Excel to Python Conversion
 
-"""
-Excel-to-Python conversion rules used when converting Excel spreadsheets
-into Jupyter notebooks (e.g. in agent execution prompts).
-"""
-
-EXCEL_TO_PYTHON_RULES = """
 If you've been asked to convert, translate, or replicate the logic of an Excel file into Python, then you should follow these rules.
 
 **Purpose of converting to Python:** The main reason to convert an Excel model to Python is so the user can easily try different input values and run different scenarios. The user should be able to change a few parameters at the top of the notebook, re-run the notebook, and see new results — without hunting through the code. Your output must support this workflow.
@@ -121,4 +114,3 @@ Once every todo item is checked off, rerun the entire notebook from top to botto
 - **Keep working.** Your job is to work through the entire todo list until all asserts pass. Do not stop early.
 - **Use the notebook well.** Markdown cells are your thinking tool. Use them to explain your understanding before writing code. This helps you catch mistakes in understanding before they become mistakes in code.
 - **Be precise with the todo list.** Check off items only after their asserts pass. The todo list is your progress tracker — it should always reflect the true state of your work.
-"""

--- a/mito-ai-core/mito_ai_core/skills/excel_to_python.py
+++ b/mito-ai-core/mito_ai_core/skills/excel_to_python.py
@@ -1,3 +1,7 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+CONTENT = """
 # Excel to Python Conversion
 
 If you've been asked to convert, translate, or replicate the logic of an Excel file into Python, then you should follow these rules.
@@ -114,3 +118,4 @@ Once every todo item is checked off, rerun the entire notebook from top to botto
 - **Keep working.** Your job is to work through the entire todo list until all asserts pass. Do not stop early.
 - **Use the notebook well.** Markdown cells are your thinking tool. Use them to explain your understanding before writing code. This helps you catch mistakes in understanding before they become mistakes in code.
 - **Be precise with the todo list.** Check off items only after their asserts pass. The todo list is your progress tracker — it should always reflect the true state of your work.
+"""

--- a/mito-ai-core/mito_ai_core/skills/excel_to_python.py
+++ b/mito-ai-core/mito_ai_core/skills/excel_to_python.py
@@ -1,6 +1,8 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+from mito_ai_core.skills.types import Skill
+
 CONTENT = """
 # Excel to Python Conversion
 
@@ -119,3 +121,13 @@ Once every todo item is checked off, rerun the entire notebook from top to botto
 - **Use the notebook well.** Markdown cells are your thinking tool. Use them to explain your understanding before writing code. This helps you catch mistakes in understanding before they become mistakes in code.
 - **Be precise with the todo list.** Check off items only after their asserts pass. The todo list is your progress tracker — it should always reflect the true state of your work.
 """
+
+
+class ExcelToPythonSkill(Skill):
+    name = "excel_to_python"
+    description = (
+        "Convert Excel workbook logic into an interactive, test-driven Jupyter notebook."
+    )
+
+    def get_content(self) -> str:
+        return CONTENT

--- a/mito-ai-core/mito_ai_core/skills/types.py
+++ b/mito-ai-core/mito_ai_core/skills/types.py
@@ -1,0 +1,14 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+
+class Skill(ABC):
+    name: ClassVar[str]
+    description: ClassVar[str]
+
+    @abstractmethod
+    def get_content(self) -> str:
+        """Return the skill instructions for the agent."""

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -1,21 +1,27 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import importlib.util
 import os
+from types import ModuleType
 from typing import Final, List, Optional
 
 from mito_ai_core.agent.types import ToolResult
 from mito_ai_core.utils.schema import MITO_FOLDER
 
-BUNDLED_SKILLS_DIR: Final[str] = os.path.join(os.path.dirname(__file__), "bundled")
+SKILLS_DIR: Final[str] = os.path.dirname(__file__)
 USER_SKILLS_DIR: Final[str] = os.path.join(MITO_FOLDER, "skills")
+SKILL_CONTENT_ATTR: Final[str] = "CONTENT"
+_EXCLUDED_SKILL_MODULES: Final[frozenset[str]] = frozenset({"utils", "__init__"})
 
 
 def _sanitize_skill_name(skill_name: str) -> str:
     if not skill_name:
         raise ValueError("Skill name cannot be empty")
 
-    if skill_name.endswith(".md"):
+    if skill_name.endswith(".py"):
+        skill_name = skill_name[:-3]
+    elif skill_name.endswith(".md"):
         skill_name = skill_name[:-3]
 
     if ".." in skill_name or "/" in skill_name or "\\" in skill_name:
@@ -36,10 +42,10 @@ def _sanitize_skill_name(skill_name: str) -> str:
 
 def _validate_skill_path(file_path: str, skill_name: str) -> None:
     resolved_path = os.path.abspath(file_path)
-    bundled_dir_abs = os.path.abspath(BUNDLED_SKILLS_DIR)
+    skills_dir_abs = os.path.abspath(SKILLS_DIR)
     user_dir_abs = os.path.abspath(USER_SKILLS_DIR)
     if not (
-        resolved_path.startswith(bundled_dir_abs)
+        resolved_path.startswith(skills_dir_abs)
         or resolved_path.startswith(user_dir_abs)
     ):
         raise ValueError(f"Invalid skill name: {skill_name}")
@@ -52,36 +58,55 @@ def _list_skills_in_dir(directory: str) -> List[str]:
         return [
             f[:-3]
             for f in os.listdir(directory)
-            if f.endswith(".md") and not f.startswith(".")
+            if f.endswith(".py")
+            and not f.startswith(".")
+            and f[:-3] not in _EXCLUDED_SKILL_MODULES
         ]
     except OSError:
         return []
 
 
+def _load_content_from_module(module: ModuleType) -> Optional[str]:
+    content = getattr(module, SKILL_CONTENT_ATTR, None)
+    if content is None or not isinstance(content, str):
+        return None
+    return content
+
+
+def _load_skill_from_path(path: str) -> Optional[str]:
+    if not os.path.exists(path):
+        return None
+
+    module_name = f"mito_skill_{os.path.basename(path)[:-3]}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return _load_content_from_module(module)
+
+
 def list_available_skills() -> List[str]:
-    """Return sorted skill names from bundled and user skill directories."""
-    names = set(_list_skills_in_dir(BUNDLED_SKILLS_DIR))
+    """Return sorted skill names from package and user skill directories."""
+    names = set(_list_skills_in_dir(SKILLS_DIR))
     names.update(_list_skills_in_dir(USER_SKILLS_DIR))
     return sorted(names)
 
 
 def get_skill(skill_name: str) -> Optional[str]:
-    """Load a skill by name. User skills override bundled skills."""
+    """Load a skill by name. User skills override package skills."""
     skill_name = _sanitize_skill_name(skill_name)
 
-    user_path = os.path.join(USER_SKILLS_DIR, f"{skill_name}.md")
+    user_path = os.path.join(USER_SKILLS_DIR, f"{skill_name}.py")
     _validate_skill_path(user_path, skill_name)
-    if os.path.exists(user_path):
-        with open(user_path, "r") as f:
-            return f.read()
+    user_content = _load_skill_from_path(user_path)
+    if user_content is not None:
+        return user_content
 
-    bundled_path = os.path.join(BUNDLED_SKILLS_DIR, f"{skill_name}.md")
-    _validate_skill_path(bundled_path, skill_name)
-    if os.path.exists(bundled_path):
-        with open(bundled_path, "r") as f:
-            return f.read()
-
-    return None
+    skill_path = os.path.join(SKILLS_DIR, f"{skill_name}.py")
+    _validate_skill_path(skill_path, skill_name)
+    return _load_skill_from_path(skill_path)
 
 
 def read_skill(skill_name: str) -> ToolResult:

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -1,127 +1,42 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-import importlib.util
-import os
-from types import ModuleType
-from typing import Final, List, Optional
+from typing import Dict, List, Optional
 
 from mito_ai_core.agent.types import ToolResult
-from mito_ai_core.utils.schema import MITO_FOLDER
+from mito_ai_core.skills.excel_to_python import ExcelToPythonSkill
+from mito_ai_core.skills.types import Skill
 
-SKILLS_DIR: Final[str] = os.path.dirname(__file__)
-USER_SKILLS_DIR: Final[str] = os.path.join(MITO_FOLDER, "skills")
-SKILL_CONTENT_ATTR: Final[str] = "CONTENT"
-_EXCLUDED_SKILL_MODULES: Final[frozenset[str]] = frozenset({"utils", "__init__"})
-
-
-def _sanitize_skill_name(skill_name: str) -> str:
-    if not skill_name:
-        raise ValueError("Skill name cannot be empty")
-
-    if skill_name.endswith(".py"):
-        skill_name = skill_name[:-3]
-    elif skill_name.endswith(".md"):
-        skill_name = skill_name[:-3]
-
-    if ".." in skill_name or "/" in skill_name or "\\" in skill_name:
-        raise ValueError(f"Skill name contains invalid characters: {skill_name}")
-
-    if os.path.isabs(skill_name):
-        raise ValueError(f"Skill name cannot be an absolute path: {skill_name}")
-
-    if "\x00" in skill_name:
-        raise ValueError("Skill name cannot contain null bytes")
-
-    invalid_chars = set("<>:|?*\"")
-    if any(c in skill_name for c in invalid_chars):
-        raise ValueError(f"Skill name contains invalid filename characters: {skill_name}")
-
-    return skill_name
-
-
-def _validate_skill_path(file_path: str, skill_name: str) -> None:
-    resolved_path = os.path.abspath(file_path)
-    skills_dir_abs = os.path.abspath(SKILLS_DIR)
-    user_dir_abs = os.path.abspath(USER_SKILLS_DIR)
-    if not (
-        resolved_path.startswith(skills_dir_abs)
-        or resolved_path.startswith(user_dir_abs)
-    ):
-        raise ValueError(f"Invalid skill name: {skill_name}")
-
-
-def _list_skills_in_dir(directory: str) -> List[str]:
-    if not os.path.exists(directory):
-        return []
-    try:
-        return [
-            f[:-3]
-            for f in os.listdir(directory)
-            if f.endswith(".py")
-            and not f.startswith(".")
-            and f[:-3] not in _EXCLUDED_SKILL_MODULES
-        ]
-    except OSError:
-        return []
-
-
-def _load_content_from_module(module: ModuleType) -> Optional[str]:
-    content = getattr(module, SKILL_CONTENT_ATTR, None)
-    if content is None or not isinstance(content, str):
-        return None
-    return content
-
-
-def _load_skill_from_path(path: str) -> Optional[str]:
-    if not os.path.exists(path):
-        return None
-
-    module_name = f"mito_skill_{os.path.basename(path)[:-3]}"
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None or spec.loader is None:
-        return None
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return _load_content_from_module(module)
+SKILLS: Dict[str, Skill] = {
+    ExcelToPythonSkill.name: ExcelToPythonSkill(),
+}
 
 
 def list_available_skills() -> List[str]:
-    """Return sorted skill names from package and user skill directories."""
-    names = set(_list_skills_in_dir(SKILLS_DIR))
-    names.update(_list_skills_in_dir(USER_SKILLS_DIR))
-    return sorted(names)
+    """Return sorted registered skill names."""
+    return sorted(SKILLS.keys())
 
 
 def get_skill(skill_name: str) -> Optional[str]:
-    """Load a skill by name. User skills override package skills."""
-    skill_name = _sanitize_skill_name(skill_name)
-
-    user_path = os.path.join(USER_SKILLS_DIR, f"{skill_name}.py")
-    _validate_skill_path(user_path, skill_name)
-    user_content = _load_skill_from_path(user_path)
-    if user_content is not None:
-        return user_content
-
-    skill_path = os.path.join(SKILLS_DIR, f"{skill_name}.py")
-    _validate_skill_path(skill_path, skill_name)
-    return _load_skill_from_path(skill_path)
+    """Return skill content by name, or None if not registered."""
+    skill = SKILLS.get(skill_name)
+    if skill is None:
+        return None
+    return skill.get_content()
 
 
 def read_skill(skill_name: str) -> ToolResult:
-    """Load a skill document and return it as a tool result."""
-    try:
-        sanitized_name = _sanitize_skill_name(skill_name)
-    except ValueError as e:
+    """Load a skill and return it as a tool result."""
+    if not skill_name or not skill_name.strip():
         return ToolResult(
             success=False,
             tool_name="read_skill",
-            error_message=str(e),
+            error_message="Skill name cannot be empty.",
         )
 
-    content = get_skill(sanitized_name)
-    if content is None:
+    sanitized_name = skill_name.strip()
+    skill = SKILLS.get(sanitized_name)
+    if skill is None:
         available = list_available_skills()
         available_text = ", ".join(available) if available else "(none)"
         return ToolResult(
@@ -136,5 +51,5 @@ def read_skill(skill_name: str) -> ToolResult:
     return ToolResult(
         success=True,
         tool_name="read_skill",
-        output=f"Skill: {sanitized_name}\n\n{content}",
+        output=f"Skill: {sanitized_name}\n\n{skill.get_content()}",
     )

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -1,0 +1,115 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import os
+from typing import Final, List, Optional
+
+from mito_ai_core.agent.types import ToolResult
+from mito_ai_core.utils.schema import MITO_FOLDER
+
+BUNDLED_SKILLS_DIR: Final[str] = os.path.join(os.path.dirname(__file__), "bundled")
+USER_SKILLS_DIR: Final[str] = os.path.join(MITO_FOLDER, "skills")
+
+
+def _sanitize_skill_name(skill_name: str) -> str:
+    if not skill_name:
+        raise ValueError("Skill name cannot be empty")
+
+    if skill_name.endswith(".md"):
+        skill_name = skill_name[:-3]
+
+    if ".." in skill_name or "/" in skill_name or "\\" in skill_name:
+        raise ValueError(f"Skill name contains invalid characters: {skill_name}")
+
+    if os.path.isabs(skill_name):
+        raise ValueError(f"Skill name cannot be an absolute path: {skill_name}")
+
+    if "\x00" in skill_name:
+        raise ValueError("Skill name cannot contain null bytes")
+
+    invalid_chars = set("<>:|?*\"")
+    if any(c in skill_name for c in invalid_chars):
+        raise ValueError(f"Skill name contains invalid filename characters: {skill_name}")
+
+    return skill_name
+
+
+def _validate_skill_path(file_path: str, skill_name: str) -> None:
+    resolved_path = os.path.abspath(file_path)
+    bundled_dir_abs = os.path.abspath(BUNDLED_SKILLS_DIR)
+    user_dir_abs = os.path.abspath(USER_SKILLS_DIR)
+    if not (
+        resolved_path.startswith(bundled_dir_abs)
+        or resolved_path.startswith(user_dir_abs)
+    ):
+        raise ValueError(f"Invalid skill name: {skill_name}")
+
+
+def _list_skills_in_dir(directory: str) -> List[str]:
+    if not os.path.exists(directory):
+        return []
+    try:
+        return [
+            f[:-3]
+            for f in os.listdir(directory)
+            if f.endswith(".md") and not f.startswith(".")
+        ]
+    except OSError:
+        return []
+
+
+def list_available_skills() -> List[str]:
+    """Return sorted skill names from bundled and user skill directories."""
+    names = set(_list_skills_in_dir(BUNDLED_SKILLS_DIR))
+    names.update(_list_skills_in_dir(USER_SKILLS_DIR))
+    return sorted(names)
+
+
+def get_skill(skill_name: str) -> Optional[str]:
+    """Load a skill by name. User skills override bundled skills."""
+    skill_name = _sanitize_skill_name(skill_name)
+
+    user_path = os.path.join(USER_SKILLS_DIR, f"{skill_name}.md")
+    _validate_skill_path(user_path, skill_name)
+    if os.path.exists(user_path):
+        with open(user_path, "r") as f:
+            return f.read()
+
+    bundled_path = os.path.join(BUNDLED_SKILLS_DIR, f"{skill_name}.md")
+    _validate_skill_path(bundled_path, skill_name)
+    if os.path.exists(bundled_path):
+        with open(bundled_path, "r") as f:
+            return f.read()
+
+    return None
+
+
+def read_skill(skill_name: str) -> ToolResult:
+    """Load a skill document and return it as a tool result."""
+    try:
+        sanitized_name = _sanitize_skill_name(skill_name)
+    except ValueError as e:
+        return ToolResult(
+            success=False,
+            tool_name="read_skill",
+            error_message=str(e),
+        )
+
+    content = get_skill(sanitized_name)
+    if content is None:
+        available = list_available_skills()
+        available_text = ", ".join(available) if available else "(none)"
+        return ToolResult(
+            success=False,
+            tool_name="read_skill",
+            error_message=(
+                f"Skill '{sanitized_name}' not found. "
+                f"Available skills: {available_text}"
+            ),
+        )
+
+    return ToolResult(
+        success=True,
+        tool_name="read_skill",
+        output=f"Skill: {sanitized_name}\n\n{content}",
+    )

--- a/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
@@ -197,6 +197,23 @@ class FakeToolExecutor:
         }))
         return ToolResult(success=True, output="MCP tool executed")
 
+    async def read_skill(
+        self,
+        ctx: AgentContext,
+        skill_name: str,
+        message: str,
+    ) -> ToolResult:
+        self.calls.append(("read_skill", {
+            "ctx": ctx,
+            "skill_name": skill_name,
+            "message": message,
+        }))
+        return ToolResult(
+            success=True,
+            tool_name="read_skill",
+            output=f"Skill: {skill_name}\n\nmock skill content",
+        )
+
 
 class FailingCellUpdateToolExecutor(FakeToolExecutor):
     """Tool executor that always fails CELL_UPDATE dispatch."""
@@ -259,6 +276,7 @@ def _agent_response_json(
         "answers": None,
         "scratchpad_code": None,
         "scratchpad_summary": None,
+        "skill_name": None,
     }
     data.update(extra)
     return json.dumps(data)
@@ -451,6 +469,26 @@ class TestToolDispatch:
 
         assert result.finished is True
         assert executor.calls[0][0] == "execute_scratchpad"
+
+    @pytest.mark.asyncio
+    async def test_read_skill_dispatched(self) -> None:
+        provider = FakeProviderManager([
+            _agent_response_json(
+                "read_skill",
+                message="Loading Excel guidance.",
+                skill_name="excel_to_python",
+            ),
+            _finished_response(),
+        ])
+        executor = FakeToolExecutor()
+        mh, ctx = _new_history_and_ctx()
+        runner = AgentRunner(provider, executor, mh)  # type: ignore[arg-type]
+
+        result = await runner.run(ctx, "")
+
+        assert result.finished is True
+        assert executor.calls[0][0] == "read_skill"
+        assert executor.calls[0][1]["skill_name"] == "excel_to_python"
 
     @pytest.mark.asyncio
     async def test_ask_user_question_dispatched(self) -> None:

--- a/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
@@ -145,6 +145,23 @@ class FakeToolExecutor:
         }))
         return ToolResult(success=True, output="MCP tool executed")
 
+    async def read_skill(
+        self,
+        ctx: AgentContext,
+        skill_name: str,
+        message: str,
+    ) -> ToolResult:
+        self.calls.append(("read_skill", {
+            "ctx": ctx,
+            "skill_name": skill_name,
+            "message": message,
+        }))
+        return ToolResult(
+            success=True,
+            tool_name="read_skill",
+            output=f"Skill: {skill_name}\n\nmock skill content",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -320,6 +337,23 @@ class TestExecuteMcpTool:
         assert executor.calls[0][1]["mcp_server_id"] == "server-1"
         assert executor.calls[0][1]["tool_name"] == "search_docs"
         assert executor.calls[0][1]["arguments"] == {"query": "pandas read_csv"}
+
+
+class TestExecuteReadSkill:
+    @pytest.mark.asyncio
+    async def test_returns_skill_content(self) -> None:
+        executor = FakeToolExecutor()
+        ctx = _make_ctx()
+        result = await executor.read_skill(
+            ctx,
+            skill_name="excel_to_python",
+            message="Need Excel translation rules.",
+        )
+
+        assert result.success
+        assert result.tool_name == "read_skill"
+        assert "excel_to_python" in (result.output or "")
+        assert executor.calls[0][0] == "read_skill"
 
 
 class TestAgentContext:

--- a/mito-ai-core/mito_ai_core/tests/skills/__init__.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -55,6 +55,15 @@ class TestReadSkill:
         assert result.tool_name == "read_skill"
         assert "Markdown" in (result.output or "")
 
+    def test_bundled_excel_to_python_skill(self) -> None:
+        assert "excel_to_python" in list_available_skills()
+        content = get_skill("excel_to_python")
+        assert content is not None
+        assert "Configuration cell" in content
+        result = read_skill("excel_to_python")
+        assert result.success
+        assert "mito_check_" in (result.output or "")
+
     def test_returns_error_for_missing_skill(self, skills_dirs) -> None:
         result = read_skill("does_not_exist")
         assert not result.success

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -3,76 +3,67 @@
 
 import pytest
 
-from mito_ai_core.skills import utils as skills_utils
-from mito_ai_core.skills.utils import get_skill, list_available_skills, read_skill
+from mito_ai_core.skills.types import Skill
+from mito_ai_core.skills.utils import SKILLS, get_skill, list_available_skills, read_skill
 
 
-def _write_skill(path, content: str) -> None:
-    path.write_text(f'CONTENT = """{content}"""\n')
+class TestSkillRegistry:
+    def test_excel_to_python_is_registered(self) -> None:
+        assert "excel_to_python" in SKILLS
+        assert SKILLS["excel_to_python"].description
 
-
-@pytest.fixture
-def skills_dirs(tmp_path, monkeypatch):
-    package_skills_dir = tmp_path / "package_skills"
-    user_dir = tmp_path / "user"
-    package_skills_dir.mkdir()
-    user_dir.mkdir()
-    monkeypatch.setattr(skills_utils, "SKILLS_DIR", str(package_skills_dir))
-    monkeypatch.setattr(skills_utils, "USER_SKILLS_DIR", str(user_dir))
-    return package_skills_dir, user_dir
-
-
-class TestListAvailableSkills:
-    def test_empty_when_no_skills(self, skills_dirs) -> None:
-        assert list_available_skills() == []
-
-    def test_lists_package_and_user_skills(self, skills_dirs) -> None:
-        package_skills_dir, user_dir = skills_dirs
-        _write_skill(package_skills_dir / "excel_to_python.py", "excel rules")
-        _write_skill(user_dir / "custom_skill.py", "custom rules")
-        assert list_available_skills() == ["custom_skill", "excel_to_python"]
+    def test_list_available_skills(self) -> None:
+        assert list_available_skills() == sorted(SKILLS.keys())
 
 
 class TestGetSkill:
-    def test_user_skill_overrides_package(self, skills_dirs) -> None:
-        package_skills_dir, user_dir = skills_dirs
-        _write_skill(package_skills_dir / "excel_to_python.py", "package rules")
-        _write_skill(user_dir / "excel_to_python.py", "user override")
-        assert get_skill("excel_to_python") == "user override"
-
-    def test_returns_none_for_missing_skill(self, skills_dirs) -> None:
-        assert get_skill("missing") is None
-
-    def test_rejects_path_traversal(self, skills_dirs) -> None:
-        with pytest.raises(ValueError, match="invalid characters"):
-            get_skill("../secrets")
-
-
-class TestReadSkill:
-    def test_returns_skill_content(self, skills_dirs) -> None:
-        package_skills_dir, _user_dir = skills_dirs
-        _write_skill(package_skills_dir / "markdown_rules.py", "# Markdown\nUse headings.")
-        result = read_skill("markdown_rules")
-        assert result.success
-        assert result.tool_name == "read_skill"
-        assert "Markdown" in (result.output or "")
-
-    def test_package_excel_to_python_skill(self) -> None:
-        assert "excel_to_python" in list_available_skills()
+    def test_returns_content_for_registered_skill(self) -> None:
         content = get_skill("excel_to_python")
         assert content is not None
         assert "Configuration cell" in content
+
+    def test_returns_none_for_missing_skill(self) -> None:
+        assert get_skill("missing") is None
+
+
+class TestReadSkill:
+    def test_returns_skill_content(self) -> None:
         result = read_skill("excel_to_python")
         assert result.success
+        assert result.tool_name == "read_skill"
         assert "mito_check_" in (result.output or "")
 
-    def test_returns_error_for_missing_skill(self, skills_dirs) -> None:
+    def test_returns_error_for_missing_skill(self) -> None:
         result = read_skill("does_not_exist")
         assert not result.success
         assert "does_not_exist" in (result.error_message or "")
         assert "Available skills" in (result.error_message or "")
 
-    def test_returns_error_for_invalid_name(self, skills_dirs) -> None:
-        result = read_skill("../etc/passwd")
+    def test_returns_error_for_empty_name(self) -> None:
+        result = read_skill("")
         assert not result.success
         assert result.error_message is not None
+
+
+class TestFormatAvailableSkills:
+    def test_includes_name_and_description(self) -> None:
+        from mito_ai_core.completions.prompt_builders.skills import format_available_skills
+
+        formatted = format_available_skills()
+        assert "excel_to_python:" in formatted
+        assert "Convert Excel workbook logic" in formatted
+
+    def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from mito_ai_core.completions.prompt_builders.skills import format_available_skills
+
+        class CustomSkill(Skill):
+            name = "custom_skill"
+            description = "A test skill."
+
+            def get_content(self) -> str:
+                return "custom content"
+
+        custom_skill = CustomSkill()
+        monkeypatch.setitem(SKILLS, custom_skill.name, custom_skill)
+        assert get_skill("custom_skill") == "custom content"
+        assert "custom_skill: A test skill." in format_available_skills()

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -1,0 +1,67 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import os
+
+import pytest
+
+from mito_ai_core.skills import utils as skills_utils
+from mito_ai_core.skills.utils import get_skill, list_available_skills, read_skill
+
+
+@pytest.fixture
+def skills_dirs(tmp_path, monkeypatch):
+    bundled_dir = tmp_path / "bundled"
+    user_dir = tmp_path / "user"
+    bundled_dir.mkdir()
+    user_dir.mkdir()
+    monkeypatch.setattr(skills_utils, "BUNDLED_SKILLS_DIR", str(bundled_dir))
+    monkeypatch.setattr(skills_utils, "USER_SKILLS_DIR", str(user_dir))
+    return bundled_dir, user_dir
+
+
+class TestListAvailableSkills:
+    def test_empty_when_no_skills(self, skills_dirs) -> None:
+        assert list_available_skills() == []
+
+    def test_lists_bundled_and_user_skills(self, skills_dirs) -> None:
+        bundled_dir, user_dir = skills_dirs
+        (bundled_dir / "excel_to_python.md").write_text("excel rules")
+        (user_dir / "custom_skill.md").write_text("custom rules")
+        assert list_available_skills() == ["custom_skill", "excel_to_python"]
+
+
+class TestGetSkill:
+    def test_user_skill_overrides_bundled(self, skills_dirs) -> None:
+        bundled_dir, user_dir = skills_dirs
+        (bundled_dir / "database_rules.md").write_text("bundled")
+        (user_dir / "database_rules.md").write_text("user override")
+        assert get_skill("database_rules") == "user override"
+
+    def test_returns_none_for_missing_skill(self, skills_dirs) -> None:
+        assert get_skill("missing") is None
+
+    def test_rejects_path_traversal(self, skills_dirs) -> None:
+        with pytest.raises(ValueError, match="invalid characters"):
+            get_skill("../secrets")
+
+
+class TestReadSkill:
+    def test_returns_skill_content(self, skills_dirs) -> None:
+        bundled_dir, _user_dir = skills_dirs
+        (bundled_dir / "markdown_rules.md").write_text("# Markdown\nUse headings.")
+        result = read_skill("markdown_rules")
+        assert result.success
+        assert result.tool_name == "read_skill"
+        assert "Markdown" in (result.output or "")
+
+    def test_returns_error_for_missing_skill(self, skills_dirs) -> None:
+        result = read_skill("does_not_exist")
+        assert not result.success
+        assert "does_not_exist" in (result.error_message or "")
+        assert "Available skills" in (result.error_message or "")
+
+    def test_returns_error_for_invalid_name(self, skills_dirs) -> None:
+        result = read_skill("../etc/passwd")
+        assert not result.success
+        assert result.error_message is not None

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -1,42 +1,44 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-import os
-
 import pytest
 
 from mito_ai_core.skills import utils as skills_utils
 from mito_ai_core.skills.utils import get_skill, list_available_skills, read_skill
 
 
+def _write_skill(path, content: str) -> None:
+    path.write_text(f'CONTENT = """{content}"""\n')
+
+
 @pytest.fixture
 def skills_dirs(tmp_path, monkeypatch):
-    bundled_dir = tmp_path / "bundled"
+    package_skills_dir = tmp_path / "package_skills"
     user_dir = tmp_path / "user"
-    bundled_dir.mkdir()
+    package_skills_dir.mkdir()
     user_dir.mkdir()
-    monkeypatch.setattr(skills_utils, "BUNDLED_SKILLS_DIR", str(bundled_dir))
+    monkeypatch.setattr(skills_utils, "SKILLS_DIR", str(package_skills_dir))
     monkeypatch.setattr(skills_utils, "USER_SKILLS_DIR", str(user_dir))
-    return bundled_dir, user_dir
+    return package_skills_dir, user_dir
 
 
 class TestListAvailableSkills:
     def test_empty_when_no_skills(self, skills_dirs) -> None:
         assert list_available_skills() == []
 
-    def test_lists_bundled_and_user_skills(self, skills_dirs) -> None:
-        bundled_dir, user_dir = skills_dirs
-        (bundled_dir / "excel_to_python.md").write_text("excel rules")
-        (user_dir / "custom_skill.md").write_text("custom rules")
+    def test_lists_package_and_user_skills(self, skills_dirs) -> None:
+        package_skills_dir, user_dir = skills_dirs
+        _write_skill(package_skills_dir / "excel_to_python.py", "excel rules")
+        _write_skill(user_dir / "custom_skill.py", "custom rules")
         assert list_available_skills() == ["custom_skill", "excel_to_python"]
 
 
 class TestGetSkill:
-    def test_user_skill_overrides_bundled(self, skills_dirs) -> None:
-        bundled_dir, user_dir = skills_dirs
-        (bundled_dir / "database_rules.md").write_text("bundled")
-        (user_dir / "database_rules.md").write_text("user override")
-        assert get_skill("database_rules") == "user override"
+    def test_user_skill_overrides_package(self, skills_dirs) -> None:
+        package_skills_dir, user_dir = skills_dirs
+        _write_skill(package_skills_dir / "excel_to_python.py", "package rules")
+        _write_skill(user_dir / "excel_to_python.py", "user override")
+        assert get_skill("excel_to_python") == "user override"
 
     def test_returns_none_for_missing_skill(self, skills_dirs) -> None:
         assert get_skill("missing") is None
@@ -48,14 +50,14 @@ class TestGetSkill:
 
 class TestReadSkill:
     def test_returns_skill_content(self, skills_dirs) -> None:
-        bundled_dir, _user_dir = skills_dirs
-        (bundled_dir / "markdown_rules.md").write_text("# Markdown\nUse headings.")
+        package_skills_dir, _user_dir = skills_dirs
+        _write_skill(package_skills_dir / "markdown_rules.py", "# Markdown\nUse headings.")
         result = read_skill("markdown_rules")
         assert result.success
         assert result.tool_name == "read_skill"
         assert "Markdown" in (result.output or "")
 
-    def test_bundled_excel_to_python_skill(self) -> None:
+    def test_package_excel_to_python_skill(self) -> None:
         assert "excel_to_python" in list_available_skills()
         content = get_skill("excel_to_python")
         assert content is not None

--- a/mito-ai-core/pyproject.toml
+++ b/mito-ai-core/pyproject.toml
@@ -60,3 +60,6 @@ timeout = 30
 
 [tool.hatch.build.targets.wheel]
 packages = ["mito_ai_core"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"mito_ai_core/skills/bundled" = "mito_ai_core/skills/bundled"

--- a/mito-ai-core/pyproject.toml
+++ b/mito-ai-core/pyproject.toml
@@ -60,6 +60,3 @@ timeout = 30
 
 [tool.hatch.build.targets.wheel]
 packages = ["mito_ai_core"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"mito_ai_core/skills/bundled" = "mito_ai_core/skills/bundled"

--- a/mito-ai-mcp/tests/test_server_e2e.py
+++ b/mito-ai-mcp/tests/test_server_e2e.py
@@ -118,6 +118,7 @@ class FakeAgentRunner:
                     scratchpad_code=None,
                     scratchpad_summary=None,
                     mcp_tool_call=None,
+                    skill_name=None,
                 )
             )
 
@@ -138,6 +139,7 @@ class FakeAgentRunner:
                 scratchpad_code=None,
                 scratchpad_summary=None,
                 mcp_tool_call=None,
+                skill_name=None,
             ),
             finished=True,
             iterations=2,

--- a/mito-ai-python-tool-executor/mito_ai_python_tool_executor/executor.py
+++ b/mito-ai-python-tool-executor/mito_ai_python_tool_executor/executor.py
@@ -445,3 +445,14 @@ class PythonToolExecutor:
             output=STREAMLIT_FUNCTIONALITY_DISABLED_MESSAGE,
             variables=vars_,
         )
+
+    async def read_skill(
+        self,
+        ctx: AgentContext,
+        skill_name: str,
+        message: str,
+    ) -> ToolResult:
+        del ctx, message
+        from mito_ai_core.skills.utils import read_skill as read_skill_content
+
+        return read_skill_content(skill_name)

--- a/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
+++ b/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
@@ -112,6 +112,7 @@ class JupyterLabToolExecutor:
             "ask_user_question",
             "scratchpad",
             "mcp_tool_call",
+            "read_skill",
         ],
         message: str,
         *,
@@ -122,6 +123,7 @@ class JupyterLabToolExecutor:
         scratchpad_code: Optional[str] = None,
         scratchpad_summary: Optional[str] = None,
         streamlit_app_prompt: Optional[str] = None,
+        skill_name: Optional[str] = None,
     ) -> AgentResponse:
         return AgentResponse(
             type=type,
@@ -136,6 +138,7 @@ class JupyterLabToolExecutor:
             scratchpad_code=scratchpad_code,
             scratchpad_summary=scratchpad_summary,
             mcp_tool_call=None,
+            skill_name=skill_name,
         )
 
     # ------------------------------------------------------------------
@@ -285,3 +288,14 @@ class JupyterLabToolExecutor:
             tool_name="mcp_tool_call",
             error_message=result.get("error", "Unknown MCP tool error"),
         )
+
+    async def read_skill(
+        self,
+        ctx: AgentContext,
+        skill_name: str,
+        message: str,
+    ) -> ToolResult:
+        del ctx, message
+        from mito_ai_core.skills.utils import read_skill as read_skill_content
+
+        return read_skill_content(skill_name)

--- a/mito-ai/src/Extensions/AiChat/hooks/agentToolExecutor.ts
+++ b/mito-ai/src/Extensions/AiChat/hooks/agentToolExecutor.ts
@@ -273,6 +273,8 @@ export const executeAgentTool = async ({
                 output: 'Updated Streamlit app preview',
             };
         }
+        case 'read_skill':
+            return unsupportedFrontendToolResult('read_skill');
         case 'finished_task':
         default:
             return unsupportedFrontendToolResult(agentResponse.type);

--- a/mito-ai/src/websockets/completions/CompletionModels.ts
+++ b/mito-ai/src/websockets/completions/CompletionModels.ts
@@ -41,7 +41,7 @@ export type CellUpdateNew = {
 export type CellUpdate = CellUpdateModification | CellUpdateNew
 
 export type AgentResponse = {
-  type: 'cell_update' | 'get_cell_output' | 'run_all_cells' | 'finished_task' | 'create_streamlit_app' | 'edit_streamlit_app' | 'ask_user_question' | 'scratchpad'
+  type: 'cell_update' | 'get_cell_output' | 'run_all_cells' | 'finished_task' | 'create_streamlit_app' | 'edit_streamlit_app' | 'ask_user_question' | 'scratchpad' | 'read_skill'
   message: string,
   cell_update?: CellUpdate | null | undefined
   get_cell_output_cell_id?: string | null | undefined
@@ -52,6 +52,7 @@ export type AgentResponse = {
   answers?: string[] | null | undefined
   scratchpad_code?: string | null | undefined
   scratchpad_summary?: string | null | undefined
+  skill_name?: string | null | undefined
 }
 
 /* 


### PR DESCRIPTION
# Description

Created a new `read_skill` tool, and added the first skill: `excel_to_python`. This let's us move all of this specialized instructions out of the system prompt, and only add it to context as needed. 

This removes ~2k tokens from the system prompt. For next steps we can remove the database instructions. 

# Testing

Send a generic message, and look at the system prompt. You should only notice that only the skill names and descriptions are included. 

Next, ask the Agent to convert a Excel file. It should load in the skill, and perform the conversion as expected. 

# Documentation

N/A -- Behind-the-scenes change. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive agent/prompt change with in-process skill loading; Jupyter frontend delegates read_skill to the backend, so behavior depends on server-side executor wiring staying correct.
> 
> **Overview**
> Introduces an on-demand **`read_skill`** agent tool so specialized instructions load into context only when needed, instead of living in the default system prompt.
> 
> The agent loop, **`AgentResponse`** schema, parsers, and **`ToolExecutor`** implementations (Python/MCP/JupyterLab) now support **`read_skill`** with a **`skill_name`** field and validation for empty or unknown skills. A new **`mito_ai_core.skills`** package registers skills (first: **`excel_to_python`**) and returns full skill text as a tool result; the system prompt lists only skill names and descriptions via **`format_available_skills()`**, documents the tool, and **removes** the always-on Excel-to-Python rules block (~2k tokens). Jupyter’s TypeScript **`AgentResponse`** type is updated; the frontend tool handler treats **`read_skill`** as unsupported because the backend resolves it in-process.
> 
> Tests cover registry utilities, runner dispatch, and executor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba4ae30b3ee460b7b6c17aae0f76a568b1853e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->