### PR TITLE
Database Skill 

### DIFF
--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -385,7 +385,7 @@ Important information:
 """))
 
     sections.append(SG.Generic("TOOL: READ_SKILL", """
-Load detailed instructions for a specialized task on demand. Use this before work that needs guidance not included in the base prompt (e.g. Excel formula translation, database connections).
+Load detailed instructions for a specialized task on demand. Use this before work that needs guidance not included in the base prompt (e.g. converting an Excel model to Python, querying a configured database).
 
 Format:
 {{

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/agent_system_message.py
@@ -11,7 +11,6 @@ from mito_ai_core.completions.prompt_builders.prompt_constants import (
     CITATION_RULES,
     CELL_REFERENCE_RULES,
     MARKDOWN_RULES,
-    get_database_rules
 )
 from mito_ai_core.completions.prompt_builders.prompt_section_registry.base import PromptSection
 from mito_ai_core.rules.utils import get_default_rules_content
@@ -630,9 +629,6 @@ Important information:
     }}
     </Example>"""))
     sections.append(SG.Generic("Cell Reference Rules", CELL_REFERENCE_RULES))
-    
-    # Database rules
-    sections.append(SG.Generic("Database Rules", get_database_rules()))
 
     # Default rules
     default_rules = get_default_rules_content()

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
@@ -113,9 +113,9 @@ Do NOT include the founders email when the user is asking for data analysis, ins
 
 def get_database_rules() -> str:
     """Return database rules for chat mode. Agent mode loads these via read_skill."""
-    from mito_ai_core.skills.database_rules import DatabaseRulesSkill
+    from mito_ai_core.skills.connect_to_db import ConnectToDbSkill
 
-    skill = DatabaseRulesSkill()
+    skill = ConnectToDbSkill()
     if not skill.is_available:
         return ""
     return skill.get_content()

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
@@ -6,12 +6,6 @@ This module contains constants used in prompts across the codebase.
 These constants ensure consistency between prompt building and message trimming.
 """
 
-import os
-import json
-from typing import Final
-
-from mito_ai_core.utils.schema import MITO_FOLDER
-
 CHART_CONFIG_RULES = """
 When creating a matplotlib chart, you must use the `# === CHART CONFIG ===` and `# === END CONFIG ===` markers to indicate the start and end of the chart configuration section.
 
@@ -117,101 +111,14 @@ Only when the user explicitly asks about Mito as a product (e.g. how to use Mito
 Do NOT include the founders email when the user is asking for data analysis, insights, code to analyze their data, or any task about their notebook/data—only when they are asking about the Mito product itself.
 """
 
-def redact_sensitive_info(connections: dict) -> dict:
-    """
-    Redacts sensitive information from connections data.
-    Returns a copy of the connections dict with sensitive fields masked.
-    """
-    redacted = {}
-    for conn_name, conn_data in connections.items():
-        redacted[conn_name] = conn_data.copy()
-        for key, value in redacted[conn_name].items():
-            redacted[conn_name][key] = 'redacted'
-    return redacted
-
 def get_database_rules() -> str:
-    """
-    Reads the user's database configurations,
-    and returns the rules for the AI to follow.
-    """
+    """Return database rules for chat mode. Agent mode loads these via read_skill."""
+    from mito_ai_core.skills.database_rules import DatabaseRulesSkill
 
