### PR TITLE
mito-ai: fix error

### DIFF
--- a/mito-ai/src/tests/utils/agentActions.test.tsx
+++ b/mito-ai/src/tests/utils/agentActions.test.tsx
@@ -62,6 +62,7 @@ describe('acceptAndRunCellUpdate', () => {
             'markdown',
         );
         expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'markdown');
+        expect(NotebookActions.run).not.toHaveBeenCalled();
     });
 
     test('passes code cell_type for code cell updates', async () => {
@@ -85,5 +86,9 @@ describe('acceptAndRunCellUpdate', () => {
             'code',
         );
         expect(NotebookActions.changeCellType).toHaveBeenCalledWith(notebookPanel.content, 'code');
+        expect(NotebookActions.run).toHaveBeenCalledWith(
+            notebookPanel.content,
+            notebookPanel.context.sessionContext,
+        );
     });
 });

--- a/mito-ai/src/utils/agentActions.tsx
+++ b/mito-ai/src/utils/agentActions.tsx
@@ -77,6 +77,7 @@ export const acceptAndRunCellUpdate = async (
         };
     }
 
+    
     const cellID = getActiveCellIDInNotebookPanel(notebookPanel)
     if (!cellID) {
         return {
@@ -85,12 +86,10 @@ export const acceptAndRunCellUpdate = async (
         };
     }
 
-    writeContentToCellByIDInNotebookPanel(
-        notebookPanel,
-        cellUpdate.code,
-        cellID,
-        cellUpdate.cell_type,
-    )
+    const targetCellId =
+        cellUpdate.type === 'modification' ? cellUpdate.id! : cellID;
+
+    setActiveCellByIDInNotebookPanel(notebookPanel, targetCellId)
 
     // We always create code cells, and then convert to markdown if necessary.
     if (cellUpdate.cell_type === 'markdown') {
@@ -98,12 +97,23 @@ export const acceptAndRunCellUpdate = async (
     } else if (cellUpdate.cell_type === 'code') {
         NotebookActions.changeCellType(notebook, 'code');
     }
-    
-    // This awaits until after the execution is finished.
-    // Note that it is important that we just run the cell and don't run and advance the cell. 
-    // We rely on the active cell remaining the same after running the cell in order to get the output
-    // of the cell to send to the agent. This is changeable in the future, but for now its an invariant we rely on.
-    await NotebookActions.run(notebook, context?.sessionContext);
+
+    writeContentToCellByIDInNotebookPanel(
+        notebookPanel,
+        cellUpdate.code,
+        targetCellId,
+        cellUpdate.cell_type,
+    )
+
+    // Markdown cells must not be executed as code (avoids SyntaxError on prose).
+    if (cellUpdate.cell_type === 'code') {
+        setActiveCellByIDInNotebookPanel(notebookPanel, targetCellId)
+        // This awaits until after the execution is finished.
+        // Note that it is important that we just run the cell and don't run and advance the cell.
+        // We rely on the active cell remaining the same after running the cell in order to get the output
+        // of the cell to send to the agent. This is changeable in the future, but for now its an invariant we rely on.
+        await NotebookActions.run(notebook, context?.sessionContext);
+    }
     
     // Scroll to the bottom of the active cell to show the output
     // as long as we are not operating in background agent mode.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, and the specification if there is one. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to agent cell-apply flow and unit tests; code-cell execution path is preserved with clearer ordering.
> 
> **Overview**
> Fixes AI **cell updates** so markdown is not executed as Python, which was causing **SyntaxError** on prose.
> 
> `acceptAndRunCellUpdate` now resolves a **`targetCellId`** (modification `id` vs active cell for new cells), activates that cell, sets **markdown/code** type, writes content, and only calls **`NotebookActions.run`** when `cell_type` is **`code`**. Code cells still run with the same session context and active-cell invariant for capturing output.
> 
> Tests assert **`NotebookActions.run`** is **not** invoked for markdown updates and **is** invoked for code updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc87d56eac5adbd2736ee7e63dbe673cedd9a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->