### PR TITLE
MCP Persistent Connections

### DIFF
--- a/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
+++ b/mito-ai/mito_ai/completions/jupyter_lab_tool_executor.py
@@ -275,7 +275,7 @@ class JupyterLabToolExecutor:
                 error_message=str(e),
             )
 
-        result = await call_server_tool(server_config, tool_name, arguments)
+        result = await call_server_tool(server_config, tool_name, arguments, server_id=mcp_server_id)
         if result.get("success"):
             return ToolResult(
                 success=True,

--- a/mito-ai/mito_ai/mcp/handlers.py
+++ b/mito-ai/mito_ai/mcp/handlers.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
-from mito_ai.mcp.mcp_client import list_server_tools
+from mito_ai.mcp.mcp_client import list_server_tools, mcp_connection_manager
 from mito_ai.mcp.utils import (
     delete_server,
     load_servers,
@@ -58,7 +58,7 @@ class MCPServersHandler(APIHandler):
 
         ids = list(servers.keys())
         results = await asyncio.gather(
-            *(list_server_tools(servers[sid]) for sid in ids),
+            *(list_server_tools(servers[sid], server_id=sid) for sid in ids),
             return_exceptions=True,
         )
 
@@ -132,7 +132,7 @@ class MCPServersHandler(APIHandler):
         )
 
     @tornado.web.authenticated
-    def delete(self, *args: Any, **kwargs: Any) -> None:
+    async def delete(self, *args: Any, **kwargs: Any) -> None:
         """Delete an MCP server by id."""
         server_id = kwargs.get("uuid")
         if not server_id:
@@ -141,4 +141,5 @@ class MCPServersHandler(APIHandler):
             return
 
         delete_server(server_id)
+        await mcp_connection_manager.invalidate(server_id)
         self.finish(json.dumps({"status": "success"}))

--- a/mito-ai/mito_ai/mcp/handlers.py
+++ b/mito-ai/mito_ai/mcp/handlers.py
@@ -58,7 +58,7 @@ class MCPServersHandler(APIHandler):
 
         ids = list(servers.keys())
         results = await asyncio.gather(
-            *(list_server_tools(servers[sid], server_id=sid) for sid in ids),
+            *(list_server_tools(servers[sid], server_id=sid, use_cache=False) for sid in ids),
             return_exceptions=True,
         )
 

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -1,22 +1,31 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GNU Affero General Public License v3.0 License.
 
-"""Minimal stdio MCP client used to verify a server and list its tools.
+"""MCP client with persistent per-server connections.
 
-Opens a short-lived session per call; no long-lived process management in v1.
+Short-lived connections are used only for one-off server validation (e.g. during
+server registration). All other callers should pass a ``server_id`` so the client
+can reuse the existing session instead of spawning a new subprocess every call.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Dict
+from contextlib import AsyncExitStack
+from typing import Any, Dict, Optional
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+CONNECT_TIMEOUT_SECONDS = 15
 LIST_TOOLS_TIMEOUT_SECONDS = 15
 CALL_TOOL_TIMEOUT_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Error helpers
+# ---------------------------------------------------------------------------
 
 
 def _flatten_exceptions(exc: BaseException) -> list[BaseException]:
@@ -40,6 +49,11 @@ def _format_exception(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+# ---------------------------------------------------------------------------
+# Params builder
+# ---------------------------------------------------------------------------
+
+
 def _build_stdio_params(config: Dict[str, Any]) -> StdioServerParameters:
     env = config.get("env") or None
     return StdioServerParameters(
@@ -49,42 +63,100 @@ def _build_stdio_params(config: Dict[str, Any]) -> StdioServerParameters:
     )
 
 
-async def _list_tools_inner(config: Dict[str, Any]) -> Dict[str, Any]:
-    params = _build_stdio_params(config)
-
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.list_tools()
-            tools = [
-                {
-                    "name": t.name,
-                    "description": t.description or "",
-                    "input_schema": getattr(t, "inputSchema", None),
-                }
-                for t in result.tools
-            ]
-            return {"success": True, "tools": tools}
+# ---------------------------------------------------------------------------
+# Connection manager
+# ---------------------------------------------------------------------------
 
 
-async def list_server_tools(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Connect to an stdio MCP server, list its tools, and disconnect.
+class MCPConnectionManager:
+    """Maintains one persistent stdio ClientSession per configured MCP server.
 
-    Returns ``{"success": True, "tools": [...]}`` on success, or
-    ``{"success": False, "error": "..."}`` on any failure.
+    A new subprocess is spawned only when there is no existing session for a
+    given ``server_id``, or when the stored config differs from the one provided
+    (indicating the server was reconfigured). On any error the broken session is
+    evicted so the next caller transparently gets a fresh connection.
     """
-    try:
-        return await asyncio.wait_for(
-            _list_tools_inner(config),
-            timeout=LIST_TOOLS_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError:
-        return {
-            "success": False,
-            "error": f"Timed out connecting to MCP server after {LIST_TOOLS_TIMEOUT_SECONDS}s",
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, ClientSession] = {}
+        self._stacks: Dict[str, AsyncExitStack] = {}
+        self._configs: Dict[str, Dict[str, Any]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+        self._global_lock = asyncio.Lock()
+
+    async def _get_lock(self, server_id: str) -> asyncio.Lock:
+        async with self._global_lock:
+            if server_id not in self._locks:
+                self._locks[server_id] = asyncio.Lock()
+            return self._locks[server_id]
+
+    async def get_session(self, server_id: str, config: Dict[str, Any]) -> ClientSession:
+        """Return an existing healthy session or open a new one."""
+        lock = await self._get_lock(server_id)
+        async with lock:
+            existing = self._sessions.get(server_id)
+            if existing is not None and self._configs.get(server_id) == config:
+                return existing
+            # No session yet, or config changed — close the old one and reconnect.
+            await self._close_locked(server_id)
+            return await self._open_locked(server_id, config)
+
+    async def _open_locked(self, server_id: str, config: Dict[str, Any]) -> ClientSession:
+        stack = AsyncExitStack()
+        try:
+            params = _build_stdio_params(config)
+            read, write = await stack.enter_async_context(stdio_client(params))
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await asyncio.wait_for(session.initialize(), timeout=CONNECT_TIMEOUT_SECONDS)
+            self._sessions[server_id] = session
+            self._stacks[server_id] = stack
+            self._configs[server_id] = dict(config)
+            return session
+        except Exception:
+            await stack.aclose()
+            raise
+
+    async def _close_locked(self, server_id: str) -> None:
+        stack = self._stacks.pop(server_id, None)
+        self._sessions.pop(server_id, None)
+        self._configs.pop(server_id, None)
+        if stack:
+            try:
+                await stack.aclose()
+            except Exception:
+                pass
+
+    async def invalidate(self, server_id: str) -> None:
+        """Evict a server's session so the next caller reconnects from scratch."""
+        lock = await self._get_lock(server_id)
+        async with lock:
+            await self._close_locked(server_id)
+
+    async def close_all(self) -> None:
+        """Shut down all open connections."""
+        for sid in list(self._sessions.keys()):
+            await self.invalidate(sid)
+
+
+mcp_connection_manager = MCPConnectionManager()
+
+
+# ---------------------------------------------------------------------------
+# Session-level helpers (shared by persistent and short-lived paths)
+# ---------------------------------------------------------------------------
+
+
+async def _list_tools_from_session(session: ClientSession) -> Dict[str, Any]:
+    result = await session.list_tools()
+    tools = [
+        {
+            "name": t.name,
+            "description": t.description or "",
+            "input_schema": getattr(t, "inputSchema", None),
         }
-    except Exception as e:
-        return {"success": False, "error": _format_exception(e)}
+        for t in result.tools
+    ]
+    return {"success": True, "tools": tools}
 
 
 def _serialize_mcp_content_item(item: Any) -> Dict[str, Any]:
@@ -97,45 +169,131 @@ def _serialize_mcp_content_item(item: Any) -> Dict[str, Any]:
     return {"type": type(item).__name__, "value": str(item)}
 
 
-async def _call_tool_inner(
+async def _call_tool_from_session(
+    session: ClientSession,
+    tool_name: str,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    result = await session.call_tool(tool_name, arguments=arguments)
+    is_error = bool(getattr(result, "isError", False))
+    payload = {
+        "is_error": is_error,
+        "structured_content": getattr(result, "structuredContent", None),
+        "content": [
+            _serialize_mcp_content_item(item)
+            for item in getattr(result, "content", []) or []
+        ],
+    }
+    serialized_payload = json.dumps(payload, ensure_ascii=False)
+    if is_error:
+        return {
+            "success": False,
+            "error": serialized_payload,
+            "output": serialized_payload,
+        }
+    return {"success": True, "output": serialized_payload}
+
+
+# ---------------------------------------------------------------------------
+# Short-lived connection helpers (one-off verification only)
+# ---------------------------------------------------------------------------
+
+
+async def _list_tools_short_lived(config: Dict[str, Any]) -> Dict[str, Any]:
+    params = _build_stdio_params(config)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            return await _list_tools_from_session(session)
+
+
+async def _call_tool_short_lived(
     config: Dict[str, Any],
     tool_name: str,
     arguments: Dict[str, Any],
 ) -> Dict[str, Any]:
     params = _build_stdio_params(config)
-
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
-            result = await session.call_tool(tool_name, arguments=arguments)
-            is_error = bool(getattr(result, "isError", False))
-            payload = {
-                "is_error": is_error,
-                "structured_content": getattr(result, "structuredContent", None),
-                "content": [
-                    _serialize_mcp_content_item(item)
-                    for item in getattr(result, "content", []) or []
-                ],
+            return await _call_tool_from_session(session, tool_name, arguments)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_server_tools(
+    config: Dict[str, Any],
+    server_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List tools for an MCP server.
+
+    Pass ``server_id`` to reuse a persistent connection. Omit it when
+    validating a new server config before it has been assigned an id.
+    """
+    if server_id is not None:
+        try:
+            session = await mcp_connection_manager.get_session(server_id, config)
+            return await asyncio.wait_for(
+                _list_tools_from_session(session),
+                timeout=LIST_TOOLS_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            await mcp_connection_manager.invalidate(server_id)
+            return {
+                "success": False,
+                "error": f"Timed out listing MCP tools after {LIST_TOOLS_TIMEOUT_SECONDS}s",
             }
-            serialized_payload = json.dumps(payload, ensure_ascii=False)
-            if is_error:
-                return {
-                    "success": False,
-                    "error": serialized_payload,
-                    "output": serialized_payload,
-                }
-            return {"success": True, "output": serialized_payload}
+        except Exception as e:
+            await mcp_connection_manager.invalidate(server_id)
+            return {"success": False, "error": _format_exception(e)}
+
+    try:
+        return await asyncio.wait_for(
+            _list_tools_short_lived(config),
+            timeout=LIST_TOOLS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        return {
+            "success": False,
+            "error": f"Timed out connecting to MCP server after {LIST_TOOLS_TIMEOUT_SECONDS}s",
+        }
+    except Exception as e:
+        return {"success": False, "error": _format_exception(e)}
 
 
 async def call_server_tool(
     config: Dict[str, Any],
     tool_name: str,
     arguments: Dict[str, Any],
+    server_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Call a single MCP tool on an stdio server and return serialized output."""
+    """Call a single MCP tool and return serialized output.
+
+    Pass ``server_id`` to reuse a persistent connection.
+    """
+    if server_id is not None:
+        try:
+            session = await mcp_connection_manager.get_session(server_id, config)
+            return await asyncio.wait_for(
+                _call_tool_from_session(session, tool_name, arguments),
+                timeout=CALL_TOOL_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            await mcp_connection_manager.invalidate(server_id)
+            return {
+                "success": False,
+                "error": f"Timed out calling MCP tool after {CALL_TOOL_TIMEOUT_SECONDS}s",
+            }
+        except Exception as e:
+            await mcp_connection_manager.invalidate(server_id)
+            return {"success": False, "error": _format_exception(e)}
+
     try:
         return await asyncio.wait_for(
-            _call_tool_inner(config, tool_name, arguments),
+            _call_tool_short_lived(config, tool_name, arguments),
             timeout=CALL_TOOL_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 from contextlib import AsyncExitStack
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -81,8 +81,19 @@ class MCPConnectionManager:
         self._sessions: Dict[str, ClientSession] = {}
         self._stacks: Dict[str, AsyncExitStack] = {}
         self._configs: Dict[str, Dict[str, Any]] = {}
+        self._tool_cache: Dict[str, List[Dict[str, Any]]] = {}
         self._locks: Dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
+
+    def get_tool_cache(self, server_id: str) -> Optional[List[Dict[str, Any]]]:
+        return self._tool_cache.get(server_id)
+
+    def set_tool_cache(self, server_id: str, tools: List[Dict[str, Any]]) -> None:
+        self._tool_cache[server_id] = tools
+
+    def invalidate_tool_cache(self, server_id: str) -> None:
+        """Clear a server's cached tool list without dropping its connection."""
+        self._tool_cache.pop(server_id, None)
 
     async def _get_lock(self, server_id: str) -> asyncio.Lock:
         async with self._global_lock:
@@ -120,6 +131,7 @@ class MCPConnectionManager:
         stack = self._stacks.pop(server_id, None)
         self._sessions.pop(server_id, None)
         self._configs.pop(server_id, None)
+        self._tool_cache.pop(server_id, None)
         if stack:
             try:
                 await stack.aclose()
@@ -234,12 +246,18 @@ async def list_server_tools(
     validating a new server config before it has been assigned an id.
     """
     if server_id is not None:
+        cached = mcp_connection_manager.get_tool_cache(server_id)
+        if cached is not None:
+            return {"success": True, "tools": cached}
         try:
             session = await mcp_connection_manager.get_session(server_id, config)
-            return await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 _list_tools_from_session(session),
                 timeout=LIST_TOOLS_TIMEOUT_SECONDS,
             )
+            if result.get("success"):
+                mcp_connection_manager.set_tool_cache(server_id, result["tools"])
+            return result
         except asyncio.TimeoutError:
             await mcp_connection_manager.invalidate(server_id)
             return {

--- a/mito-ai/mito_ai/mcp/mcp_client.py
+++ b/mito-ai/mito_ai/mcp/mcp_client.py
@@ -85,7 +85,11 @@ class MCPConnectionManager:
         self._locks: Dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
 
-    def get_tool_cache(self, server_id: str) -> Optional[List[Dict[str, Any]]]:
+    def get_tool_cache(self, server_id: str, config: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+        """Return cached tools only if the session was opened with the same config."""
+        if self._configs.get(server_id) != config:
+            self._tool_cache.pop(server_id, None)
+            return None
         return self._tool_cache.get(server_id)
 
     def set_tool_cache(self, server_id: str, tools: List[Dict[str, Any]]) -> None:
@@ -239,16 +243,19 @@ async def _call_tool_short_lived(
 async def list_server_tools(
     config: Dict[str, Any],
     server_id: Optional[str] = None,
+    use_cache: bool = True,
 ) -> Dict[str, Any]:
     """List tools for an MCP server.
 
     Pass ``server_id`` to reuse a persistent connection. Omit it when
     validating a new server config before it has been assigned an id.
+    Pass ``use_cache=False`` when a live result is required (e.g. health checks).
     """
     if server_id is not None:
-        cached = mcp_connection_manager.get_tool_cache(server_id)
-        if cached is not None:
-            return {"success": True, "tools": cached}
+        if use_cache:
+            cached = mcp_connection_manager.get_tool_cache(server_id, config)
+            if cached is not None:
+                return {"success": True, "tools": cached}
         try:
             session = await mcp_connection_manager.get_session(server_id, config)
             result = await asyncio.wait_for(

--- a/mito-ai/mito_ai/mcp/utils.py
+++ b/mito-ai/mito_ai/mcp/utils.py
@@ -62,7 +62,7 @@ async def get_available_mcp_tools() -> List[Dict[str, Any]]:
         return []
 
     results = await asyncio.gather(
-        *(list_server_tools(servers[sid]) for sid in ids),
+        *(list_server_tools(servers[sid], server_id=sid) for sid in ids),
         return_exceptions=True,
     )
 


### PR DESCRIPTION
# Description

Every time the AI needed to know what MCP tools were available — or actually call one — the code would:
 
1. Spawn a new subprocess (starting the MCP server from scratch)
2. Do a handshake
3. Ask "what tools do you have?"
4. Do the work
5. Kill the process

This happened on every single AI message that involved MCP tools.

The old approach meant each agent loop was paying subprocess startup cost plus a tools/list round-trip on top of that. With many tools across several servers, this adds up fast and makes the agent feel sluggish.

What we've done is the same basic idea as a database connection pool: you pay the setup cost once, then reuse the connection for the lifetime of the session.

# Testing

1. Visit the MCP settings page, and confirm you can still connect to servers.
2. Have the Agent use and MCP server.
3. Have the Agent use the same sever a second time.

In theory, multiple calls to the same MCP server should be faster, this is hard to test without proper benchmarks. However, the logic behind the persistent connections is sound. 

# Documentation

N/A - BTS changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how long-lived MCP child processes are managed; stale sessions, leaked subprocesses, or incorrect invalidation could affect agent tool calls until reconnect, though errors trigger eviction and delete clears the pool entry.
> 
> **Overview**
> Replaces **per-call MCP subprocess spawn** with a **persistent connection pool** keyed by `server_id`, so listing tools and invoking tools reuse one stdio `ClientSession` instead of starting the server on every agent message.
> 
> `MCPConnectionManager` holds sessions, configs, per-server locks, and a **cached tool list**; failures and timeouts **evict** the session so the next call reconnects. **Short-lived** connections remain only when `server_id` is omitted (e.g. validating a new server on POST).
> 
> Call sites now pass `server_id` from the JupyterLab tool executor, MCP settings GET, and `get_available_mcp_tools`. **Deleting** an MCP server is **async** and **invalidates** the pooled connection for that id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151baa3d1c22e50b7621f3382f95c97878b2f989. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->