-    # Get the db configuration from the user's mito folder
-
-    APP_DIR_PATH: Final[str] = os.path.join(MITO_FOLDER)
-    connections_path: Final[str] = os.path.join(APP_DIR_PATH, 'db', 'connections.json')
-    schemas_path: Final[str] = os.path.join(APP_DIR_PATH, 'db', 'schemas.json')
-    
-    try:
-        with open(connections_path, 'r') as f:
-            connections = json.load(f)
-            sanitized_connections = redact_sensitive_info(connections)
-    except FileNotFoundError:
-        connections = None
-        sanitized_connections = None
-
-    try:
-        with open(schemas_path, 'r') as f:
-            schemas = json.load(f)
-    except FileNotFoundError:
-        schemas = None
-
-    # If there is a db configuration, add return the rules
-
-    if connections is not None:
-        DATABASE_RULES = f"""DATABASE RULES:
-If the user has requested data that you believe is stored in the database:
-- Use the provided schema.
-- Only use SQLAlchemy to query the database.
-- Do not use a with statement when creating the SQLAlchemy engine. Instead, initialize it once so it can be reused for multiple queries.
-- Always return the results of the query in a pandas DataFrame, unless instructed otherwise.
-- Every schema has a unique connection ID. This ID can be used to find the connection details in the connections.json file.
-- Do not use the connection ID to query the database. It is only for matching the schema to the correct connection.
-- When using the connection ID, do not include any comments about it in your code.
-- Connection details are stored in a JSON file located at: `{connections_path}`
-- Here is the sanitized contents of the connections.json file:
-
-{sanitized_connections}
-
-- Do not hard-code connection credentials into your code. Instead, load the connections.json file and access connection fields dynamically like so:
-
-```
-connections[connection_name]["username"]
-```
-
-- The user may colloquially ask for a "list of x", always assume they want a pandas DataFrame. 
-- When working with dataframes created from an SQL query, ALWAYS use lowercase column names. 
-- If you think the requested data is stored in the database, but you are unsure, then ask the user for clarification.
-
-## Additional MSSQL Rules
-
-- When connecting to a Microsoft SQL Server (MSSQL) database, use the following format:
-
-```
-import urllib.parse
-
-encoded_password = urllib.parse.quote_plus(password) 
-conn_str = f"mssql+pyodbc://username:encoded_password@host:port/database?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
-```
-
-- Always URL-encode passwords for MSSQL connections to handle special characters properly.
-- Include the port number in MSSQL connection strings.
-- Use "ODBC+Driver+18+for+SQL+Server" (with plus signs) in the driver parameter.
-- Always include "TrustServerCertificate=yes" for MSSQL connections to avoid SSL certificate issues.
-
-## Additional Oracle Rules
-
-- When connecting to an Oracle database, use the following format:
-```
-conn_str = f"oracle+oracledb://username:password@host:port?service_name=service_name"
-```
-
-Here is the schema:
-{schemas}
-        """
-    else:
-        DATABASE_RULES = ""
-
-    return DATABASE_RULES
+    skill = DatabaseRulesSkill()
+    if not skill.is_available():
+        return ""
+    return skill.get_content()
 
 
 CHAT_CODE_FORMATTING_RULES = """

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/prompt_constants.py
@@ -116,7 +116,7 @@ def get_database_rules() -> str:
     from mito_ai_core.skills.database_rules import DatabaseRulesSkill
 
     skill = DatabaseRulesSkill()
-    if not skill.is_available():
+    if not skill.is_available:
         return ""
     return skill.get_content()
 

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
@@ -1,12 +1,14 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from mito_ai_core.skills.utils import SKILLS
+from mito_ai_core.skills.utils import _available_skills
 
 
 def format_available_skills() -> str:
-    if not SKILLS:
+    skills = _available_skills()
+    if not skills:
         return "No skills are currently available."
     return "\n".join(
-        f"- {skill.name}: {skill.description}" for skill in sorted(SKILLS.values(), key=lambda s: s.name)
+        f"- {skill.name}: {skill.description}"
+        for skill in sorted(skills.values(), key=lambda s: s.name)
     )

--- a/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
+++ b/mito-ai-core/mito_ai_core/completions/prompt_builders/skills.py
@@ -1,11 +1,11 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from mito_ai_core.skills.utils import _available_skills
+from mito_ai_core.skills.utils import get_available_skills
 
 
 def format_available_skills() -> str:
-    skills = _available_skills()
+    skills = get_available_skills()
     if not skills:
         return "No skills are currently available."
     return "\n".join(

--- a/mito-ai-core/mito_ai_core/skills/__init__.py
+++ b/mito-ai-core/mito_ai_core/skills/__init__.py
@@ -4,13 +4,12 @@
 """Agent skills — on-demand instructions loaded via the read_skill tool."""
 
 from mito_ai_core.skills.types import Skill
-from mito_ai_core.skills.utils import SKILLS, get_available_skills, get_skill, list_available_skills, read_skill
+from mito_ai_core.skills.utils import SKILLS, get_available_skills, get_skill, read_skill
 
 __all__ = [
     "Skill",
     "SKILLS",
     "get_available_skills",
     "get_skill",
-    "list_available_skills",
     "read_skill",
 ]

--- a/mito-ai-core/mito_ai_core/skills/__init__.py
+++ b/mito-ai-core/mito_ai_core/skills/__init__.py
@@ -4,11 +4,12 @@
 """Agent skills — on-demand instructions loaded via the read_skill tool."""
 
 from mito_ai_core.skills.types import Skill
-from mito_ai_core.skills.utils import SKILLS, get_skill, list_available_skills, read_skill
+from mito_ai_core.skills.utils import SKILLS, get_available_skills, get_skill, list_available_skills, read_skill
 
 __all__ = [
     "Skill",
     "SKILLS",
+    "get_available_skills",
     "get_skill",
     "list_available_skills",
     "read_skill",

--- a/mito-ai-core/mito_ai_core/skills/connect_to_db.py
+++ b/mito-ai-core/mito_ai_core/skills/connect_to_db.py
@@ -98,14 +98,15 @@ def _get_skill_description(connections: Optional[dict]) -> str:
         entries.append(f"{name} ({db_type})")
 
     return (
-        "Use this skill if the user has requested data from a database. "
-        "This skill contains the database credentials and instructions on how to properly query the database. "
+        "Query configured databases and return results as pandas DataFrames. "
+        "Use when the user asks for SQL data, mentions tables or schemas, or needs data from "
+        "a connected database. This skill contains the database connection details, schemas, and rules for querying the database correctly."
         f"Configured databases: {', '.join(sorted(entries))}."
     )
 
 
 class ConnectToDbSkill(Skill):
-    name = "connect_to_db"
+    name = "connect-to-db"
 
     @property
     def description(self) -> str:

--- a/mito-ai-core/mito_ai_core/skills/connect_to_db.py
+++ b/mito-ai-core/mito_ai_core/skills/connect_to_db.py
@@ -1,6 +1,8 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+"""Connect to DB skill."""
+
 import json
 import os
 from typing import Any, Dict, Final, Optional, cast
@@ -84,8 +86,8 @@ def _load_schemas() -> Optional[Any]:
         return None
 
 
-class DatabaseRulesSkill(Skill):
-    name = "database_rules"
+class ConnectToDbSkill(Skill):
+    name = "connect_to_db"
     description = "Use this skill if the user has requested data from a database. This skill contains the database credentials and instructions on how to properly query the database."
 
     @property

--- a/mito-ai-core/mito_ai_core/skills/connect_to_db.py
+++ b/mito-ai-core/mito_ai_core/skills/connect_to_db.py
@@ -86,9 +86,30 @@ def _load_schemas() -> Optional[Any]:
         return None
 
 
+def _get_skill_description(connections: Optional[dict]) -> str:
+    if connections is None:
+        return "No database connections are configured."
+
+    entries = []
+    for conn_data in connections.values():
+        conn = cast(dict, conn_data)
+        name = conn.get("alias") or conn.get("database") or "unknown"
+        db_type = conn.get("type", "unknown")
+        entries.append(f"{name} ({db_type})")
+
+    return (
+        "Use this skill if the user has requested data from a database. "
+        "This skill contains the database credentials and instructions on how to properly query the database. "
+        f"Configured databases: {', '.join(sorted(entries))}."
+    )
+
+
 class ConnectToDbSkill(Skill):
     name = "connect_to_db"
-    description = "Use this skill if the user has requested data from a database. This skill contains the database credentials and instructions on how to properly query the database."
+
+    @property
+    def description(self) -> str:
+        return _get_skill_description(_load_connections())
 
     @property
     def is_available(self) -> bool:

--- a/mito-ai-core/mito_ai_core/skills/database_rules.py
+++ b/mito-ai-core/mito_ai_core/skills/database_rules.py
@@ -1,0 +1,110 @@
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GNU Affero General Public License v3.0 License.
+
+import json
+import os
+from typing import Any, Dict, Final, Optional, cast
+
+from mito_ai_core.skills.types import Skill
+from mito_ai_core.utils.schema import MITO_FOLDER
+
+CONNECTIONS_PATH: Final[str] = os.path.join(MITO_FOLDER, "db", "connections.json")
+SCHEMAS_PATH: Final[str] = os.path.join(MITO_FOLDER, "db", "schemas.json")
+
+STATIC_RULES = """
+# Database Rules
+
+If the user has requested data that you believe is stored in the database:
+
+- Use the provided schema.
+- Only use SQLAlchemy to query the database.
+- Do not use a with statement when creating the SQLAlchemy engine. Instead, initialize it once so it can be reused for multiple queries.
+- Always return the results of the query in a pandas DataFrame, unless instructed otherwise.
+- Every schema has a unique connection ID. This ID can be used to find the connection details in the connections.json file.
+- Do not use the connection ID to query the database. It is only for matching the schema to the correct connection.
+- When using the connection ID, do not include any comments about it in your code.
+- Do not hard-code connection credentials into your code. Instead, load the connections.json file and access connection fields dynamically like so:
+
+```
+connections[connection_name]["username"]
+```
+
+- The user may colloquially ask for a "list of x", always assume they want a pandas DataFrame.
+- When working with dataframes created from an SQL query, ALWAYS use lowercase column names.
+- If you think the requested data is stored in the database, but you are unsure, then ask the user for clarification.
+
+## Additional MSSQL Rules
+
+When connecting to a Microsoft SQL Server (MSSQL) database, use the following format:
+
+```
+import urllib.parse
+
+encoded_password = urllib.parse.quote_plus(password)
+conn_str = f"mssql+pyodbc://username:encoded_password@host:port/database?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+```
+
+- Always URL-encode passwords for MSSQL connections to handle special characters properly.
+- Include the port number in MSSQL connection strings.
+- Use "ODBC+Driver+18+for+SQL+Server" (with plus signs) in the driver parameter.
+- Always include "TrustServerCertificate=yes" for MSSQL connections to avoid SSL certificate issues.
+
+## Additional Oracle Rules
+
+When connecting to an Oracle database, use the following format:
+
+```
+conn_str = f"oracle+oracledb://username:password@host:port?service_name=service_name"
+```
+"""
+
+
+def _redact_sensitive_info(connections: dict) -> dict:
+    redacted: Dict[str, Dict[str, Any]] = {}
+    for conn_name, conn_data in connections.items():
+        redacted[conn_name] = conn_data.copy()
+        for key in redacted[conn_name]:
+            redacted[conn_name][key] = "redacted"
+    return redacted
+
+
+def _load_connections() -> Optional[dict]:
+    try:
+        with open(CONNECTIONS_PATH, "r") as f:
+            return cast(dict, json.load(f))
+    except FileNotFoundError:
+        return None
+
+
+def _load_schemas() -> Optional[Any]:
+    try:
+        with open(SCHEMAS_PATH, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+
+class DatabaseRulesSkill(Skill):
+    name = "database_rules"
+    description = "Query data from the user's configured database connections using SQLAlchemy."
+
+    def is_available(self) -> bool:
+        return _load_connections() is not None
+
+    def get_content(self) -> str:
+        connections = _load_connections()
+        if connections is None:
+            return ""
+
+        sanitized_connections = _redact_sensitive_info(connections)
+        schemas = _load_schemas()
+
+        return (
+            f"{STATIC_RULES.strip()}\n\n"
+            f"## Your Database Configuration\n\n"
+            f"Connection details are stored in a JSON file located at: `{CONNECTIONS_PATH}`\n\n"
+            f"Here is the sanitized contents of the connections.json file:\n\n"
+            f"{sanitized_connections}\n\n"
+            f"Here is the schema:\n\n"
+            f"{schemas}"
+        )

--- a/mito-ai-core/mito_ai_core/skills/database_rules.py
+++ b/mito-ai-core/mito_ai_core/skills/database_rules.py
@@ -86,8 +86,9 @@ def _load_schemas() -> Optional[Any]:
 
 class DatabaseRulesSkill(Skill):
     name = "database_rules"
-    description = "Query data from the user's configured database connections using SQLAlchemy."
+    description = "Use this skill if the user has requested data from a database. This skill contains the database credentials and instructions on how to properly query the database."
 
+    @property
     def is_available(self) -> bool:
         return _load_connections() is not None
 

--- a/mito-ai-core/mito_ai_core/skills/excel_to_python.py
+++ b/mito-ai-core/mito_ai_core/skills/excel_to_python.py
@@ -124,12 +124,15 @@ Once every todo item is checked off, rerun the entire notebook from top to botto
 
 
 class ExcelToPythonSkill(Skill):
-    name = "excel_to_python"
+    name = "excel-to-python"
 
     @property
     def description(self) -> str:
         return (
-            "Convert Excel workbook logic into an interactive, test-driven Jupyter notebook."
+            "Convert Excel workbook formulas and logic into an interactive, scenario-ready "
+            "Jupyter notebook validated against the source file. Use when the user asks to "
+            "convert, translate, replicate, or port an Excel model to Python, rebuild a "
+            "spreadsheet in a notebook, or run what-if scenarios from an .xlsx file."
         )
 
     def get_content(self) -> str:

--- a/mito-ai-core/mito_ai_core/skills/excel_to_python.py
+++ b/mito-ai-core/mito_ai_core/skills/excel_to_python.py
@@ -125,9 +125,12 @@ Once every todo item is checked off, rerun the entire notebook from top to botto
 
 class ExcelToPythonSkill(Skill):
     name = "excel_to_python"
-    description = (
-        "Convert Excel workbook logic into an interactive, test-driven Jupyter notebook."
-    )
+
+    @property
+    def description(self) -> str:
+        return (
+            "Convert Excel workbook logic into an interactive, test-driven Jupyter notebook."
+        )
 
     def get_content(self) -> str:
         return CONTENT

--- a/mito-ai-core/mito_ai_core/skills/types.py
+++ b/mito-ai-core/mito_ai_core/skills/types.py
@@ -8,7 +8,10 @@ from typing import ClassVar
 class Skill(ABC):
     name: ClassVar[str]
     description: ClassVar[str]
-    is_available: ClassVar[bool] = True
+
+    @property
+    def is_available(self) -> bool:
+        return True
 
     @abstractmethod
     def get_content(self) -> str:

--- a/mito-ai-core/mito_ai_core/skills/types.py
+++ b/mito-ai-core/mito_ai_core/skills/types.py
@@ -7,7 +7,11 @@ from typing import ClassVar
 
 class Skill(ABC):
     name: ClassVar[str]
-    description: ClassVar[str]
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Short summary shown in the available skills list."""
 
     @property
     def is_available(self) -> bool:

