### PR TITLE
Speech-to-Text

### DIFF
--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -3,7 +3,7 @@
  * Distributed under the terms of the GNU Affero General Public License v3.0 License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { classNames } from '../../../utils/classNames';
 import { IContextManager } from '../../ContextManager/ContextManagerPlugin';
@@ -22,7 +22,6 @@ import SelectedContextContainer from '../../../components/SelectedContextContain
 import AttachFileButton from '../../../components/AttachFileButton';
 import DatabaseButton from '../../../components/DatabaseButton';
 import IconButton from '../../../components/IconButton';
-import VoiceInputButton from '../../../components/VoiceInputButton';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { AgentExecutionStatus } from '../ChatTaskpane';
 import { uploadFileToBackend } from '../../../utils/fileUpload';
@@ -58,6 +57,8 @@ interface ChatInputProps {
     onAttentionGlowAnimationEnd?: () => void;
     /** Fired when DataFrame viewer selection is added via the Jupyter command (for attention glow, etc.). */
     onDataframeViewerContextAdded?: () => void;
+    /** Parent can call this to append dictated text into the input (e.g. voice button in chat controls). */
+    voiceTranscriptRef?: React.MutableRefObject<((text: string) => void) | null>;
 }
 
 export interface ExpandedVariable extends Variable {
@@ -98,6 +99,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
     attentionGlowActive = false,
     onAttentionGlowAnimationEnd,
     onDataframeViewerContextAdded,
+    voiceTranscriptRef,
 }) => {
     const [input, setInput] = useState(initialContent);
     const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -425,7 +427,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         adjustHeight();
     }, [textAreaRef?.current?.value]);
 