--- a/mito-ai-core/mito_ai_core/skills/types.py
+++ b/mito-ai-core/mito_ai_core/skills/types.py
@@ -9,6 +9,10 @@ class Skill(ABC):
     name: ClassVar[str]
     description: ClassVar[str]
 
+    def is_available(self) -> bool:
+        """Whether this skill should appear in Available Skills and be readable."""
+        return True
+
     @abstractmethod
     def get_content(self) -> str:
         """Return the skill instructions for the agent."""

--- a/mito-ai-core/mito_ai_core/skills/types.py
+++ b/mito-ai-core/mito_ai_core/skills/types.py
@@ -8,10 +8,7 @@ from typing import ClassVar
 class Skill(ABC):
     name: ClassVar[str]
     description: ClassVar[str]
-
-    def is_available(self) -> bool:
-        """Whether this skill should appear in Available Skills and be readable."""
-        return True
+    is_available: ClassVar[bool] = True
 
     @abstractmethod
     def get_content(self) -> str:

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from mito_ai_core.agent.types import ToolResult
 from mito_ai_core.skills.database_rules import DatabaseRulesSkill
@@ -18,11 +18,6 @@ def get_available_skills() -> Dict[str, Skill]:
     return {
         name: skill for name, skill in SKILLS.items() if skill.is_available
     }
-
-
-def list_available_skills() -> List[str]:
-    """Return sorted registered skill names that are currently available."""
-    return sorted(get_available_skills().keys())
 
 
 def get_skill(skill_name: str) -> Optional[str]:
@@ -45,7 +40,7 @@ def read_skill(skill_name: str) -> ToolResult:
     sanitized_name = skill_name.strip()
     skill = get_available_skills().get(sanitized_name)
     if skill is None:
-        available = list_available_skills()
+        available = sorted(get_available_skills().keys())
         available_text = ", ".join(available) if available else "(none)"
         return ToolResult(
             success=False,

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -4,22 +4,30 @@
 from typing import Dict, List, Optional
 
 from mito_ai_core.agent.types import ToolResult
+from mito_ai_core.skills.database_rules import DatabaseRulesSkill
 from mito_ai_core.skills.excel_to_python import ExcelToPythonSkill
 from mito_ai_core.skills.types import Skill
 
 SKILLS: Dict[str, Skill] = {
     ExcelToPythonSkill.name: ExcelToPythonSkill(),
+    DatabaseRulesSkill.name: DatabaseRulesSkill(),
 }
 
 
+def _available_skills() -> Dict[str, Skill]:
+    return {
+        name: skill for name, skill in SKILLS.items() if skill.is_available()
+    }
+
+
 def list_available_skills() -> List[str]:
-    """Return sorted registered skill names."""
-    return sorted(SKILLS.keys())
+    """Return sorted registered skill names that are currently available."""
+    return sorted(_available_skills().keys())
 
 
 def get_skill(skill_name: str) -> Optional[str]:
-    """Return skill content by name, or None if not registered."""
-    skill = SKILLS.get(skill_name)
+    """Return skill content by name, or None if not registered or unavailable."""
+    skill = _available_skills().get(skill_name)
     if skill is None:
         return None
     return skill.get_content()
@@ -35,7 +43,7 @@ def read_skill(skill_name: str) -> ToolResult:
         )
 
     sanitized_name = skill_name.strip()