-    const appendVoiceTranscript = (text: string): void => {
+    const appendVoiceTranscript = useCallback((text: string): void => {
         const trimmed = text.trim();
         if (!trimmed) {
             return;
@@ -433,7 +435,17 @@ const ChatInput: React.FC<ChatInputProps> = ({
         setInput((prev) => (prev ? `${prev} ${trimmed}` : trimmed));
         textAreaRef.current?.focus();
         setTimeout(() => adjustHeight(), 0);
-    };
+    }, []);
+
+    useEffect(() => {
+        if (!voiceTranscriptRef) {
+            return;
+        }
+        voiceTranscriptRef.current = appendVoiceTranscript;
+        return () => {
+            voiceTranscriptRef.current = null;
+        };
+    }, [voiceTranscriptRef, appendVoiceTranscript]);
 
     const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
         const value = event.target.value;
@@ -757,14 +769,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
             >
                 <DatabaseButton app={app} />
                 <AttachFileButton onFileUploaded={handleFileUpload} notebookTracker={notebookTracker} />
-                <VoiceInputButton
-                    onTranscript={appendVoiceTranscript}
-                    disabled={
-                        !canSendMessages ||
-                        agentExecutionStatus === 'working' ||
-                        agentExecutionStatus === 'stopping'
-                    }
-                />
                 <IconButton
                     icon={<span className="add-context-button-icon">@</span>}
                     title="Add Context"

--- a/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatMessage/ChatInput.tsx
@@ -22,6 +22,7 @@ import SelectedContextContainer from '../../../components/SelectedContextContain
 import AttachFileButton from '../../../components/AttachFileButton';
 import DatabaseButton from '../../../components/DatabaseButton';
 import IconButton from '../../../components/IconButton';
+import VoiceInputButton from '../../../components/VoiceInputButton';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { AgentExecutionStatus } from '../ChatTaskpane';
 import { uploadFileToBackend } from '../../../utils/fileUpload';
@@ -424,6 +425,16 @@ const ChatInput: React.FC<ChatInputProps> = ({
         adjustHeight();
     }, [textAreaRef?.current?.value]);
 
+    const appendVoiceTranscript = (text: string): void => {
+        const trimmed = text.trim();
+        if (!trimmed) {
+            return;
+        }
+        setInput((prev) => (prev ? `${prev} ${trimmed}` : trimmed));
+        textAreaRef.current?.focus();
+        setTimeout(() => adjustHeight(), 0);
+    };
+
     const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
         const value = event.target.value;
         setInput(value);
@@ -746,6 +757,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
             >
                 <DatabaseButton app={app} />
                 <AttachFileButton onFileUploaded={handleFileUpload} notebookTracker={notebookTracker} />
+                <VoiceInputButton
+                    onTranscript={appendVoiceTranscript}
+                    disabled={
+                        !canSendMessages ||
+                        agentExecutionStatus === 'working' ||
+                        agentExecutionStatus === 'stopping'
+                    }
+                />
                 <IconButton
                     icon={<span className="add-context-button-icon">@</span>}
                     title="Add Context"

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -37,6 +37,7 @@ import LoadingCircle from '../../components/LoadingCircle';
 import ModelSelector from '../../components/ModelSelector';
 import NextStepsPills from '../../components/NextStepsPills';
 import ToggleButton from '../../components/ToggleButton';
+import VoiceInputButton from '../../components/VoiceInputButton';
 
 // Internal imports - Icons
 import { OpenIndicatorLabIcon } from '../../icons';
@@ -185,6 +186,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
 
     // Ref to trigger refresh of the usage badge
     const usageBadgeRef = useRef<UsageBadgeRef>(null);
+    const voiceTranscriptRef = useRef<((text: string) => void) | null>(null);
 
     /** Brief border glow on the taskpane when context arrives from the DataFrame viewer */
     const [attentionGlowActive, setAttentionGlowActive] = useState(false);
@@ -1200,6 +1202,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     onDataframeViewerContextAdded={handleDataframeViewerContextAdded}
                     attentionGlowActive={attentionGlowActive}
                     onAttentionGlowAnimationEnd={() => setAttentionGlowActive(false)}
+                    voiceTranscriptRef={voiceTranscriptRef}
                 />
             </div>
             {agentExecution.agentExecutionStatus !== 'working' && agentExecution.agentExecutionStatus !== 'stopping' && (
@@ -1228,31 +1231,37 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                             void updateModelOnBackend(config.model);
                         }} />
                     </div>
-                    <button
-                        className="button-base submit-button"
-                        disabled={ghCopilot.copilotBlocksChat}
-                        onClick={() => {
-                            if (ghCopilot.copilotBlocksChat) {
-                                return;
-                            }
-                            const chatInput = document.querySelector('.chat-input') as HTMLTextAreaElement;
-                            if (chatInput && chatInput.value) {
-                                // Simulate an Enter keypress
-                                // This triggers the existing submission logic in ChatInput.tsx
-                                const enterEvent = new KeyboardEvent('keydown', {
-                                    key: 'Enter',
-                                    code: 'Enter',
-                                    keyCode: 13,
-                                    which: 13,
-                                    bubbles: true,
-                                    cancelable: true
-                                });
-                                chatInput.dispatchEvent(enterEvent);
-                            }
-                        }}
-                    >
-                        <span className="submit-text">Submit</span> ⏎
-                    </button>
+                    <div className="chat-controls-right">
+                        <VoiceInputButton
+                            onTranscript={(text) => voiceTranscriptRef.current?.(text)}
+                            disabled={ghCopilot.copilotBlocksChat}
+                        />
+                        <button
+                            className="button-base submit-button"
+                            disabled={ghCopilot.copilotBlocksChat}
+                            onClick={() => {
+                                if (ghCopilot.copilotBlocksChat) {
+                                    return;
+                                }
+                                const chatInput = document.querySelector('.chat-input') as HTMLTextAreaElement;
+                                if (chatInput && chatInput.value) {
+                                    // Simulate an Enter keypress
+                                    // This triggers the existing submission logic in ChatInput.tsx
+                                    const enterEvent = new KeyboardEvent('keydown', {
+                                        key: 'Enter',
+                                        code: 'Enter',
+                                        keyCode: 13,
+                                        which: 13,
+                                        bubbles: true,
+                                        cancelable: true
+                                    });
+                                    chatInput.dispatchEvent(enterEvent);
+                                }
+                            }}
+                        >
+                            <span className="submit-text">Submit</span> ⏎
+                        </button>
+                    </div>
                 </div>
             )}
             {(agentExecution.agentExecutionStatus === 'working' || agentExecution.agentExecutionStatus === 'stopping') && (

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -187,6 +187,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     // Ref to trigger refresh of the usage badge
     const usageBadgeRef = useRef<UsageBadgeRef>(null);
     const voiceTranscriptRef = useRef<((text: string) => void) | null>(null);
+    const stopDictationRef = useRef<(() => void) | null>(null);
 
     /** Brief border glow on the taskpane when context arrives from the DataFrame viewer */
     const [attentionGlowActive, setAttentionGlowActive] = useState(false);
@@ -490,6 +491,8 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
+
+        stopDictationRef.current?.();
 
         // Then send the new message to replace it
         if (agentModeEnabled) {
@@ -1234,6 +1237,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
                     <div className="chat-controls-right">
                         <VoiceInputButton
                             onTranscript={(text) => voiceTranscriptRef.current?.(text)}
+                            stopDictationRef={stopDictationRef}
                             disabled={ghCopilot.copilotBlocksChat}
                         />
                         <button

--- a/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
+++ b/mito-ai/src/Extensions/AiChat/ChatTaskpane.tsx
@@ -188,6 +188,9 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
     const usageBadgeRef = useRef<UsageBadgeRef>(null);
     const voiceTranscriptRef = useRef<((text: string) => void) | null>(null);
     const stopDictationRef = useRef<(() => void) | null>(null);
+    const stopDictation = (): void => {
+        stopDictationRef.current?.();
+    };
 
     /** Brief border glow on the taskpane when context arrives from the DataFrame viewer */
     const [attentionGlowActive, setAttentionGlowActive] = useState(false);
@@ -320,6 +323,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
+        stopDictation();
         // Check if user is in agent mode and switch to chat mode if needed
         if (agentModeEnabledRef.current) {
             await startNewChat();
@@ -355,6 +359,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
+        stopDictation();
         // Step 0: reset the state for a new message
         resetForNewMessage()
 
@@ -389,6 +394,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
+        stopDictation();
 
         // Step 0: reset the state for a new message
         resetForNewMessage()
@@ -434,6 +440,7 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
+        stopDictation();
         // Step 0: reset the state for a new message
         resetForNewMessage()
 
@@ -491,8 +498,6 @@ const ChatTaskpane: React.FC<IChatTaskpaneProps> = ({
         if (copilotBlocksChatRef.current) {
             return;
         }
-
-        stopDictationRef.current?.();
 
         // Then send the new message to replace it
         if (agentModeEnabled) {

--- a/mito-ai/src/components/VoiceInputButton.tsx
+++ b/mito-ai/src/components/VoiceInputButton.tsx
@@ -31,10 +31,6 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({ onTranscript, disab
             className={classNames('icon-button-hover', 'voice-input-button', {
                 'voice-input-button--listening': isListening,
             })}
-            style={{
-                height: 'var(--chat-context-button-height)',
-                width: 'var(--chat-context-button-height)',
-            }}
         />
     );
 };

--- a/mito-ai/src/components/VoiceInputButton.tsx
+++ b/mito-ai/src/components/VoiceInputButton.tsx
@@ -25,6 +25,12 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
     const { isListening, isSupported, toggleListening, stopListening } = useSpeechToText(onTranscript);
 
     useEffect(() => {
+        if (disabled) {
+            stopListening();
+        }
+    }, [disabled, stopListening]);
+
+    useEffect(() => {
         if (!stopDictationRef) {
             return;
         }

--- a/mito-ai/src/components/VoiceInputButton.tsx
+++ b/mito-ai/src/components/VoiceInputButton.tsx
@@ -3,7 +3,7 @@
  * Distributed under the terms of the GNU Affero General Public License v3.0 License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import IconButton from './IconButton';
 import MicrophoneOutlineIcon from '../icons/MicrophoneOutlineIcon';
 import { useSpeechToText } from '../hooks/useSpeechToText';
@@ -13,10 +13,26 @@ import '../../style/VoiceInputButton.css';
 interface VoiceInputButtonProps {
     onTranscript: (text: string) => void;
     disabled?: boolean;
+    /** Parent can call this to stop an active dictation session (e.g. on message send). */
+    stopDictationRef?: React.MutableRefObject<(() => void) | null>;
 }
 
-const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({ onTranscript, disabled = false }) => {
-    const { isListening, isSupported, toggleListening } = useSpeechToText(onTranscript);
+const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
+    onTranscript,
+    disabled = false,
+    stopDictationRef,
+}) => {
+    const { isListening, isSupported, toggleListening, stopListening } = useSpeechToText(onTranscript);
+
+    useEffect(() => {
+        if (!stopDictationRef) {
+            return;
+        }
+        stopDictationRef.current = stopListening;
+        return () => {
+            stopDictationRef.current = null;
+        };
+    }, [stopDictationRef, stopListening]);
 
     if (!isSupported) {
         return null;

--- a/mito-ai/src/components/VoiceInputButton.tsx
+++ b/mito-ai/src/components/VoiceInputButton.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+import IconButton from './IconButton';
+import MicrophoneOutlineIcon from '../icons/MicrophoneOutlineIcon';
+import { useSpeechToText } from '../hooks/useSpeechToText';
+import { classNames } from '../utils/classNames';
+import '../../style/VoiceInputButton.css';
+
+interface VoiceInputButtonProps {
+    onTranscript: (text: string) => void;
+    disabled?: boolean;
+}
+
+const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({ onTranscript, disabled = false }) => {
+    const { isListening, isSupported, toggleListening } = useSpeechToText(onTranscript);
+
+    if (!isSupported) {
+        return null;
+    }
+
+    return (
+        <IconButton
+            icon={<MicrophoneOutlineIcon />}
+            title={isListening ? 'Stop dictation' : 'Dictate message'}
+            disabled={disabled}
+            onClick={toggleListening}
+            className={classNames('icon-button-hover', 'voice-input-button', {
+                'voice-input-button--listening': isListening,
+            })}
+            style={{
+                height: 'var(--chat-context-button-height)',
+                width: 'var(--chat-context-button-height)',
+            }}
+        />
+    );
+};
+
+export default VoiceInputButton;

--- a/mito-ai/src/hooks/useSpeechToText.ts
+++ b/mito-ai/src/hooks/useSpeechToText.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface ISpeechRecognition extends EventTarget {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    start: () => void;
+    stop: () => void;
+    onresult: ((event: ISpeechRecognitionEvent) => void) | null;
+    onerror: (() => void) | null;
+    onend: (() => void) | null;
+}
+
+interface ISpeechRecognitionEvent {
+    resultIndex: number;
+    results: {
+        length: number;
+        [index: number]: {
+            isFinal: boolean;
+            [index: number]: { transcript: string };
+        };
+    };
+}
+
+type SpeechRecognitionConstructor = new () => ISpeechRecognition;
+
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null {
+    const win = window as Window & {
+        SpeechRecognition?: SpeechRecognitionConstructor;
+        webkitSpeechRecognition?: SpeechRecognitionConstructor;
+    };
+    return win.SpeechRecognition ?? win.webkitSpeechRecognition ?? null;
+}
+
+export function useSpeechToText(onTranscript: (text: string) => void): {
+    isListening: boolean;
+    isSupported: boolean;
+    toggleListening: () => void;
+} {
+    const [isListening, setIsListening] = useState(false);
+    const [isSupported] = useState(() => getSpeechRecognitionConstructor() !== null);
+    const recognitionRef = useRef<ISpeechRecognition | null>(null);
+    const onTranscriptRef = useRef(onTranscript);
+    onTranscriptRef.current = onTranscript;
+
+    const stopListening = useCallback(() => {
+        recognitionRef.current?.stop();
+        recognitionRef.current = null;
+        setIsListening(false);
+    }, []);
+
+    const startListening = useCallback(() => {
+        const SpeechRecognitionClass = getSpeechRecognitionConstructor();
+        if (!SpeechRecognitionClass) {
+            return;
+        }
+
+        const recognition = new SpeechRecognitionClass();
+        recognition.continuous = true;
+        recognition.interimResults = false;
+        recognition.lang = 'en-US';
+
+        recognition.onresult = (event: ISpeechRecognitionEvent) => {
+            let transcript = '';
+            for (let i = event.resultIndex; i < event.results.length; i++) {
+                const result = event.results[i];
+                const alternative = result?.[0];
+                if (!result?.isFinal || !alternative) {
+                    continue;
+                }
+                transcript += alternative.transcript;
+            }
+            const trimmed = transcript.trim();
+            if (trimmed) {
+                onTranscriptRef.current(trimmed);
+            }
+        };
+
+        recognition.onerror = () => {
+            stopListening();
+        };
+
+        recognition.onend = () => {
+            recognitionRef.current = null;
+            setIsListening(false);
+        };
+
+        recognitionRef.current = recognition;
+        recognition.start();
+        setIsListening(true);
+    }, [stopListening]);
+
+    const toggleListening = useCallback(() => {
+        if (isListening) {
+            stopListening();
+        } else {
+            startListening();
+        }
+    }, [isListening, startListening, stopListening]);
+
+    useEffect(() => {
+        return () => {
+            recognitionRef.current?.stop();
+        };
+    }, []);
+
+    return { isListening, isSupported, toggleListening };
+}

--- a/mito-ai/src/hooks/useSpeechToText.ts
+++ b/mito-ai/src/hooks/useSpeechToText.ts
@@ -41,6 +41,7 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
     isListening: boolean;
     isSupported: boolean;
     toggleListening: () => void;
+    stopListening: () => void;
 } {
     const [isListening, setIsListening] = useState(false);
     const [isSupported] = useState(() => getSpeechRecognitionConstructor() !== null);
@@ -133,5 +134,5 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
         };
     }, [releaseRecognition]);
 
-    return { isListening, isSupported, toggleListening };
+    return { isListening, isSupported, toggleListening, stopListening };
 }

--- a/mito-ai/src/hooks/useSpeechToText.ts
+++ b/mito-ai/src/hooks/useSpeechToText.ts
@@ -81,6 +81,9 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
         recognition.lang = 'en-US';
 
         recognition.onresult = (event: ISpeechRecognitionEvent) => {
+            if (recognitionRef.current !== recognition) {
+                return;
+            }
             let transcript = '';
             for (let i = event.resultIndex; i < event.results.length; i++) {
                 const result = event.results[i];
@@ -97,10 +100,16 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
         };
 
         recognition.onerror = () => {
+            if (recognitionRef.current !== recognition) {
+                return;
+            }
             stopListening();
         };
 
         recognition.onend = () => {
+            if (recognitionRef.current !== recognition) {
+                return;
+            }
             recognitionRef.current = null;
             setIsListening(false);
         };

--- a/mito-ai/src/hooks/useSpeechToText.ts
+++ b/mito-ai/src/hooks/useSpeechToText.ts
@@ -48,11 +48,22 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
     const onTranscriptRef = useRef(onTranscript);
     onTranscriptRef.current = onTranscript;
 
-    const stopListening = useCallback(() => {
-        recognitionRef.current?.stop();
+    const releaseRecognition = useCallback(() => {
+        const recognition = recognitionRef.current;
+        if (!recognition) {
+            return;
+        }
         recognitionRef.current = null;
-        setIsListening(false);
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognition.onend = null;
+        recognition.stop();
     }, []);
+
+    const stopListening = useCallback(() => {
+        releaseRecognition();
+        setIsListening(false);
+    }, [releaseRecognition]);
 
     const startListening = useCallback(() => {
         if (recognitionRef.current) {
@@ -109,9 +120,9 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
 
     useEffect(() => {
         return () => {
-            recognitionRef.current?.stop();
+            releaseRecognition();
         };
-    }, []);
+    }, [releaseRecognition]);
 
     return { isListening, isSupported, toggleListening };
 }

--- a/mito-ai/src/hooks/useSpeechToText.ts
+++ b/mito-ai/src/hooks/useSpeechToText.ts
@@ -55,6 +55,10 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
     }, []);
 
     const startListening = useCallback(() => {
+        if (recognitionRef.current) {
+            return;
+        }
+
         const SpeechRecognitionClass = getSpeechRecognitionConstructor();
         if (!SpeechRecognitionClass) {
             return;
@@ -96,12 +100,12 @@ export function useSpeechToText(onTranscript: (text: string) => void): {
     }, [stopListening]);
 
     const toggleListening = useCallback(() => {
-        if (isListening) {
+        if (recognitionRef.current) {
             stopListening();
         } else {
             startListening();
         }
-    }, [isListening, startListening, stopListening]);
+    }, [startListening, stopListening]);
 
     useEffect(() => {
         return () => {

--- a/mito-ai/src/icons/MicrophoneOutlineIcon.tsx
+++ b/mito-ai/src/icons/MicrophoneOutlineIcon.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+import React from 'react';
+
+const MicrophoneOutlineIcon: React.FC = () => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+            d="M12 14a3 3 0 0 0 3-3V6a3 3 0 1 0-6 0v5a3 3 0 0 0 3 3Z"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            d="M19 11v1a7 7 0 0 1-14 0v-1M12 19v3M8 22h8"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+);
+
+export default MicrophoneOutlineIcon;

--- a/mito-ai/src/icons/MicrophoneOutlineIcon.tsx
+++ b/mito-ai/src/icons/MicrophoneOutlineIcon.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 const MicrophoneOutlineIcon: React.FC = () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M12 14a3 3 0 0 0 3-3V6a3 3 0 1 0-6 0v5a3 3 0 0 0 3 3Z"
             stroke="currentColor"

--- a/mito-ai/style/ChatTaskpane.css
+++ b/mito-ai/style/ChatTaskpane.css
@@ -173,6 +173,13 @@
 .chat-controls-left > * {
   margin: 0 !important;
 }
+
+.chat-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .submit-button {
   background-color: var(--purple-400);
   color: var(--purple-700);

--- a/mito-ai/style/VoiceInputButton.css
+++ b/mito-ai/style/VoiceInputButton.css
@@ -10,10 +10,11 @@
   border-radius: 3px;
   background-color: transparent;
   border: none;
+  color: var(--purple-700);
 }
 
 .voice-input-button:hover:not(:disabled) {
-  background-color: var(--jp-layout-color3);
+  background-color: var(--purple-400);
 }
 
 .voice-input-button svg {
@@ -24,21 +25,20 @@
 @keyframes voice-input-pulse {
   0%,
   100% {
-    background-color: rgba(157, 108, 255, 0.12);
+    background-color: var(--purple-300);
   }
   50% {
-    background-color: rgba(157, 108, 255, 0.28);
+    background-color: var(--purple-400);
   }
 }
 
 .voice-input-button--listening {
-  color: var(--purple-500);
   animation: voice-input-pulse 1.4s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .voice-input-button--listening {
     animation: none;
-    background-color: rgba(157, 108, 255, 0.15);
+    background-color: var(--purple-400);
   }
 }

--- a/mito-ai/style/VoiceInputButton.css
+++ b/mito-ai/style/VoiceInputButton.css
@@ -3,8 +3,25 @@
  * Distributed under the terms of the GNU Affero General Public License v3.0 License.
  */
 
+.voice-input-button {
+  min-width: 36px;
+  min-height: 28px;
+  padding: 4px 10px;
+  border-radius: 3px;
+  background-color: transparent;
+  border: none;
+}
+
+.voice-input-button:hover:not(:disabled) {
+  background-color: var(--jp-layout-color3);
+}
+
+.voice-input-button svg {
+  width: 18px;
+  height: 18px;
+}
+
 .voice-input-button--listening {
   color: var(--purple-500);
   background-color: rgba(157, 108, 255, 0.15);
-  border-radius: 6px;
 }

--- a/mito-ai/style/VoiceInputButton.css
+++ b/mito-ai/style/VoiceInputButton.css
@@ -21,7 +21,24 @@
   height: 18px;
 }
 
+@keyframes voice-input-pulse {
+  0%,
+  100% {
+    background-color: rgba(157, 108, 255, 0.12);
+  }
+  50% {
+    background-color: rgba(157, 108, 255, 0.28);
+  }
+}
+
 .voice-input-button--listening {
   color: var(--purple-500);
-  background-color: rgba(157, 108, 255, 0.15);
+  animation: voice-input-pulse 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-input-button--listening {
+    animation: none;
+    background-color: rgba(157, 108, 255, 0.15);
+  }
 }

--- a/mito-ai/style/VoiceInputButton.css
+++ b/mito-ai/style/VoiceInputButton.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Saga Inc.
+ * Distributed under the terms of the GNU Affero General Public License v3.0 License.
+ */
+
+.voice-input-button--listening {
+  color: var(--purple-500);
+  background-color: rgba(157, 108, 255, 0.15);
+  border-radius: 6px;
+}


### PR DESCRIPTION
# Description

Adds a new dictation tool to the chat taskpane. 

# Testing

Use the dictation tool to speak directly to Mito AI.

# Documentation

Yes we should document this somewhere. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Web Speech API integration with no server or auth changes; unsupported browsers hide the control, and dictation stops on submit.
> 
> **Overview**
> Adds **voice dictation** to the Mito AI chat taskpane so users can speak into the message field instead of typing only.
> 
> A new **`useSpeechToText`** hook wraps the browser **Web Speech API** (`SpeechRecognition` / `webkitSpeechRecognition`), streams **final** transcript chunks, and exposes start/stop/toggle. **`VoiceInputButton`** sits next to Submit in the controls bar (hidden when the API is unsupported), shows a listening state with pulse styling, and stops when disabled or when the parent invokes **`stopDictationRef`**. **`ChatInput`** registers **`voiceTranscriptRef`** to append dictated text to the textarea (with spacing), refocus, and resize height. **`ChatTaskpane`** wires those refs and **ends dictation on message send** so recording does not continue after submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d674fdc18032c3a7debb6958ba50e7426942cb8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->