-    skill = SKILLS.get(sanitized_name)
+    skill = _available_skills().get(sanitized_name)
     if skill is None:
         available = list_available_skills()
         available_text = ", ".join(available) if available else "(none)"

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -16,7 +16,7 @@ SKILLS: Dict[str, Skill] = {
 
 def _available_skills() -> Dict[str, Skill]:
     return {
-        name: skill for name, skill in SKILLS.items() if skill.is_available()
+        name: skill for name, skill in SKILLS.items() if skill.is_available
     }
 
 

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -4,13 +4,13 @@
 from typing import Dict, Optional
 
 from mito_ai_core.agent.types import ToolResult
-from mito_ai_core.skills.database_rules import DatabaseRulesSkill
+from mito_ai_core.skills.connect_to_db import ConnectToDbSkill
 from mito_ai_core.skills.excel_to_python import ExcelToPythonSkill
 from mito_ai_core.skills.types import Skill
 
 SKILLS: Dict[str, Skill] = {
     ExcelToPythonSkill.name: ExcelToPythonSkill(),
-    DatabaseRulesSkill.name: DatabaseRulesSkill(),
+    ConnectToDbSkill.name: ConnectToDbSkill(),
 }
 
 

--- a/mito-ai-core/mito_ai_core/skills/utils.py
+++ b/mito-ai-core/mito_ai_core/skills/utils.py
@@ -14,7 +14,7 @@ SKILLS: Dict[str, Skill] = {
 }
 
 
-def _available_skills() -> Dict[str, Skill]:
+def get_available_skills() -> Dict[str, Skill]:
     return {
         name: skill for name, skill in SKILLS.items() if skill.is_available
     }
@@ -22,12 +22,12 @@ def _available_skills() -> Dict[str, Skill]:
 
 def list_available_skills() -> List[str]:
     """Return sorted registered skill names that are currently available."""
-    return sorted(_available_skills().keys())
+    return sorted(get_available_skills().keys())
 
 
 def get_skill(skill_name: str) -> Optional[str]:
     """Return skill content by name, or None if not registered or unavailable."""
-    skill = _available_skills().get(skill_name)
+    skill = get_available_skills().get(skill_name)
     if skill is None:
         return None
     return skill.get_content()
@@ -43,7 +43,7 @@ def read_skill(skill_name: str) -> ToolResult:
         )
 
     sanitized_name = skill_name.strip()
-    skill = _available_skills().get(sanitized_name)
+    skill = get_available_skills().get(sanitized_name)
     if skill is None:
         available = list_available_skills()
         available_text = ", ".join(available) if available else "(none)"

--- a/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_agent_runner.py
@@ -476,7 +476,7 @@ class TestToolDispatch:
             _agent_response_json(
                 "read_skill",
                 message="Loading Excel guidance.",
-                skill_name="excel_to_python",
+                skill_name="excel-to-python",
             ),
             _finished_response(),
         ])
@@ -488,7 +488,7 @@ class TestToolDispatch:
 
         assert result.finished is True
         assert executor.calls[0][0] == "read_skill"
-        assert executor.calls[0][1]["skill_name"] == "excel_to_python"
+        assert executor.calls[0][1]["skill_name"] == "excel-to-python"
 
     @pytest.mark.asyncio
     async def test_ask_user_question_dispatched(self) -> None:

--- a/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
+++ b/mito-ai-core/mito_ai_core/tests/agent/test_tool_executor.py
@@ -346,13 +346,13 @@ class TestExecuteReadSkill:
         ctx = _make_ctx()
         result = await executor.read_skill(
             ctx,
-            skill_name="excel_to_python",
+            skill_name="excel-to-python",
             message="Need Excel translation rules.",
         )
 
         assert result.success
         assert result.tool_name == "read_skill"
-        assert "excel_to_python" in (result.output or "")
+        assert "excel-to-python" in (result.output or "")
         assert executor.calls[0][0] == "read_skill"
 
 

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -1,10 +1,29 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
+import json
+
 import pytest
 
+from mito_ai_core.completions.prompt_builders.prompt_constants import get_database_rules
+from mito_ai_core.skills import database_rules as database_rules_module
 from mito_ai_core.skills.types import Skill
 from mito_ai_core.skills.utils import SKILLS, get_skill, list_available_skills, read_skill
+
+
+@pytest.fixture
+def db_config(tmp_path, monkeypatch):
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    connections_path = db_dir / "connections.json"
+    schemas_path = db_dir / "schemas.json"
+    connections_path.write_text(
+        json.dumps({"my_db": {"username": "admin", "password": "secret", "host": "localhost"}})
+    )
+    schemas_path.write_text(json.dumps({"my_db": {"tables": ["users"]}}))
+    monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", str(connections_path))
+    monkeypatch.setattr(database_rules_module, "SCHEMAS_PATH", str(schemas_path))
+    return connections_path, schemas_path
 
 
 class TestSkillRegistry:
@@ -12,8 +31,21 @@ class TestSkillRegistry:
         assert "excel_to_python" in SKILLS
         assert SKILLS["excel_to_python"].description
 
-    def test_list_available_skills(self) -> None:
-        assert list_available_skills() == sorted(SKILLS.keys())
+    def test_database_rules_is_registered(self) -> None:
+        assert "database_rules" in SKILLS
+
+    def test_list_available_skills_includes_excel_to_python(self) -> None:
+        assert "excel_to_python" in list_available_skills()
+
+    def test_database_rules_not_listed_without_config(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        missing_path = str(tmp_path / "missing" / "connections.json")
+        monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", missing_path)
+        assert "database_rules" not in list_available_skills()
+
+    def test_database_rules_listed_when_configured(self, db_config) -> None:
+        assert "database_rules" in list_available_skills()
 
 
 class TestGetSkill:
@@ -25,6 +57,13 @@ class TestGetSkill:
     def test_returns_none_for_missing_skill(self) -> None:
         assert get_skill("missing") is None
 
+    def test_database_rules_includes_user_config(self, db_config) -> None:
+        content = get_skill("database_rules")
+        assert content is not None
+        assert "SQLAlchemy" in content
+        assert "redacted" in content
+        assert "users" in content
+
 
 class TestReadSkill:
     def test_returns_skill_content(self) -> None:
@@ -32,6 +71,11 @@ class TestReadSkill:
         assert result.success
         assert result.tool_name == "read_skill"
         assert "mito_check_" in (result.output or "")
+
+    def test_read_database_rules(self, db_config) -> None:
+        result = read_skill("database_rules")
+        assert result.success
+        assert "Your Database Configuration" in (result.output or "")
 
     def test_returns_error_for_missing_skill(self) -> None:
         result = read_skill("does_not_exist")
@@ -53,6 +97,13 @@ class TestFormatAvailableSkills:
         assert "excel_to_python:" in formatted
         assert "Convert Excel workbook logic" in formatted
 
+    def test_includes_database_rules_when_configured(self, db_config) -> None:
+        from mito_ai_core.completions.prompt_builders.skills import format_available_skills
+
+        formatted = format_available_skills()
+        assert "database_rules:" in formatted
+        assert "SQLAlchemy" in formatted
+
     def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 
@@ -67,3 +118,16 @@ class TestFormatAvailableSkills:
         monkeypatch.setitem(SKILLS, custom_skill.name, custom_skill)
         assert get_skill("custom_skill") == "custom content"
         assert "custom_skill: A test skill." in format_available_skills()
+
+
+class TestGetDatabaseRulesForChat:
+    def test_returns_empty_when_no_db(self, tmp_path, monkeypatch) -> None:
+        missing_path = str(tmp_path / "missing" / "connections.json")
+        monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", missing_path)
+        assert get_database_rules() == ""
+
+    def test_matches_skill_content(self, db_config) -> None:
+        from mito_ai_core.skills.database_rules import DatabaseRulesSkill
+
+        skill = DatabaseRulesSkill()
+        assert get_database_rules() == skill.get_content()

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from mito_ai_core.completions.prompt_builders.prompt_constants import get_database_rules
-from mito_ai_core.skills import database_rules as database_rules_module
+from mito_ai_core.skills import connect_to_db as connect_to_db_module
 from mito_ai_core.skills.types import Skill
 from mito_ai_core.skills.utils import SKILLS, get_available_skills, get_skill, read_skill
 
@@ -21,8 +21,8 @@ def db_config(tmp_path, monkeypatch):
         json.dumps({"my_db": {"username": "admin", "password": "secret", "host": "localhost"}})
     )
     schemas_path.write_text(json.dumps({"my_db": {"tables": ["users"]}}))
-    monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", str(connections_path))
-    monkeypatch.setattr(database_rules_module, "SCHEMAS_PATH", str(schemas_path))
+    monkeypatch.setattr(connect_to_db_module, "CONNECTIONS_PATH", str(connections_path))
+    monkeypatch.setattr(connect_to_db_module, "SCHEMAS_PATH", str(schemas_path))
     return connections_path, schemas_path
 
 
@@ -31,21 +31,21 @@ class TestSkillRegistry:
         assert "excel_to_python" in SKILLS
         assert SKILLS["excel_to_python"].description
 
-    def test_database_rules_is_registered(self) -> None:
-        assert "database_rules" in SKILLS
+    def test_connect_to_db_is_registered(self) -> None:
+        assert "connect_to_db" in SKILLS
 
     def test_list_available_skills_includes_excel_to_python(self) -> None:
         assert "excel_to_python" in get_available_skills()
 
-    def test_database_rules_not_listed_without_config(
+    def test_connect_to_db_not_listed_without_config(
         self, tmp_path, monkeypatch
     ) -> None:
         missing_path = str(tmp_path / "missing" / "connections.json")
-        monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", missing_path)
-        assert "database_rules" not in get_available_skills()
+        monkeypatch.setattr(connect_to_db_module, "CONNECTIONS_PATH", missing_path)
+        assert "connect_to_db" not in get_available_skills()
 
-    def test_database_rules_listed_when_configured(self, db_config) -> None:
-        assert "database_rules" in get_available_skills()
+    def test_connect_to_db_listed_when_configured(self, db_config) -> None:
+        assert "connect_to_db" in get_available_skills()
 
 
 class TestGetSkill:
@@ -57,8 +57,8 @@ class TestGetSkill:
     def test_returns_none_for_missing_skill(self) -> None:
         assert get_skill("missing") is None
 
-    def test_database_rules_includes_user_config(self, db_config) -> None:
-        content = get_skill("database_rules")
+    def test_connect_to_db_includes_user_config(self, db_config) -> None:
+        content = get_skill("connect_to_db")
         assert content is not None
         assert "SQLAlchemy" in content
         assert "redacted" in content
@@ -72,8 +72,8 @@ class TestReadSkill:
         assert result.tool_name == "read_skill"
         assert "mito_check_" in (result.output or "")
 
-    def test_read_database_rules(self, db_config) -> None:
-        result = read_skill("database_rules")
+    def test_read_connect_to_db(self, db_config) -> None:
+        result = read_skill("connect_to_db")
         assert result.success
         assert "Your Database Configuration" in (result.output or "")
 
@@ -97,11 +97,11 @@ class TestFormatAvailableSkills:
         assert "excel_to_python:" in formatted
         assert "Convert Excel workbook logic" in formatted
 
-    def test_includes_database_rules_when_configured(self, db_config) -> None:
+    def test_includes_connect_to_db_when_configured(self, db_config) -> None:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 
         formatted = format_available_skills()
-        assert "database_rules:" in formatted
+        assert "connect_to_db:" in formatted
         assert "database" in formatted.lower()
 
     def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,11 +123,11 @@ class TestFormatAvailableSkills:
 class TestGetDatabaseRulesForChat:
     def test_returns_empty_when_no_db(self, tmp_path, monkeypatch) -> None:
         missing_path = str(tmp_path / "missing" / "connections.json")
-        monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", missing_path)
+        monkeypatch.setattr(connect_to_db_module, "CONNECTIONS_PATH", missing_path)
         assert get_database_rules() == ""
 
     def test_matches_skill_content(self, db_config) -> None:
-        from mito_ai_core.skills.database_rules import DatabaseRulesSkill
+        from mito_ai_core.skills.connect_to_db import ConnectToDbSkill
 
-        skill = DatabaseRulesSkill()
+        skill = ConnectToDbSkill()
         assert get_database_rules() == skill.get_content()

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -102,7 +102,7 @@ class TestFormatAvailableSkills:
 
         formatted = format_available_skills()
         assert "database_rules:" in formatted
-        assert "SQLAlchemy" in formatted
+        assert "database" in formatted.lower()
 
     def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -8,7 +8,7 @@ import pytest
 from mito_ai_core.completions.prompt_builders.prompt_constants import get_database_rules
 from mito_ai_core.skills import database_rules as database_rules_module
 from mito_ai_core.skills.types import Skill
-from mito_ai_core.skills.utils import SKILLS, get_skill, list_available_skills, read_skill
+from mito_ai_core.skills.utils import SKILLS, get_available_skills, get_skill, read_skill
 
 
 @pytest.fixture
@@ -35,17 +35,17 @@ class TestSkillRegistry:
         assert "database_rules" in SKILLS
 
     def test_list_available_skills_includes_excel_to_python(self) -> None:
-        assert "excel_to_python" in list_available_skills()
+        assert "excel_to_python" in get_available_skills()
 
     def test_database_rules_not_listed_without_config(
         self, tmp_path, monkeypatch
     ) -> None:
         missing_path = str(tmp_path / "missing" / "connections.json")
         monkeypatch.setattr(database_rules_module, "CONNECTIONS_PATH", missing_path)
-        assert "database_rules" not in list_available_skills()
+        assert "database_rules" not in get_available_skills()
 
     def test_database_rules_listed_when_configured(self, db_config) -> None:
-        assert "database_rules" in list_available_skills()
+        assert "database_rules" in get_available_skills()
 
 
 class TestGetSkill:

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -38,29 +38,30 @@ def db_config(tmp_path, monkeypatch):
 
 class TestSkillRegistry:
     def test_excel_to_python_is_registered(self) -> None:
-        assert "excel_to_python" in SKILLS
-        assert SKILLS["excel_to_python"].description
+        assert "excel-to-python" in SKILLS
+        assert SKILLS["excel-to-python"].description
+        assert "Use when" in SKILLS["excel-to-python"].description
 
     def test_connect_to_db_is_registered(self) -> None:
-        assert "connect_to_db" in SKILLS
+        assert "connect-to-db" in SKILLS
 
     def test_list_available_skills_includes_excel_to_python(self) -> None:
-        assert "excel_to_python" in get_available_skills()
+        assert "excel-to-python" in get_available_skills()
 
     def test_connect_to_db_not_listed_without_config(
         self, tmp_path, monkeypatch
     ) -> None:
         missing_path = str(tmp_path / "missing" / "connections.json")
         monkeypatch.setattr(connect_to_db_module, "CONNECTIONS_PATH", missing_path)
-        assert "connect_to_db" not in get_available_skills()
+        assert "connect-to-db" not in get_available_skills()
 
     def test_connect_to_db_listed_when_configured(self, db_config) -> None:
-        assert "connect_to_db" in get_available_skills()
+        assert "connect-to-db" in get_available_skills()
 
 
 class TestGetSkill:
     def test_returns_content_for_registered_skill(self) -> None:
-        content = get_skill("excel_to_python")
+        content = get_skill("excel-to-python")
         assert content is not None
         assert "Configuration cell" in content
 
@@ -68,7 +69,7 @@ class TestGetSkill:
         assert get_skill("missing") is None
 
     def test_connect_to_db_includes_user_config(self, db_config) -> None:
-        content = get_skill("connect_to_db")
+        content = get_skill("connect-to-db")
         assert content is not None
         assert "SQLAlchemy" in content
         assert "redacted" in content
@@ -77,13 +78,13 @@ class TestGetSkill:
 
 class TestReadSkill:
     def test_returns_skill_content(self) -> None:
-        result = read_skill("excel_to_python")
+        result = read_skill("excel-to-python")
         assert result.success
         assert result.tool_name == "read_skill"
         assert "mito_check_" in (result.output or "")
 
     def test_read_connect_to_db(self, db_config) -> None:
-        result = read_skill("connect_to_db")
+        result = read_skill("connect-to-db")
         assert result.success
         assert "Your Database Configuration" in (result.output or "")
 
@@ -104,15 +105,17 @@ class TestFormatAvailableSkills:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 
         formatted = format_available_skills()
-        assert "excel_to_python:" in formatted
-        assert "Convert Excel workbook logic" in formatted
+        assert "excel-to-python:" in formatted
+        assert "Convert Excel workbook formulas" in formatted
+        assert "Use when" in formatted
 
     def test_includes_connect_to_db_when_configured(self, db_config) -> None:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 
         formatted = format_available_skills()
-        assert "connect_to_db:" in formatted
-        assert "database" in formatted.lower()
+        assert "connect-to-db:" in formatted
+        assert "SQLAlchemy" in formatted
+        assert "Use when" in formatted
         assert "my_db (postgres)" in formatted
 
     def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -114,7 +114,7 @@ class TestFormatAvailableSkills:
 
         formatted = format_available_skills()
         assert "connect-to-db:" in formatted
-        assert "SQLAlchemy" in formatted
+        assert "pandas DataFrames" in formatted
         assert "Use when" in formatted
         assert "my_db (postgres)" in formatted
 

--- a/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
+++ b/mito-ai-core/mito_ai_core/tests/skills/test_skills_utils.py
@@ -18,7 +18,17 @@ def db_config(tmp_path, monkeypatch):
     connections_path = db_dir / "connections.json"
     schemas_path = db_dir / "schemas.json"
     connections_path.write_text(
-        json.dumps({"my_db": {"username": "admin", "password": "secret", "host": "localhost"}})
+        json.dumps(
+            {
+                "550e8400-e29b-41d4-a716-446655440000": {
+                    "type": "postgres",
+                    "alias": "my_db",
+                    "username": "admin",
+                    "password": "secret",
+                    "host": "localhost",
+                }
+            }
+        )
     )
     schemas_path.write_text(json.dumps({"my_db": {"tables": ["users"]}}))
     monkeypatch.setattr(connect_to_db_module, "CONNECTIONS_PATH", str(connections_path))
@@ -103,13 +113,17 @@ class TestFormatAvailableSkills:
         formatted = format_available_skills()
         assert "connect_to_db:" in formatted
         assert "database" in formatted.lower()
+        assert "my_db (postgres)" in formatted
 
     def test_custom_skill_in_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from mito_ai_core.completions.prompt_builders.skills import format_available_skills
 
         class CustomSkill(Skill):
             name = "custom_skill"
-            description = "A test skill."
+
+            @property
+            def description(self) -> str:
+                return "A test skill."
 
             def get_content(self) -> str:
                 return "custom content"


### PR DESCRIPTION
# Description

Moved the database rules out of the system prompt, and into a separate skill.

# Testing

Ask the Agent to get something from a database. Test tagging the database and just mentioning it. 

# Documentation

N/A -- BTS change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how DB credentials and query rules reach the model (on-demand vs always in agent prompt); behavior should match when `read_skill` is used, but agent may omit DB context if it skips the skill.
> 
> **Overview**
> Database guidance moves out of the **agent** system prompt and into an on-demand **`connect_to_db`** skill loaded via **`read_skill`**, so agent chats only pay for DB instructions when the skill is used.
> 
> A new **`ConnectToDbSkill`** centralizes SQLAlchemy rules, redacted **`connections.json`**, and schema text; it appears in **Available Skills** only when **`connections.json`** exists. **`get_available_skills`**, **`get_skill`**, and **`read_skill`** now ignore unavailable skills. **Chat mode** still injects DB rules through **`get_database_rules()`**, which delegates to the same skill content when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13f65bc2094e4cfb117373cf8bab36ab7b5b670. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->